### PR TITLE
SynapticManipulation block type with two specific connection override blocks

### DIFF
--- a/examples/circuit_simulations_with_manipulations_example.ipynb
+++ b/examples/circuit_simulations_with_manipulations_example.ipynb
@@ -1,0 +1,215 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Circuit simulation examples (with synaptic manipulations)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import obi_one as obi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# circuit_path_prefix = \"/Users/james/Documents/obi/additional_data/O1_data/O1_data/\"\n",
+    "# circuit_path_prefix = \"/Users/mwr/Documents/artefacts/SONATA/O1_data/\"\n",
+    "circuit_path_prefix = \"/Users/pokorny/Data/Circuits/\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Loading two circuits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Circuit 'ToyCircuit-S1-6k' with 5924 neurons and 568717 synapses\n"
+     ]
+    }
+   ],
+   "source": [
+    "circuit = obi.Circuit(name=\"ToyCircuit-S1-6k\", path=circuit_path_prefix + \"ToyCircuit-S1-6k/circuit_config.json\")\n",
+    "# circuit = obi.Circuit(name=\"O1\", path=circuit_path_prefix + \"circuit_config_postfix.json\")\n",
+    "print(f\"Circuit '{circuit}' with {circuit.sonata_circuit.nodes.size} neurons and {circuit.sonata_circuit.edges.size} synapses\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Set up simulation campaign"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sim duration\n",
+    "sim_duration = 3000.0\n",
+    "\n",
+    "# Empty Simulation Configuration\n",
+    "sim_conf = obi.SimulationsForm.empty_config()\n",
+    "\n",
+    "# Info\n",
+    "info = obi.Info(name=\"O1 Simulation\", description=\"Simulation of O1 circuit with predefined neuron set and constant current stimulus\")\n",
+    "sim_conf.set(info, name=\"info\")\n",
+    "\n",
+    "# Neuron Sets\n",
+    "sim_neuron_set = obi.IDNeuronSet(neuron_ids=obi.NamedTuple(name=\"IDNeuronSet1\", elements=range(10)))\n",
+    "sim_conf.add(sim_neuron_set, name='L1All')\n",
+    "\n",
+    "sync_neuron_set = obi.IDNeuronSet(neuron_ids=obi.NamedTuple(name=\"IDNeuronSet2\", elements=range(3)))\n",
+    "sim_conf.add(sync_neuron_set, name='ID3')\n",
+    "\n",
+    "# Regular Timesteps\n",
+    "regular_timestamps = obi.RegularTimestamps(start_time=0.0, number_of_repetitions=3, interval=sim_duration)\n",
+    "sim_conf.add(regular_timestamps, name='RegularTimestamps')\n",
+    "\n",
+    "# Stimulus\n",
+    "poisson_input = obi.PoissonSpikeStimulus(duration=800.0, timestamps=regular_timestamps.ref, frequency=20, source_neuron_set=sim_neuron_set.ref, targeted_neuron_set=sim_neuron_set.ref)\n",
+    "sim_conf.add(poisson_input, name='PoissonInputStimulus')\n",
+    "\n",
+    "sync_input = obi.FullySynchronousSpikeStimulus(timestamps=regular_timestamps.ref, source_neuron_set=sync_neuron_set.ref, targeted_neuron_set=sim_neuron_set.ref)\n",
+    "sim_conf.add(sync_input, name='SynchronousInputStimulus')\n",
+    "\n",
+    "# Recordings\n",
+    "voltage_recording = obi.SomaVoltageRecording(neuron_set=sim_neuron_set.ref, start_time=0.0, end_time=sim_duration)\n",
+    "sim_conf.add(voltage_recording, name='VoltageRecording')\n",
+    "\n",
+    "# Synaptic manipulations (executed in order!!)\n",
+    "syn_manip_mg = obi.SynapticMgManipulation(magnesium_value=[2.0, 2.4])\n",
+    "syn_manip_use = obi.SynapticUseManipulation(use_scaling=0.7050728631217412)\n",
+    "sim_conf.add(syn_manip_mg, name='SynapticMgManipulation')\n",
+    "sim_conf.add(syn_manip_use, name='SynapticUseManipulation')\n",
+    "\n",
+    "# Initialization\n",
+    "simulations_initialize = obi.SimulationsForm.Initialize(circuit=circuit, \n",
+    "                                                        node_set=sim_neuron_set.ref, \n",
+    "                                                        simulation_length=sim_duration)\n",
+    "sim_conf.set(simulations_initialize, name='initialize')\n",
+    "\n",
+    "# Validated Config\n",
+    "validated_sim_conf = sim_conf.validated_config()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# sim_conf.model_dump(mode=\"json\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[2025-06-27 12:00:36,746] INFO: \n",
+      "MULTIPLE VALUE PARAMETERS\n",
+      "[2025-06-27 12:00:36,747] INFO: manipulations.SynapticMgManipulation.magnesium_value: [2.0, 2.4]\n",
+      "[2025-06-27 12:00:36,747] INFO: \n",
+      "COORDINATE PARAMETERS\n",
+      "[2025-06-27 12:00:36,748] INFO: manipulations.SynapticMgManipulation.magnesium_value: 2.0\n",
+      "[2025-06-27 12:00:36,748] INFO: manipulations.SynapticMgManipulation.magnesium_value: 2.4\n",
+      "[2025-06-27 12:00:36,748] INFO: None\n",
+      "[2025-06-27 12:00:36,750] INFO: create_bbp_workflow_campaign_config() not yet complete.\n",
+      "[2025-06-27 12:00:36,753] INFO: initialize.circuit is a Circuit instance.\n",
+      "[2025-06-27 12:00:36,770] INFO: initialize.circuit is a Circuit instance.\n"
+     ]
+    }
+   ],
+   "source": [
+    "grid_scan = obi.GridScan(form=validated_sim_conf, output_root='../../obi-output/circuit_simulations_with_manipulations/grid_scan')\n",
+    "grid_scan.multiple_value_parameters(display=True)\n",
+    "grid_scan.coordinate_parameters(display=True)\n",
+    "grid_scan.execute(processing_method='generate')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Deserialization\n",
+    "grid_scan_ds = obi.deserialize_obi_object_from_json_file(\"../../obi-output/circuit_simulations_with_manipulations/grid_scan/run_scan_config.json\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "GridScan(type='GridScan', form=SimulationsForm(type='SimulationsForm', timestamps={'RegularTimestamps': RegularTimestamps(type='RegularTimestamps', start_time=0.0, number_of_repetitions=3, interval=3000.0)}, stimuli={'PoissonInputStimulus': PoissonSpikeStimulus(type='PoissonSpikeStimulus', timestamp_offset=0.0, timestamps=TimestampsReference(type='TimestampsReference', block_dict_name='timestamps', block_name='RegularTimestamps'), source_neuron_set=NeuronSetReference(type='NeuronSetReference', block_dict_name='neuron_sets', block_name='L1All'), targeted_neuron_set=NeuronSetReference(type='NeuronSetReference', block_dict_name='neuron_sets', block_name='L1All'), duration=800.0, random_seed=0, frequency=20.0), 'SynchronousInputStimulus': FullySynchronousSpikeStimulus(type='FullySynchronousSpikeStimulus', timestamp_offset=0.0, timestamps=TimestampsReference(type='TimestampsReference', block_dict_name='timestamps', block_name='RegularTimestamps'), source_neuron_set=NeuronSetReference(type='NeuronSetReference', block_dict_name='neuron_sets', block_name='ID3'), targeted_neuron_set=NeuronSetReference(type='NeuronSetReference', block_dict_name='neuron_sets', block_name='L1All'))}, recordings={'VoltageRecording': SomaVoltageRecording(type='SomaVoltageRecording', start_time=0.0, end_time=3000.0, dt=0.1, neuron_set=NeuronSetReference(type='NeuronSetReference', block_dict_name='neuron_sets', block_name='L1All'))}, neuron_sets={'L1All': IDNeuronSet(type='IDNeuronSet', random_sample=None, random_seed=0, neuron_ids=IDNeuronSet1), 'ID3': IDNeuronSet(type='IDNeuronSet', random_sample=None, random_seed=0, neuron_ids=IDNeuronSet2)}, manipulations={'SynapticMgManipulation': SynapticMgManipulation(type='SynapticMgManipulation', magnesium_value=[2.0, 2.4]), 'SynapticUseManipulation': SynapticUseManipulation(type='SynapticUseManipulation', use_scaling=0.7050728631217412)}, initialize=Initialize(type='SimulationsForm.Initialize', circuit=Circuit(type='Circuit', name='ToyCircuit-S1-6k', path='/Users/pokorny/Data/Circuits/ToyCircuit-S1-6k/circuit_config.json', matrix_path=None), simulation_length=3000.0, node_set=NeuronSetReference(type='NeuronSetReference', block_dict_name='neuron_sets', block_name='L1All'), random_seed=1, extracellular_calcium_concentration=1.1, v_init=-80.0), info=Info(type='Info', campaign_name='No name provided', campaign_description='No description provided')), output_root=PosixPath('../../obi-output/circuit_simulations_with_manipulations/grid_scan'), coordinate_directory_option='NAME_EQUALS_VALUE')"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "grid_scan_ds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "obi-one",
+   "language": "python",
+   "name": "obi-one"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/obi_one/__init__.py
+++ b/obi_one/__init__.py
@@ -110,6 +110,8 @@ __all__ = [
     "StimulusReference",
     "StimulusUnion",
     "SubthresholdCurrentClampSomaticStimulus",
+    "SynapticUseManipulation",
+    "SynapticMgManipulation",
     "nbS1POmInputs",
     "nbS1VPMInputs",
     "SynapseSetUnion",
@@ -259,4 +261,9 @@ from obi_one.scientific.unions.unions_timestamps import TimestampsUnion, Timesta
 
 from obi_one.scientific.validations.reconstruction_morphology_validation import (
     ReconstructionMorphologyValidation,
+)
+
+from obi_one.scientific.unions.unions_manipulations import (
+    SynapticMgManipulation,
+    SynapticUseManipulation,
 )

--- a/obi_one/scientific/simulation/manipulations.py
+++ b/obi_one/scientific/simulation/manipulations.py
@@ -8,6 +8,10 @@ class SynapticManipulation(Block, ABC):
     def _get_override_name(self) -> str:
         pass
 
+    def config(self) -> dict:
+        self.check_simulation_init()
+        return self._generate_config()
+
     def _generate_config(self) -> dict:
         sonata_config = {
             "name": self._get_override_name(),

--- a/obi_one/scientific/simulation/manipulations.py
+++ b/obi_one/scientific/simulation/manipulations.py
@@ -1,0 +1,41 @@
+from abc import ABC, abstractmethod
+from obi_one.core.block import Block
+
+
+class SynapticManipulation(Block, ABC):
+
+    @abstractmethod
+    def _get_override_name(self) -> str:
+        pass
+
+    def _generate_config(self) -> dict:
+        sonata_config = {
+            "name": self._get_override_name(),
+            "source": "All",
+            "target": "All",
+            "synapse_configure": self._get_synapse_configure(),
+        }
+
+        return sonata_config
+
+
+class SynapticUseManipulation(SynapticManipulation):
+
+    use_scaling: float | list[float] = 0.7050728631217412
+
+    def _get_override_name(self) -> str:
+        return "ach_use"
+
+    def _get_synapse_configure(self) -> str:
+        return f"%s.Use *= {self.use_scaling}"
+
+
+class SynapticMgManipulation(SynapticManipulation):
+
+    magnesium_value: float | list[float] = 2.4
+    
+    def _get_override_name(self) -> str:
+        return "Mg"
+
+    def _get_synapse_configure(self) -> str:
+        return f"%%s.mg = {self.magnesium_value}"

--- a/obi_one/scientific/simulation/manipulations.py
+++ b/obi_one/scientific/simulation/manipulations.py
@@ -26,7 +26,7 @@ class SynapticManipulation(Block, ABC):
 class SynapticUseManipulation(SynapticManipulation):
     """Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."""
 
-    title: ClassVar[str] = "Manipulation of the synaptic 'Use' parameter"
+    title: ClassVar[str] = "Synaptic Use Manipulation"
 
     use_scaling: float | list[float] = 0.7050728631217412
 
@@ -40,7 +40,7 @@ class SynapticUseManipulation(SynapticManipulation):
 class SynapticMgManipulation(SynapticManipulation):
     """Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."""
 
-    title: ClassVar[str] = "Manipulation of the synaptic 'Magnesium' parameter"
+    title: ClassVar[str] = "Synaptic Mg2+ Concentration Manipulation"
 
     magnesium_value: float | list[float] = 2.4
     

--- a/obi_one/scientific/simulation/manipulations.py
+++ b/obi_one/scientific/simulation/manipulations.py
@@ -24,6 +24,9 @@ class SynapticManipulation(Block, ABC):
 
 
 class SynapticUseManipulation(SynapticManipulation):
+    """Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."""
+
+    title: ClassVar[str] = "Manipulation of the synaptic 'Use' parameter"
 
     use_scaling: float | list[float] = 0.7050728631217412
 
@@ -35,6 +38,9 @@ class SynapticUseManipulation(SynapticManipulation):
 
 
 class SynapticMgManipulation(SynapticManipulation):
+    """Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."""
+
+    title: ClassVar[str] = "Manipulation of the synaptic 'Magnesium' parameter"
 
     magnesium_value: float | list[float] = 2.4
     

--- a/obi_one/scientific/simulation/manipulations.py
+++ b/obi_one/scientific/simulation/manipulations.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from obi_one.core.block import Block
+from typing import ClassVar
 
 
 class SynapticManipulation(Block, ABC):

--- a/obi_one/scientific/simulation/manipulations.py
+++ b/obi_one/scientific/simulation/manipulations.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from obi_one.core.block import Block
+from pydantic import NonNegativeFloat
 from typing import ClassVar
 
 
@@ -29,7 +30,7 @@ class SynapticUseManipulation(SynapticManipulation):
 
     title: ClassVar[str] = "Synaptic Use Manipulation"
 
-    use_scaling: float | list[float] = 0.7050728631217412
+    use_scaling: NonNegativeFloat | list[NonNegativeFloat] = 0.7050728631217412
 
     def _get_override_name(self) -> str:
         return "ach_use"
@@ -43,7 +44,7 @@ class SynapticMgManipulation(SynapticManipulation):
 
     title: ClassVar[str] = "Synaptic Mg2+ Concentration Manipulation"
 
-    magnesium_value: float | list[float] = 2.4
+    magnesium_value: NonNegativeFloat | list[NonNegativeFloat] = 2.4
     
     def _get_override_name(self) -> str:
         return "Mg"

--- a/obi_one/scientific/simulation/simulations.py
+++ b/obi_one/scientific/simulation/simulations.py
@@ -13,7 +13,7 @@ from obi_one.scientific.circuit.neuron_sets import NeuronSet
 from obi_one.scientific.unions.unions_extracellular_location_sets import (
     ExtracellularLocationSetUnion,
 )
-from obi_one.scientific.unions.unions_manipulations import ManipulationsUnion, ManipulationsReference
+from obi_one.scientific.unions.unions_manipulations import SynapticManipulationsUnion, SynapticManipulationsReference
 from obi_one.scientific.unions.unions_morphology_locations import MorphologyLocationUnion
 from obi_one.scientific.unions.unions_neuron_sets import SimulationNeuronSetUnion, NeuronSetReference
 from obi_one.scientific.unions.unions_recordings import RecordingUnion, RecordingReference
@@ -44,7 +44,7 @@ class SimulationsForm(Form):
     stimuli: dict[str, StimulusUnion] = Field(default_factory=dict, title="Stimuli", reference_type=StimulusReference.__name__, description="Stimuli for the simulation")
     recordings: dict[str, RecordingUnion] = Field(default_factory=dict, reference_type=RecordingReference.__name__, description="Recordings for the simulation")
     neuron_sets: dict[str, SimulationNeuronSetUnion] = Field(default_factory=dict, reference_type=NeuronSetReference.__name__, description="Neuron sets for the simulation")
-    manipulations: dict[str, ManipulationsUnion] = Field(default_factory=dict, reference_type=ManipulationsReference.__name__, description="Manipulations for the simulation")
+    synaptic_manipulations: dict[str, SynapticManipulationsUnion] = Field(default_factory=dict, reference_type=SynapticManipulationsReference.__name__, description="Synaptic manipulations for the simulation")
 
     class Config:
         json_schema_extra = {
@@ -176,9 +176,9 @@ class SimulationsForm(Form):
         return self
 
     @model_validator(mode="after")
-    def initialize_manipulations(self) -> Self:
+    def initialize_synaptic_manipulations(self) -> Self:
         """Initializes manipulationms within simulation campaign."""
-        for _k, _v in self.manipulations.items():
+        for _k, _v in self.synaptic_manipulations.items():
             _v.set_simulation_level_name(_k)
         return self
 
@@ -267,10 +267,10 @@ class Simulation(SimulationsForm, SingleCoordinateMixin):
         for recording_key, recording in self.recordings.items():
             self._sonata_config["reports"].update(recording.config())
 
-        # Generate list of manipulation configs (executed in the order in the list)
-        # FIXME: Check and make sure that the order in the self.manipulations dict is preserved!
+        # Generate list of synaptic manipulation configs (executed in the order in the list)
+        # FIXME: Check and make sure that the order in the self.synaptic_manipulations dict is preserved!
         manipulation_list = []
-        for manipulation_key, manipulation in self.manipulations.items():
+        for manipulation_key, manipulation in self.synaptic_manipulations.items():
             manipulation_list.append(manipulation.config())
         if len(manipulation_list) > 0:
             self._sonata_config["connection_overrides"] = manipulation_list

--- a/obi_one/scientific/simulation/simulations.py
+++ b/obi_one/scientific/simulation/simulations.py
@@ -13,6 +13,7 @@ from obi_one.scientific.circuit.neuron_sets import NeuronSet
 from obi_one.scientific.unions.unions_extracellular_location_sets import (
     ExtracellularLocationSetUnion,
 )
+from obi_one.scientific.unions.unions_manipulations import ManipulationsUnion, ManipulationsReference
 from obi_one.scientific.unions.unions_morphology_locations import MorphologyLocationUnion
 from obi_one.scientific.unions.unions_neuron_sets import SimulationNeuronSetUnion, NeuronSetReference
 from obi_one.scientific.unions.unions_recordings import RecordingUnion, RecordingReference
@@ -43,6 +44,7 @@ class SimulationsForm(Form):
     stimuli: dict[str, StimulusUnion] = Field(default_factory=dict, title="Stimuli", reference_type=StimulusReference.__name__, description="Stimuli for the simulation")
     recordings: dict[str, RecordingUnion] = Field(default_factory=dict, reference_type=RecordingReference.__name__, description="Recordings for the simulation")
     neuron_sets: dict[str, SimulationNeuronSetUnion] = Field(default_factory=dict, reference_type=NeuronSetReference.__name__, description="Neuron sets for the simulation")
+    manipulations: dict[str, ManipulationsUnion] = Field(default_factory=dict, reference_type=ManipulationsReference.__name__, description="Manipulations for the simulation")
 
     class Config:
         json_schema_extra = {
@@ -170,6 +172,13 @@ class SimulationsForm(Form):
     def initialize_neuron_sets(self) -> Self:
         """Initializes neuron sets within simulation campaign."""
         for _k, _v in self.neuron_sets.items():
+            _v.set_simulation_level_name(_k)
+        return self
+
+    @model_validator(mode="after")
+    def initialize_manipulations(self) -> Self:
+        """Initializes manipulationms within simulation campaign."""
+        for _k, _v in self.manipulations.items():
             _v.set_simulation_level_name(_k)
         return self
 

--- a/obi_one/scientific/simulation/simulations.py
+++ b/obi_one/scientific/simulation/simulations.py
@@ -267,6 +267,14 @@ class Simulation(SimulationsForm, SingleCoordinateMixin):
         for recording_key, recording in self.recordings.items():
             self._sonata_config["reports"].update(recording.config())
 
+        # Generate list of manipulation configs (executed in the order in the list)
+        # FIXME: Check and make sure that the order in the self.manipulations dict is preserved!
+        manipulation_list = []
+        for manipulation_key, manipulation in self.manipulations.items():
+            manipulation_list.append(manipulation.config())
+        if len(manipulation_list) > 0:
+            self._sonata_config["connection_overrides"] = manipulation_list
+
         # Resolve neuron sets and add them to the SONATA circuit object
         # NOTE: The name that is used as neuron_sets dict key is always used as name for a new node
         # set, even for a PredefinedNeuronSet in which case a new node set will be created which just

--- a/obi_one/scientific/unions/unions_manipulations.py
+++ b/obi_one/scientific/unions/unions_manipulations.py
@@ -1,0 +1,16 @@
+from obi_one.scientific.simulation.manipulations import (
+    SynapticMgManipulation, 
+    SynapticUseManipulation
+)
+
+ManipulationsUnion = (
+    SynapticMgManipulation
+    | SynapticUseManipulation
+)
+
+from obi_one.core.block_reference import BlockReference
+from typing import ClassVar, Any
+class ManipulationsReference(BlockReference):
+    """A reference to a Manipulations block."""
+    
+    allowed_block_types: ClassVar[Any] = ManipulationsUnion

--- a/obi_one/scientific/unions/unions_manipulations.py
+++ b/obi_one/scientific/unions/unions_manipulations.py
@@ -3,14 +3,14 @@ from obi_one.scientific.simulation.manipulations import (
     SynapticUseManipulation
 )
 
-ManipulationsUnion = (
+SynapticManipulationsUnion = (
     SynapticMgManipulation
     | SynapticUseManipulation
 )
 
 from obi_one.core.block_reference import BlockReference
 from typing import ClassVar, Any
-class ManipulationsReference(BlockReference):
-    """A reference to a Manipulations block."""
-    
-    allowed_block_types: ClassVar[Any] = ManipulationsUnion
+class SynapticManipulationsReference(BlockReference):
+    """A reference to a SynapticManipulations block."""
+
+    allowed_block_types: ClassVar[Any] = SynapticManipulationsUnion


### PR DESCRIPTION
Implemented two specific synaptic manipulation classes (blocks) to be used in the `SimulationsForm`:
- `SynapticUseManipulation`: Allows a user to scale the synaptic Use value (globally, for all connections)
- `SynapticMgManipulation`: Allows a user to set the synaptic Magnesium value (globally, for all connections)

Added a simple example notebook as well.

IMPORTANT: In general, these manipulations rely on the order they are put into the dict, as they are execute in order! For the ones we have at the moment, this should not be relevant though. But I have added a note that we should check at some point that the order is always preserved.

Related ticket: https://github.com/openbraininstitute/obi-one/issues/226