### PR TITLE
work around new docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ format_types: ## Count the number of errors by type
 	uv run -m ruff check --output-format=json | jq -r '.[] | [.code, .message] | @tsv' | sort | uniq -c
 
 build:  ## Build the Docker image
-	docker compose --progress=plain build app
+	docker compose --profile "*" --progress=plain build app
 
 publish: build  ## Publish the Docker image to DockerHub
 	docker compose push app


### PR DESCRIPTION
* docker-compose seems to have gotten picky about --profiles when using build, between version 2.35.1 and 2.36.0, the latter is used in the CI.
* probably due to [BUG] Explicitly building services that are not part of COMPOSE_PROFILES broken since 2.36.0 docker/compose#12825