### PR TITLE
Removed node_population from PredefinedNeuronSet

### DIFF
--- a/obi_one/scientific/blocks/neuron_sets.py
+++ b/obi_one/scientific/blocks/neuron_sets.py
@@ -365,7 +365,7 @@ class PredefinedNeuronSet(AbstractNeuronSet):
             msg = f"Node set '{self.node_set}' not found in circuit '{circuit}'!"
             raise ValueError(msg)
 
-    def _get_expression(self, circuit: Circuit, population: str | None) -> list:
+    def _get_expression(self, circuit: Circuit, population: str) -> list:
         """Returns the SONATA node set expression (w/o subsampling)."""
         self.check_node_set(circuit, population)
         return [self.node_set]

--- a/obi_one/scientific/blocks/neuron_sets.py
+++ b/obi_one/scientific/blocks/neuron_sets.py
@@ -118,7 +118,7 @@ class AbstractNeuronSet(Block, abc.ABC):
         if population is None:
             if ignore_none:
                 return
-            msg = "A node population name must be provided!"
+            msg = "Must specify a node population name!"
             raise ValueError(msg)
         if population not in Circuit.get_node_population_names(circuit.sonata_circuit):
             msg = f"Node population '{population}' not found in circuit '{circuit}'!"

--- a/obi_one/scientific/blocks/neuron_sets.py
+++ b/obi_one/scientific/blocks/neuron_sets.py
@@ -180,7 +180,15 @@ class AbstractNeuronSet(Block, abc.ABC):
         expression = self._get_expression(circuit, population)
         name = "__TMP_NODE_SET__"
         self.add_node_set_to_circuit(c, {name: expression})
-        return c.nodes[population].ids(name)
+
+        try:
+            node_ids = c.nodes[population].ids(name)
+        except snap.BluepySnapError as e:
+            # In case of an error, return empty list
+            L.warning(e)
+            node_ids = []
+
+        return node_ids
 
     def get_neuron_ids(self, circuit: Circuit, population: str | None = None) -> np.ndarray:
         """Returns list of neuron IDs (with subsampling, if specified)."""
@@ -196,7 +204,7 @@ class AbstractNeuronSet(Block, abc.ABC):
             ids = ids[rng.permutation([True] * num_sample + [False] * (len(ids) - num_sample))]
 
         if len(ids) == 0:
-            L.warning("WARNING: Neuron set empty!")
+            L.warning("Neuron set empty!")
 
         return ids
 
@@ -1184,7 +1192,7 @@ class PairMotifNeuronSet(NeuronSet):
             )
 
         if pair_tab.shape[0] == 0:
-            L.warning("WARNING: Pair table empty!")
+            L.warning("Pair table empty!")
 
         return pair_tab
 

--- a/obi_one/scientific/blocks/neuron_sets.py
+++ b/obi_one/scientific/blocks/neuron_sets.py
@@ -208,12 +208,12 @@ class AbstractNeuronSet(Block, abc.ABC):
         """
         self.enforce_no_lists()
         population = self._population(population)
-        self.check_population(circuit, population)
         if self.sample_percentage == _MAX_PERCENT and not force_resolve_ids:
             # Symbolic expression can be preserved
             expression = self._get_expression(circuit, population)
         else:
             # Individual IDs need to be resolved
+            self.check_population(circuit, population)
             expression = {
                 "population": population,
                 "node_id": self.get_neuron_ids(circuit, population).tolist(),
@@ -345,7 +345,7 @@ class NeuronSet(AbstractNeuronSet):
         return population
 
 
-class PredefinedNeuronSet(NeuronSet):
+class PredefinedNeuronSet(AbstractNeuronSet):
     """Neuron set wrapper of an existing (named) node sets already predefined in the node \
         sets file.
     """
@@ -360,7 +360,10 @@ class PredefinedNeuronSet(NeuronSet):
             msg = f"Node set '{self.node_set}' not found in circuit '{circuit}'!"
             raise ValueError(msg)
 
-    def _get_expression(self, circuit: Circuit, population: str) -> list:
+    def _population(self, population: str | None = None) -> None:
+        return population
+
+    def _get_expression(self, circuit: Circuit, population: str | None) -> list:
         """Returns the SONATA node set expression (w/o subsampling)."""
         self.check_node_set(circuit, population)
         return [self.node_set]

--- a/obi_one/scientific/blocks/neuron_sets.py
+++ b/obi_one/scientific/blocks/neuron_sets.py
@@ -112,7 +112,14 @@ class AbstractNeuronSet(Block, abc.ABC):
         """Returns the SONATA node set expression (w/o subsampling)."""
 
     @staticmethod
-    def check_population(circuit: Circuit, population: str) -> None:
+    def check_population(
+        circuit: Circuit, population: str | None, *, ignore_none: bool = False
+    ) -> None:
+        if population is None:
+            if ignore_none:
+                return
+            msg = "A node population name must be provided!"
+            raise ValueError(msg)
         if population not in Circuit.get_node_population_names(circuit.sonata_circuit):
             msg = f"Node population '{population}' not found in circuit '{circuit}'!"
             raise ValueError(msg)
@@ -215,6 +222,7 @@ class AbstractNeuronSet(Block, abc.ABC):
         population = self._population(population)
         if self.sample_percentage == _MAX_PERCENT and not force_resolve_ids:
             # Symbolic expression can be preserved
+            self.check_population(circuit, population, ignore_none=True)
             expression = self._get_expression(circuit, population)
         else:
             # Individual IDs need to be resolved

--- a/obi_one/scientific/blocks/neuron_sets.py
+++ b/obi_one/scientific/blocks/neuron_sets.py
@@ -168,9 +168,6 @@ class AbstractNeuronSet(Block, abc.ABC):
         return self._population(population)
 
     def _population(self, population: str | None = None) -> str:  # noqa: PLR6301
-        if population is None:
-            msg = "Must specify a node population name!"
-            raise ValueError(msg)
         return population
 
     def _resolve_ids(self, circuit: Circuit, population: str | None = None) -> list[int]:
@@ -367,9 +364,6 @@ class PredefinedNeuronSet(AbstractNeuronSet):
         if self.node_set not in circuit.node_sets:
             msg = f"Node set '{self.node_set}' not found in circuit '{circuit}'!"
             raise ValueError(msg)
-
-    def _population(self, population: str | None = None) -> None:
-        return population
 
     def _get_expression(self, circuit: Circuit, population: str | None) -> list:
         """Returns the SONATA node set expression (w/o subsampling)."""


### PR DESCRIPTION
Removed `node_population` from `PredefinedNeuronSet` by deriving it from `AbstractNeuronSet` instead of `NeuronSet`. Also, added small fixes and improvements for error handling and consistency with other neuron sets.

Consequences:
- There is no check if a predefined neuron set may span multiple populations
- `get_node_set_definition` can be called w/o providing a population, but will require one if subsampling is selected
- `get_neuron_ids` will always require a population to be provided
- An empty list (+ warning) will be returned if a predefined neuron set cannot be resolved in the given population
- The same behavior now also applies to other predefined neuron sets, like `AllNeurons`, `ExcitatoryNeurons`, and `InhibitoryNeurons`

Related ticket: https://github.com/openbraininstitute/obi-one/issues/381