### PR TITLE
Make connectivity optional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ apt-get install -qyy \
     build-essential \
     ca-certificates \
     cmake \
+    libboost1.81-all-dev \
+    libhdf5-dev \
+    libopenmpi-dev \
     zlib1g-dev \
     git
 EOT
@@ -49,11 +52,19 @@ RUN \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     --mount=type=bind,source=README.md,target=README.md \
     --mount=type=bind,source=obi,target=obi \
-    uv sync --locked --no-editable
+    uv sync --locked --no-editable --no-cache
 
 # run stage
 FROM python:$PYTHON_BASE
 SHELL ["bash", "-e", "-x", "-o", "pipefail", "-c"]
+
+RUN <<EOT
+apt-get update -qy
+apt-get install -qyy \
+    -o APT::Install-Recommends=false \
+    -o APT::Install-Suggests=false \
+    libhdf5-103-1
+EOT
 
 RUN <<EOT
 groupadd -r app

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ help:  ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-23s\033[0m %s\n", $$1, $$2}'
 
 install:  ## Install dependencies into .venv
-	CMAKE_POLICY_VERSION_MINIMUM=3.5 uv sync
+	CMAKE_POLICY_VERSION_MINIMUM=3.5 uv sync --extra connectivity
 	uv run python -m ipykernel install --user --name=obi-one --display-name "obi-one"
 
 compile-deps:  ## Create or update the lock file, without upgrading the version of the dependencies

--- a/docker-compose.run.yml
+++ b/docker-compose.run.yml
@@ -2,7 +2,7 @@ services:
   app:
     profiles: [run]
     image: "${IMAGE_NAME}:${IMAGE_TAG}"
-    platform: linux/amd64  # because of pyflagser
+#    platform: linux/amd64  # for pyflagser
     build:
       dockerfile: Dockerfile
       args:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -2,7 +2,7 @@ services:
   test:
     profiles: [test]
     image: "${IMAGE_NAME}:${IMAGE_TAG}"
-    platform: linux/amd64  # because of pyflagser
+#    platform: linux/amd64  # for pyflagser
     command:
     - sh
     - -cx

--- a/obi/modeling/basic_connectivity_plots/basic_connectivity_plots.py
+++ b/obi/modeling/basic_connectivity_plots/basic_connectivity_plots.py
@@ -1,7 +1,31 @@
-from obi.modeling.core.form import Form
+import os
+import traceback
+import warnings
+
+import matplotlib.colors as mcolors
+import matplotlib.pyplot as plt
+import numpy as np
+
+from obi.modeling.basic_connectivity_plots.helpers import (
+    compute_global_connectivity,
+    connection_probability_pathway,
+    connection_probability_within_pathway,
+    plot_connection_probability_pathway_stats,
+    plot_connection_probability_stats,
+    plot_node_stats,
+)
 from obi.modeling.core.block import Block
-from obi.modeling.core.single import SingleCoordinateMixin
+from obi.modeling.core.form import Form
 from obi.modeling.core.path import NamedPath
+from obi.modeling.core.single import SingleCoordinateMixin
+
+try:
+    from connalysis.network.topology import node_degree
+    from connalysis.randomization import ER_model
+    from conntility import ConnectivityMatrix
+except ImportError:
+    warnings.warn("Connectome functionalities not available", UserWarning, stacklevel=1)
+
 
 class BasicConnectivityPlots(Form):
     """
@@ -21,17 +45,6 @@ class BasicConnectivityPlots(Form):
     initialize: Initialize
 
 
-import os
-from typing import ClassVar
-import traceback
-
-import numpy as np
-import matplotlib.colors as mcolors
-
-from conntility import ConnectivityMatrix
-from connalysis.network.topology import rc_submatrix, node_degree
-from connalysis.randomization import ER_model
-from .helpers import *
 
 class BasicConnectivityPlot(BasicConnectivityPlots, SingleCoordinateMixin):
     """
@@ -49,7 +62,6 @@ class BasicConnectivityPlot(BasicConnectivityPlots, SingleCoordinateMixin):
             print("Plot Types:", plot_types)
 
             print(f"Info: Running idx {self.idx}, plots for {plot_types}")
-        
 
             # Load matrix
             print(f"Info: Loading matrix '{self.initialize.matrix_path}'")

--- a/obi/modeling/basic_connectivity_plots/helpers.py
+++ b/obi/modeling/basic_connectivity_plots/helpers.py
@@ -2,14 +2,19 @@
 Last modified 03.2025 
 Author: Daniela Egas Santander"""
 
-import numpy as np 
+import warnings
+
 import matplotlib.pyplot as plt
-import matplotlib.gridspec as gridspec
 import networkx as nx
+import numpy as np
+from matplotlib import gridspec
 
+try:
+    from connalysis.network.classic import connection_probability_within, density
+    from connalysis.network.topology import rc_submatrix
+except ImportError:
+    warnings.warn("Connectome functionalities not available", UserWarning, stacklevel=1)
 
-from connalysis.network.topology import rc_submatrix
-from connalysis.network.classic import density, connection_probability_within
 
 ### Stats functions 
 

--- a/obi/modeling/connectivity_matrix_extraction/connectivity_matrix_extraction.py
+++ b/obi/modeling/connectivity_matrix_extraction/connectivity_matrix_extraction.py
@@ -1,7 +1,19 @@
-from obi.modeling.core.form import Form
+import os
+import warnings
+from typing import ClassVar
+
+from bluepysnap import Circuit
+
 from obi.modeling.core.block import Block
-from obi.modeling.core.single import SingleCoordinateMixin
+from obi.modeling.core.form import Form
 from obi.modeling.core.path import NamedPath
+from obi.modeling.core.single import SingleCoordinateMixin
+
+try:
+    from conntility.connectivity import ConnectivityMatrix
+except ImportError:
+    warnings.warn("Connectome functionalities not available", UserWarning, stacklevel=1)
+
 
 class ConnectivityMatrixExtractions(Form):
     """
@@ -16,11 +28,6 @@ class ConnectivityMatrixExtractions(Form):
 
     initialize: Initialize
 
-
-import os
-from conntility.connectivity import ConnectivityMatrix
-from bluepysnap import Circuit
-from typing import ClassVar
 
 class ConnectivityMatrixExtraction(ConnectivityMatrixExtractions, SingleCoordinateMixin):
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,6 @@ dependencies = [
     "brainbuilder",
     # MORPHOLOGY CONTAINERIZATION
     "bluepysnap",
-    # CONNECTIVITY
-    "connectome-utilities",
-    "connectome-analysis>=1.0.1",
     # FAST API SERVICE
     "fastapi",
     "uvicorn",
@@ -33,6 +30,23 @@ dependencies = [
     # ENTITYSDK
     "entitysdk",
     "obi-auth",
+    "networkx>=3.4.2",
+]
+
+[project.optional-dependencies]
+connectivity = [
+    "connectome-analysis>=1.0.1",
+    "connectome-utilities>=0.4.10",
+]
+
+
+[dependency-groups]
+dev = [
+    "coverage[toml]",
+    "pyright",
+    "pytest",
+    "pytest-cov",
+    "ruff",
 ]
 
 [build-system]
@@ -49,15 +63,6 @@ include = ["obi*"]
 [tool.uv.sources]
 bluepysnap = { git = "https://github.com/openbraininstitute/snap.git" }
 brainbuilder = { git = "https://github.com/openbraininstitute/brainbuilder.git", branch = "split_popul_fix" }
-
-[dependency-groups]
-dev = [
-    "coverage[toml]",
-    "pyright",
-    "pytest",
-    "pytest-cov",
-    "ruff",
-]
 
 [tool.ruff]
 line-length = 100

--- a/uv.lock
+++ b/uv.lock
@@ -1669,13 +1669,12 @@ dependencies = [
     { name = "blueetl" },
     { name = "bluepysnap" },
     { name = "brainbuilder" },
-    { name = "connectome-analysis" },
-    { name = "connectome-utilities" },
     { name = "entitysdk" },
     { name = "fastapi" },
     { name = "ipykernel" },
     { name = "jupyter" },
     { name = "jupyterlab" },
+    { name = "networkx" },
     { name = "neurom" },
     { name = "notebook" },
     { name = "obi-auth" },
@@ -1684,6 +1683,12 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "starlette" },
     { name = "uvicorn" },
+]
+
+[package.optional-dependencies]
+connectivity = [
+    { name = "connectome-analysis" },
+    { name = "connectome-utilities" },
 ]
 
 [package.dev-dependencies]
@@ -1700,13 +1705,14 @@ requires-dist = [
     { name = "blueetl" },
     { name = "bluepysnap", git = "https://github.com/openbraininstitute/snap.git" },
     { name = "brainbuilder", git = "https://github.com/openbraininstitute/brainbuilder.git?branch=split_popul_fix" },
-    { name = "connectome-analysis", specifier = ">=1.0.1" },
-    { name = "connectome-utilities" },
+    { name = "connectome-analysis", marker = "extra == 'connectivity'", specifier = ">=1.0.1" },
+    { name = "connectome-utilities", marker = "extra == 'connectivity'", specifier = ">=0.4.10" },
     { name = "entitysdk" },
     { name = "fastapi" },
     { name = "ipykernel" },
     { name = "jupyter" },
     { name = "jupyterlab" },
+    { name = "networkx", specifier = ">=3.4.2" },
     { name = "neurom" },
     { name = "notebook" },
     { name = "obi-auth" },
@@ -1716,6 +1722,7 @@ requires-dist = [
     { name = "starlette" },
     { name = "uvicorn" },
 ]
+provides-extras = ["connectivity"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
connectivity is not installed in the Docker image, but it's added only to the local installation (make install).

Reason: the connectivity packages depend on pyflagsercount and bigrandomgraphs, that don't adhere to modern standards and cannot be installed cleanly.
Moreover, pyflagser doesn't provide a source dist on pypi (see https://pypi.org/project/pyflagser/#files), so it cannot be installed in docker on Mac, unless enforcing platform=linux/amd64, but this would cause the process in the container to run using qemu.
