### PR TITLE
Require uv >= 0.8.0, remove pinning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.9
-ARG UV_VERSION=0.6
+ARG UV_VERSION=latest
 ARG PYTHON_VERSION=3.12
 ARG PYTHON_BASE=${PYTHON_VERSION}-slim-trixie
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
     "bluepyefe>=2.3.48",
     # CONNECTOME-UTILITIES
     "connectome-utilities>=0.4.11",
-    "bluecellulab>=2.6.62"
+    "bluecellulab>=2.6.62",
 ]
 
 [project.optional-dependencies]
@@ -93,6 +93,9 @@ Issues = "https://github.com/openbraininstitute/obi-one/issues"
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["obi_one*"]
+
+[tool.uv]
+required-version = ">=0.8.0"
 
 [tool.ruff]
 line-length = 100

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12.2, <3.13"
 
 [[package]]


### PR DESCRIPTION
The uv.lock has been automatically updated from (version = 1, revision = 2) to (version = 1, revision = 3).

Found in https://github.com/openbraininstitute/obi-one/pull/334