### PR TITLE
Added All/Exc/Inh neuron sets

### DIFF
--- a/obi_one/__init__.py
+++ b/obi_one/__init__.py
@@ -17,6 +17,7 @@ from obi_one.core.validation import Validation
 
 __all__ = [
     "Activity",
+    "AllNeurons",
     "AfferentSynapsesBlock",
     "BasicConnectivityPlot",
     "BasicConnectivityPlots",
@@ -40,6 +41,7 @@ __all__ = [
     "ConstantCurrentClampSomaticStimulus",
     "CoupledScan",
     "EntityFromID",
+    "ExcitatoryNeurons",
     "ExtracellularLocationSet",
     "ExtracellularLocationSetUnion",
     "FolderCompression",
@@ -51,6 +53,7 @@ __all__ = [
     "HyperpolarizingCurrentClampSomaticStimulus",
     "IDNeuronSet",
     "Info",
+    "InhibitoryNeurons",
     "IntracellularLocationSet",
     "IntracellularLocationSetUnion",
     "LoadAssetMethod",
@@ -177,8 +180,10 @@ from obi_one.scientific.circuit.neuron_sets import (
     SimplexMembershipBasedNeuronSet,
     nbS1VPMInputs,
     nbS1POmInputs,
-    rCA1CA3Inputs
-
+    rCA1CA3Inputs,
+    AllNeurons,
+    ExcitatoryNeurons,
+    InhibitoryNeurons,
 )
 from obi_one.scientific.circuit_extraction.circuit_extraction import (
     CircuitExtraction,

--- a/obi_one/scientific/circuit/neuron_sets.py
+++ b/obi_one/scientific/circuit/neuron_sets.py
@@ -319,6 +319,30 @@ class PredefinedNeuronSet(NeuronSet):
         return [self.node_set]
 
 
+class AllNeurons(PredefinedNeuronSet):
+    """Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."""
+
+    title: ClassVar[str] = "All Neurons"
+
+    node_set: ClassVar[str] = "All"
+
+
+class ExcitatoryNeurons(PredefinedNeuronSet):
+    """Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."""
+
+    title: ClassVar[str] = "Excitatory Neurons"
+
+    node_set: ClassVar[str] = "Excitatory"
+
+
+class InhibitoryNeurons(PredefinedNeuronSet):
+    """Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."""
+
+    title: ClassVar[str] = "Excitatory Neurons"
+
+    node_set: ClassVar[str] = "Inhibitory"
+
+
 class nbS1VPMInputs(AbstractNeuronSet):
     """Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."""
 

--- a/obi_one/scientific/circuit/neuron_sets.py
+++ b/obi_one/scientific/circuit/neuron_sets.py
@@ -338,7 +338,7 @@ class ExcitatoryNeurons(PredefinedNeuronSet):
 class InhibitoryNeurons(PredefinedNeuronSet):
     """Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."""
 
-    title: ClassVar[str] = "Excitatory Neurons"
+    title: ClassVar[str] = "Inhibitory Neurons"
 
     node_set: ClassVar[str] = "Inhibitory"
 

--- a/obi_one/scientific/unions/unions_neuron_sets.py
+++ b/obi_one/scientific/unions/unions_neuron_sets.py
@@ -9,7 +9,10 @@ from obi_one.scientific.circuit.neuron_sets import (
     SimplexMembershipBasedNeuronSet,
     nbS1VPMInputs,
     nbS1POmInputs,
-    rCA1CA3Inputs
+    rCA1CA3Inputs,
+    AllNeurons,
+    ExcitatoryNeurons,
+    InhibitoryNeurons,
 )
 
 NeuronSetUnion = (
@@ -24,6 +27,9 @@ NeuronSetUnion = (
     | nbS1VPMInputs
     | nbS1POmInputs
     | rCA1CA3Inputs
+    | AllNeurons
+    | ExcitatoryNeurons
+    | InhibitoryNeurons
 )
 
 SimulationNeuronSetUnion = (
@@ -31,6 +37,9 @@ SimulationNeuronSetUnion = (
     | nbS1VPMInputs
     | nbS1POmInputs
     | rCA1CA3Inputs
+    | AllNeurons
+    | ExcitatoryNeurons
+    | InhibitoryNeurons
 )
 
 from obi_one.core.block_reference import BlockReference

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obi-one"
-version = "2025.6.9"
+version = "2025.6.11"
 authors = [
   { name="James Isbister", email="james.isbister@openbraininstitute.org" },
   { name="Christoph Pokorny", email="christoph.pokorny@openbraininstitute.org" },

--- a/uv.lock
+++ b/uv.lock
@@ -1827,7 +1827,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/cc/13/a92988c6609c1aa52
 
 [[package]]
 name = "obi-one"
-version = "2025.6.9"
+version = "2025.6.11"
 source = { editable = "." }
 dependencies = [
     { name = "blueetl" },


### PR DESCRIPTION
Added default neuron sets for "All", "Excitatory" and "Inhibitory" node sets which are defined in all our circuits. These are (hard-coded) special cases of the existing `PredefinedNeuronSet` class.

Related ticket: https://github.com/openbraininstitute/obi-one/issues/260