### PR TITLE
Fix neuronset and replay

### DIFF
--- a/examples/circuit_simulations_example.ipynb
+++ b/examples/circuit_simulations_example.ipynb
@@ -75,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +114,9 @@
     "# Stimuli\n",
     "current_stimulus = obi.ConstantCurrentClampSomaticStimulus(timestamps=regular_timesteps.ref, duration=5.0, neuron_set=stim_neuron_set.ref, amplitude=[0.2, 0.5])\n",
     "sync_current_stimulus = obi.ConstantCurrentClampSomaticStimulus(timestamps=regular_timesteps.ref, duration=100.0, neuron_set=stim_neuron_set.ref, amplitude=0.1)\n",
-    "poisson_input = obi.PoissonSpikeStimulus(timestamps=regular_timesteps.ref, stim_duration=800, frequency=20, source_neuron_set=replay_neuron_set.ref)\n",
+    "poisson_input = obi.PoissonSpikeStimulus(timestamps=regular_timesteps.ref, stim_duration=800, frequency=20,\n",
+    "                                         source_neuron_set=replay_neuron_set.ref,\n",
+    "                                         targeted_neuron_set=stim_neuron_set.ref)\n",
     "sim_conf.add(current_stimulus, name='CurrentStimulus')\n",
     "sim_conf.add(sync_current_stimulus, name='SyncCurrentStimulus')\n",
     "sim_conf.add(poisson_input, name='PoissonInputStimulus')\n",

--- a/examples/circuit_simulations_example.ipynb
+++ b/examples/circuit_simulations_example.ipynb
@@ -22,7 +22,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "circuit_path_prefix = \"/Users/james/Documents/obi/additional_data/O1_data/O1_data/\"\n",
+    "# circuit_path_prefix = \"/Users/james/Documents/obi/additional_data/O1_data/O1_data/\"\n",
+    "circuit_path_prefix = \"/Users/mwr/Documents/artefacts/SONATA/O1_data/\"\n",
     "# circuit_path_prefix = \"/Users/pokorny/Data/Circuits/\""
    ]
   },
@@ -48,7 +49,7 @@
    ],
    "source": [
     "# circuit = obi.Circuit(name=\"ToyCircuit-S1-6k\", path=circuit_path_prefix + \"ToyCircuit-S1-6k/circuit_config.json\")\n",
-    "circuit = obi.Circuit(name=\"O1\", path=circuit_path_prefix + \"circuit_config.json\")\n",
+    "circuit = obi.Circuit(name=\"O1\", path=circuit_path_prefix + \"circuit_config_postfix.json\")\n",
     "print(f\"Circuit '{circuit}' with {circuit.sonata_circuit.nodes.size} neurons and {circuit.sonata_circuit.edges.size} synapses\")"
    ]
   },
@@ -93,22 +94,27 @@
     "sim_conf.add(regular_timesteps, name='stim_times')\n",
     "\n",
     "# Neuron Sets\n",
-    "sim_neuron_set = obi.PredefinedNeuronSet(node_set=\"Layer1\")\n",
-    "stim_neuron_set = obi.PredefinedNeuronSet(node_set=\"Layer1\", random_sample=[10, 20])\n",
-    "rec_neuron_set = obi.PredefinedNeuronSet(node_set=\"Layer1\", random_sample=100)\n",
+    "node_pop = circuit._default_population_name(circuit.sonata_circuit)\n",
+    "\n",
+    "sim_neuron_set = obi.PredefinedNeuronSet(node_set=\"Layer1\", node_population=node_pop)\n",
+    "stim_neuron_set = obi.PredefinedNeuronSet(node_set=\"Layer1\", random_sample=[10, 20], node_population=node_pop)\n",
+    "replay_neuron_set = obi.PredefinedNeuronSet(node_set=\"proj_Thalamocortical_POM_Source\", random_sample=0.25, node_population=\"POm\")\n",
+    "rec_neuron_set = obi.PredefinedNeuronSet(node_set=\"Layer1\", random_sample=100, node_population=node_pop)\n",
     "property_neuron_set = obi.PropertyNeuronSet(\n",
     "    property_filter=[obi.scientific.circuit.neuron_sets.NeuronPropertyFilter(filter_dict={\"layer\": [2, 3], \"synapse_class\": [\"INH\"]}),\n",
     "                     obi.scientific.circuit.neuron_sets.NeuronPropertyFilter(filter_dict={\"layer\": [1, 2, 3], \"synapse_class\": [\"EXC\"]})],\n",
+    "    node_population=node_pop\n",
     ")\n",
     "sim_conf.add(sim_neuron_set, name='L1All')\n",
     "sim_conf.add(stim_neuron_set, name='L1Stim')\n",
     "sim_conf.add(rec_neuron_set, name='L1Rec')\n",
     "sim_conf.add(property_neuron_set, name='PropertyNeuronSet')\n",
+    "sim_conf.add(replay_neuron_set, name=\"POM_input\")\n",
     "\n",
     "# Stimuli\n",
     "current_stimulus = obi.ConstantCurrentClampSomaticStimulus(timestamps=regular_timesteps.ref, duration=5.0, neuron_set=stim_neuron_set.ref, amplitude=[0.2, 0.5])\n",
     "sync_current_stimulus = obi.ConstantCurrentClampSomaticStimulus(timestamps=regular_timesteps.ref, duration=100.0, neuron_set=stim_neuron_set.ref, amplitude=0.1)\n",
-    "poisson_input = obi.PoissonSpikeStimulus(timestamps=regular_timesteps.ref, stim_duration=800, frequency=20, neuron_set=stim_neuron_set.ref)\n",
+    "poisson_input = obi.PoissonSpikeStimulus(timestamps=regular_timesteps.ref, stim_duration=800, frequency=20, source_neuron_set=replay_neuron_set.ref)\n",
     "sim_conf.add(current_stimulus, name='CurrentStimulus')\n",
     "sim_conf.add(sync_current_stimulus, name='SyncCurrentStimulus')\n",
     "sim_conf.add(poisson_input, name='PoissonInputStimulus')\n",
@@ -141,39 +147,103 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[2025-06-13 10:53:12,672] INFO: \n",
+      "[2025-06-13 16:20:05,066] INFO: \n",
       "MULTIPLE VALUE PARAMETERS\n",
-      "[2025-06-13 10:53:12,672] INFO: stimuli.CurrentStimulus.amplitude: [0.2, 0.5]\n",
-      "[2025-06-13 10:53:12,672] INFO: neuron_sets.L1Stim.random_sample: [10, 20]\n",
-      "[2025-06-13 10:53:12,673] INFO: neuron_sets.PropertyNeuronSet.property_filter: [layer=2,3,synapse_class=INH, layer=1,2,3,synapse_class=EXC]\n",
-      "[2025-06-13 10:53:12,673] INFO: initialize.circuit: [Circuit(type='Circuit', name='O1', path='/Users/james/Documents/obi/additional_data/O1_data/O1_data/circuit_config.json', matrix_path=None), Circuit(type='Circuit', name='O1_2', path='/Users/james/Documents/obi/additional_data/O1_data/O1_data/circuit_config.json', matrix_path=None)]\n",
-      "[2025-06-13 10:53:12,673] INFO: \n",
+      "[2025-06-13 16:20:05,067] INFO: stimuli.CurrentStimulus.amplitude: [0.2, 0.5]\n",
+      "[2025-06-13 16:20:05,067] INFO: neuron_sets.L1Stim.random_sample: [10, 20]\n",
+      "[2025-06-13 16:20:05,068] INFO: neuron_sets.PropertyNeuronSet.property_filter: [layer=2,3,synapse_class=INH, layer=1,2,3,synapse_class=EXC]\n",
+      "[2025-06-13 16:20:05,068] INFO: initialize.circuit: [Circuit(type='Circuit', name='O1', path='/Users/mwr/Documents/artefacts/SONATA/O1_data/circuit_config_postfix.json', matrix_path=None), Circuit(type='Circuit', name='O1_2', path='/Users/mwr/Documents/artefacts/SONATA/O1_data/circuit_config.json', matrix_path=None)]\n",
+      "[2025-06-13 16:20:05,069] INFO: \n",
       "COORDINATE PARAMETERS\n",
-      "[2025-06-13 10:53:12,673] INFO: stimuli.CurrentStimulus.amplitude: 0.2, neuron_sets.L1Stim.random_sample: 10, neuron_sets.PropertyNeuronSet.property_filter: layer=2,3,synapse_class=INH, initialize.circuit: O1\n",
-      "[2025-06-13 10:53:12,674] INFO: stimuli.CurrentStimulus.amplitude: 0.2, neuron_sets.L1Stim.random_sample: 10, neuron_sets.PropertyNeuronSet.property_filter: layer=2,3,synapse_class=INH, initialize.circuit: O1_2\n",
-      "[2025-06-13 10:53:12,674] INFO: stimuli.CurrentStimulus.amplitude: 0.2, neuron_sets.L1Stim.random_sample: 10, neuron_sets.PropertyNeuronSet.property_filter: layer=1,2,3,synapse_class=EXC, initialize.circuit: O1\n",
-      "[2025-06-13 10:53:12,674] INFO: stimuli.CurrentStimulus.amplitude: 0.2, neuron_sets.L1Stim.random_sample: 10, neuron_sets.PropertyNeuronSet.property_filter: layer=1,2,3,synapse_class=EXC, initialize.circuit: O1_2\n",
-      "[2025-06-13 10:53:12,674] INFO: stimuli.CurrentStimulus.amplitude: 0.2, neuron_sets.L1Stim.random_sample: 20, neuron_sets.PropertyNeuronSet.property_filter: layer=2,3,synapse_class=INH, initialize.circuit: O1\n",
-      "[2025-06-13 10:53:12,674] INFO: stimuli.CurrentStimulus.amplitude: 0.2, neuron_sets.L1Stim.random_sample: 20, neuron_sets.PropertyNeuronSet.property_filter: layer=2,3,synapse_class=INH, initialize.circuit: O1_2\n",
-      "[2025-06-13 10:53:12,674] INFO: stimuli.CurrentStimulus.amplitude: 0.2, neuron_sets.L1Stim.random_sample: 20, neuron_sets.PropertyNeuronSet.property_filter: layer=1,2,3,synapse_class=EXC, initialize.circuit: O1\n",
-      "[2025-06-13 10:53:12,675] INFO: stimuli.CurrentStimulus.amplitude: 0.2, neuron_sets.L1Stim.random_sample: 20, neuron_sets.PropertyNeuronSet.property_filter: layer=1,2,3,synapse_class=EXC, initialize.circuit: O1_2\n",
-      "[2025-06-13 10:53:12,675] INFO: stimuli.CurrentStimulus.amplitude: 0.5, neuron_sets.L1Stim.random_sample: 10, neuron_sets.PropertyNeuronSet.property_filter: layer=2,3,synapse_class=INH, initialize.circuit: O1\n",
-      "[2025-06-13 10:53:12,675] INFO: stimuli.CurrentStimulus.amplitude: 0.5, neuron_sets.L1Stim.random_sample: 10, neuron_sets.PropertyNeuronSet.property_filter: layer=2,3,synapse_class=INH, initialize.circuit: O1_2\n",
-      "[2025-06-13 10:53:12,675] INFO: stimuli.CurrentStimulus.amplitude: 0.5, neuron_sets.L1Stim.random_sample: 10, neuron_sets.PropertyNeuronSet.property_filter: layer=1,2,3,synapse_class=EXC, initialize.circuit: O1\n",
-      "[2025-06-13 10:53:12,675] INFO: stimuli.CurrentStimulus.amplitude: 0.5, neuron_sets.L1Stim.random_sample: 10, neuron_sets.PropertyNeuronSet.property_filter: layer=1,2,3,synapse_class=EXC, initialize.circuit: O1_2\n",
-      "[2025-06-13 10:53:12,675] INFO: stimuli.CurrentStimulus.amplitude: 0.5, neuron_sets.L1Stim.random_sample: 20, neuron_sets.PropertyNeuronSet.property_filter: layer=2,3,synapse_class=INH, initialize.circuit: O1\n",
-      "[2025-06-13 10:53:12,676] INFO: stimuli.CurrentStimulus.amplitude: 0.5, neuron_sets.L1Stim.random_sample: 20, neuron_sets.PropertyNeuronSet.property_filter: layer=2,3,synapse_class=INH, initialize.circuit: O1_2\n",
-      "[2025-06-13 10:53:12,676] INFO: stimuli.CurrentStimulus.amplitude: 0.5, neuron_sets.L1Stim.random_sample: 20, neuron_sets.PropertyNeuronSet.property_filter: layer=1,2,3,synapse_class=EXC, initialize.circuit: O1\n",
-      "[2025-06-13 10:53:12,676] INFO: stimuli.CurrentStimulus.amplitude: 0.5, neuron_sets.L1Stim.random_sample: 20, neuron_sets.PropertyNeuronSet.property_filter: layer=1,2,3,synapse_class=EXC, initialize.circuit: O1_2\n",
-      "[2025-06-13 10:53:12,676] INFO: None\n",
-      "[2025-06-13 10:54:22,684] INFO: create_bbp_workflow_campaign_config() not yet complete.\n"
+      "[2025-06-13 16:20:05,069] INFO: stimuli.CurrentStimulus.amplitude: 0.2, neuron_sets.L1Stim.random_sample: 10, neuron_sets.PropertyNeuronSet.property_filter: layer=2,3,synapse_class=INH, initialize.circuit: O1\n",
+      "[2025-06-13 16:20:05,069] INFO: stimuli.CurrentStimulus.amplitude: 0.2, neuron_sets.L1Stim.random_sample: 10, neuron_sets.PropertyNeuronSet.property_filter: layer=2,3,synapse_class=INH, initialize.circuit: O1_2\n",
+      "[2025-06-13 16:20:05,069] INFO: stimuli.CurrentStimulus.amplitude: 0.2, neuron_sets.L1Stim.random_sample: 10, neuron_sets.PropertyNeuronSet.property_filter: layer=1,2,3,synapse_class=EXC, initialize.circuit: O1\n",
+      "[2025-06-13 16:20:05,070] INFO: stimuli.CurrentStimulus.amplitude: 0.2, neuron_sets.L1Stim.random_sample: 10, neuron_sets.PropertyNeuronSet.property_filter: layer=1,2,3,synapse_class=EXC, initialize.circuit: O1_2\n",
+      "[2025-06-13 16:20:05,070] INFO: stimuli.CurrentStimulus.amplitude: 0.2, neuron_sets.L1Stim.random_sample: 20, neuron_sets.PropertyNeuronSet.property_filter: layer=2,3,synapse_class=INH, initialize.circuit: O1\n",
+      "[2025-06-13 16:20:05,070] INFO: stimuli.CurrentStimulus.amplitude: 0.2, neuron_sets.L1Stim.random_sample: 20, neuron_sets.PropertyNeuronSet.property_filter: layer=2,3,synapse_class=INH, initialize.circuit: O1_2\n",
+      "[2025-06-13 16:20:05,070] INFO: stimuli.CurrentStimulus.amplitude: 0.2, neuron_sets.L1Stim.random_sample: 20, neuron_sets.PropertyNeuronSet.property_filter: layer=1,2,3,synapse_class=EXC, initialize.circuit: O1\n",
+      "[2025-06-13 16:20:05,070] INFO: stimuli.CurrentStimulus.amplitude: 0.2, neuron_sets.L1Stim.random_sample: 20, neuron_sets.PropertyNeuronSet.property_filter: layer=1,2,3,synapse_class=EXC, initialize.circuit: O1_2\n",
+      "[2025-06-13 16:20:05,071] INFO: stimuli.CurrentStimulus.amplitude: 0.5, neuron_sets.L1Stim.random_sample: 10, neuron_sets.PropertyNeuronSet.property_filter: layer=2,3,synapse_class=INH, initialize.circuit: O1\n",
+      "[2025-06-13 16:20:05,071] INFO: stimuli.CurrentStimulus.amplitude: 0.5, neuron_sets.L1Stim.random_sample: 10, neuron_sets.PropertyNeuronSet.property_filter: layer=2,3,synapse_class=INH, initialize.circuit: O1_2\n",
+      "[2025-06-13 16:20:05,071] INFO: stimuli.CurrentStimulus.amplitude: 0.5, neuron_sets.L1Stim.random_sample: 10, neuron_sets.PropertyNeuronSet.property_filter: layer=1,2,3,synapse_class=EXC, initialize.circuit: O1\n",
+      "[2025-06-13 16:20:05,071] INFO: stimuli.CurrentStimulus.amplitude: 0.5, neuron_sets.L1Stim.random_sample: 10, neuron_sets.PropertyNeuronSet.property_filter: layer=1,2,3,synapse_class=EXC, initialize.circuit: O1_2\n",
+      "[2025-06-13 16:20:05,071] INFO: stimuli.CurrentStimulus.amplitude: 0.5, neuron_sets.L1Stim.random_sample: 20, neuron_sets.PropertyNeuronSet.property_filter: layer=2,3,synapse_class=INH, initialize.circuit: O1\n",
+      "[2025-06-13 16:20:05,072] INFO: stimuli.CurrentStimulus.amplitude: 0.5, neuron_sets.L1Stim.random_sample: 20, neuron_sets.PropertyNeuronSet.property_filter: layer=2,3,synapse_class=INH, initialize.circuit: O1_2\n",
+      "[2025-06-13 16:20:05,072] INFO: stimuli.CurrentStimulus.amplitude: 0.5, neuron_sets.L1Stim.random_sample: 20, neuron_sets.PropertyNeuronSet.property_filter: layer=1,2,3,synapse_class=EXC, initialize.circuit: O1\n",
+      "[2025-06-13 16:20:05,072] INFO: stimuli.CurrentStimulus.amplitude: 0.5, neuron_sets.L1Stim.random_sample: 20, neuron_sets.PropertyNeuronSet.property_filter: layer=1,2,3,synapse_class=EXC, initialize.circuit: O1_2\n",
+      "[2025-06-13 16:20:05,073] INFO: None\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['Layer1']\n",
+      "['Layer1']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['Layer1']\n",
+      "['Layer1']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['Layer1']\n",
+      "['Layer1']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['Layer1']\n",
+      "['Layer1']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['Layer1']\n",
+      "['Layer1']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['Layer1']\n",
+      "['Layer1']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['Layer1']\n",
+      "['Layer1']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['Layer1']\n",
+      "['Layer1']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['Layer1']\n",
+      "['Layer1']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['Layer1']\n",
+      "['Layer1']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['Layer1']\n",
+      "['Layer1']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['Layer1']\n",
+      "['Layer1']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['Layer1']\n",
+      "['Layer1']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['Layer1']\n",
+      "['Layer1']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['Layer1']\n",
+      "['Layer1']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "['Layer1']\n",
+      "['Layer1']\n",
+      "['proj_Thalamocortical_POM_Source']\n",
+      "[2025-06-13 16:20:19,540] INFO: create_bbp_workflow_campaign_config() not yet complete.\n"
      ]
     },
     {
@@ -197,7 +267,7 @@
        " 15: None}"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -212,7 +282,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<KeysViewHDF5 ['POm']>\n",
+      "[3158 1312    2 ... 4712 6054 4093]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Spot check of generated spikes files\n",
+    "import h5py\n",
+    "\n",
+    "h5 = h5py.File(\"../../obi-output/circuit_simulations/grid_scan/stimuli.CurrentStimulus.amplitude=0.2/neuron_sets.L1Stim.random_sample=10/neuron_sets.PropertyNeuronSet.property_filter=layer=1,2,3,synapse_class=EXC/initialize.circuit=O1/PoissonInputStimulus_spikes.h5\", \"r\")\n",
+    "\n",
+    "print(h5[\"spikes\"].keys())\n",
+    "print(h5[\"spikes/POm\"][\"node_ids\"][:])\n",
+    "h5.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -222,10 +317,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "GridScan(type='GridScan', form=SimulationsForm(type='SimulationsForm', timestamps={'stim_times': RegularTimestamps(type='RegularTimestamps', start_time=0.0, number_of_repetitions=3, interval=1000.0)}, stimuli={'CurrentStimulus': ConstantCurrentClampSomaticStimulus(type='ConstantCurrentClampSomaticStimulus', timestamps=TimestampsReference(type='TimestampsReference', block_dict_name='timestamps', block_name='stim_times'), delay=0.0, duration=5.0, neuron_set=NeuronSetReference(type='NeuronSetReference', block_dict_name='neuron_sets', block_name='L1Stim'), represents_physical_electrode=False, amplitude=[0.2, 0.5]), 'SyncCurrentStimulus': ConstantCurrentClampSomaticStimulus(type='ConstantCurrentClampSomaticStimulus', timestamps=TimestampsReference(type='TimestampsReference', block_dict_name='timestamps', block_name='stim_times'), delay=0.0, duration=100.0, neuron_set=NeuronSetReference(type='NeuronSetReference', block_dict_name='neuron_sets', block_name='L1Stim'), represents_physical_electrode=False, amplitude=0.1), 'PoissonInputStimulus': PoissonSpikeStimulus(type='PoissonSpikeStimulus', timestamps=TimestampsReference(type='TimestampsReference', block_dict_name='timestamps', block_name='stim_times'), stim_duration=800.0, source_neuron_set=NeuronSetReference(type='NeuronSetReference', block_dict_name='neuron_sets', block_name='POM_input'), targeted_neuron_set=None, random_seed=0, frequency=20.0)}, recordings={'SomaVoltRec': SomaVoltageRecording(type='SomaVoltageRecording', start_time=0.0, end_time=3000.0, dt=0.1, neuron_set=NeuronSetReference(type='NeuronSetReference', block_dict_name='neuron_sets', block_name='L1Rec'))}, neuron_sets={'L1All': PredefinedNeuronSet(type='PredefinedNeuronSet', random_sample=None, random_seed=0, node_population='S1nonbarrel_neurons', node_set='Layer1'), 'L1Stim': PredefinedNeuronSet(type='PredefinedNeuronSet', random_sample=[10, 20], random_seed=0, node_population='S1nonbarrel_neurons', node_set='Layer1'), 'L1Rec': PredefinedNeuronSet(type='PredefinedNeuronSet', random_sample=100, random_seed=0, node_population='S1nonbarrel_neurons', node_set='Layer1'), 'PropertyNeuronSet': PropertyNeuronSet(type='PropertyNeuronSet', random_sample=None, random_seed=0, node_population='S1nonbarrel_neurons', property_filter=[layer=2,3,synapse_class=INH, layer=1,2,3,synapse_class=EXC], node_sets=()), 'POM_input': PredefinedNeuronSet(type='PredefinedNeuronSet', random_sample=0.25, random_seed=0, node_population='POm', node_set='proj_Thalamocortical_POM_Source')}, initialize=Initialize(type='SimulationsForm.Initialize', circuit=[Circuit(type='Circuit', name='O1', path='/Users/mwr/Documents/artefacts/SONATA/O1_data/circuit_config_postfix.json', matrix_path=None), Circuit(type='Circuit', name='O1_2', path='/Users/mwr/Documents/artefacts/SONATA/O1_data/circuit_config.json', matrix_path=None)], simulation_length=3000.0, node_set=NeuronSetReference(type='NeuronSetReference', block_dict_name='neuron_sets', block_name='L1All'), random_seed=1, extracellular_calcium_concentration=1.1, v_init=-80.0, spike_location='soma', sonata_version=1, target_simulator='CORENEURON', timestep=0.025), info=Info(type='Info', campaign_name='No name provided', campaign_description='No description provided')), output_root=PosixPath('../../obi-output/circuit_simulations/grid_scan'), coordinate_directory_option='NAME_EQUALS_VALUE')"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "grid_scan_ds"
+   ]
   }
  ],
  "metadata": {
@@ -244,7 +352,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/obi_one/scientific/circuit/neuron_sets.py
+++ b/obi_one/scientific/circuit/neuron_sets.py
@@ -159,7 +159,6 @@ class NeuronSet(Block, abc.ABC):
         population = self._population(population)
         c = circuit.sonata_circuit
         expression = self._get_expression(circuit, population)
-        print(expression)
         name = "__TMP_NODE_SET__"
         self.add_node_set_to_circuit(c, {name: expression})
         return c.nodes[population].ids(name)

--- a/obi_one/scientific/simulation/simulations.py
+++ b/obi_one/scientific/simulation/simulations.py
@@ -162,7 +162,7 @@ class Simulation(SimulationsForm, SingleCoordinateMixin):
         self._sonata_config["inputs"] = {}
         for stimulus_key, stimulus in self.stimuli.items():
             if hasattr (stimulus, "generate_spikes"):
-                stimulus.generate_spikes(self.initialize.circuit, self.initialize.circuit.default_population_name, self.coordinate_output_root)
+                stimulus.generate_spikes(self.initialize.circuit, self.coordinate_output_root)
             self._sonata_config["inputs"].update(stimulus.config())
 
         # Generate recording configs
@@ -197,7 +197,7 @@ class Simulation(SimulationsForm, SingleCoordinateMixin):
             # Add node set to SONATA circuit object
             # (will raise an error in case already existing)
             nset_def = _nset.get_node_set_definition(
-                self.initialize.circuit, self.initialize.circuit.default_population_name
+                self.initialize.circuit  # , self.initialize.circuit.default_population_name
             )
             NeuronSet.add_node_set_to_circuit(c, {_name: nset_def}, overwrite_if_exists=False)
 


### PR DESCRIPTION
Stimuli now use the proper keyword required in sonata.
Spike replay binary files fixed.
Spike replay stimuli now make a distinction between source and target neuron sets. Note that the target neuron set is optional: If not specified the default of the circuit is used.

You can now specify a node population when defining a neuron set. 
In order to ensure backwards compatibility, the old paradigm that specifies the node population when the neuron set is evaluated still does work! But user is strongly encouraged to not use it that way.