### PR TITLE
(POC) - GraphQL morpho metrics

### DIFF
--- a/app/application.py
+++ b/app/application.py
@@ -11,13 +11,13 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.requests import Request
-from starlette.responses import Response
+from starlette.responses import Response, PlainTextResponse
 
 from app.config import settings
 from app.dependencies.auth import user_verified
 from app.endpoints.declared_endpoints import activate_declared_endpoints
 from app.endpoints.generated_endpoints import activate_generated_endpoints
-from app.endpoints.graphql import graphql_router
+from app.endpoints.graphql import graphql_router, schema
 from app.errors import ApiError, ApiErrorCode
 from app.logger import L
 from app.schemas.base import ErrorResponse
@@ -138,3 +138,9 @@ generated_router = APIRouter(
 app.include_router(activate_generated_endpoints(generated_router))
 
 app.include_router(graphql_router, prefix="/graphql")
+
+# Add GraphQL schema export endpoint
+@app.get("/graphl/schema", response_class=PlainTextResponse)
+async def graphql_schema() -> PlainTextResponse:
+    """Export GraphQL schema as SDL (Schema Definition Language) file."""
+    return schema.as_str()

--- a/app/application.py
+++ b/app/application.py
@@ -17,6 +17,7 @@ from app.config import settings
 from app.dependencies.auth import user_verified
 from app.endpoints.declared_endpoints import activate_declared_endpoints
 from app.endpoints.generated_endpoints import activate_generated_endpoints
+from app.endpoints.graphql import graphql_router
 from app.errors import ApiError, ApiErrorCode
 from app.logger import L
 from app.schemas.base import ErrorResponse
@@ -135,3 +136,5 @@ generated_router = APIRouter(
     prefix="/generated", tags=["generated"], dependencies=[Depends(user_verified)]
 )
 app.include_router(activate_generated_endpoints(generated_router))
+
+app.include_router(graphql_router, prefix="/graphql")

--- a/app/application.py
+++ b/app/application.py
@@ -11,7 +11,7 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.requests import Request
-from starlette.responses import Response, PlainTextResponse
+from starlette.responses import PlainTextResponse, Response
 
 from app.config import settings
 from app.dependencies.auth import user_verified
@@ -138,6 +138,7 @@ generated_router = APIRouter(
 app.include_router(activate_generated_endpoints(generated_router))
 
 app.include_router(graphql_router, prefix="/graphql")
+
 
 # Add GraphQL schema export endpoint
 @app.get("/graphl/schema", response_class=PlainTextResponse)

--- a/app/endpoints/graphql.py
+++ b/app/endpoints/graphql.py
@@ -54,10 +54,12 @@ async def get_context(
 # Types
 @strawberry.type
 class MultipleValuesContainer:
-    values: list[float]
-    length: int
-    mean: float
-    std: float
+    """Container for statistical information about a list of values."""
+
+    values: list[float] = strawberry.field(description="The list of individual values.")
+    length: int = strawberry.field(description="The number of values in the list.")
+    mean: float = strawberry.field(description="The arithmetic mean of all values.")
+    std: float = strawberry.field(description="The standard deviation of all values.")
 
 
 @strawberry.type

--- a/app/endpoints/graphql.py
+++ b/app/endpoints/graphql.py
@@ -1,246 +1,122 @@
 """GraphQL endpoints for the obi-one application."""
 
+import io
 import json
 from enum import Enum
-from typing import NewType
+from typing import Annotated, NewType, Dict, Any
 
 import entitysdk.client
+import neurom
 import strawberry
+from entitysdk.models.cell_morphology import CellMorphology
 from fastapi import Depends
+from neurom import load_morphology
+from neurom.core.morphology import Morphology
 from strawberry.experimental.pydantic import type as pydantic_type
 from strawberry.fastapi import GraphQLRouter
+from strawberry.dataloader import DataLoader
 
 from app.dependencies.entitysdk import get_client
-from obi_one.scientific.library.circuit_metrics import (
-    CircuitMetricsEdgePopulation,
-    CircuitMetricsNodePopulation,
-    CircuitMetricsOutput,
-    CircuitStatsLevelOfDetail,
-    get_circuit_metrics,
-)
 from obi_one.scientific.library.morphology_metrics import (
     MorphologyMetricsOutput,
     get_morphology_metrics,
 )
 
-# Create JSON scalar for complex dict fields
-JSON = strawberry.scalar(
-    NewType("JSON", str),
-    serialize=lambda v: json.dumps(v) if v is not None else None,
-    parse_value=lambda v: json.loads(v) if v is not None else None,
-)
+# DataLoader for morphology fetching
+class MorphologyDataLoader(DataLoader[str, Morphology]):
+    def __init__(self, db_client: entitysdk.client.Client):
+        super().__init__(load_fn=self._load_morphologies)
+        self.db_client = db_client
+
+    async def _load_morphologies(self, cell_morphology_ids: list[str]) -> list[Morphology]:
+        """Load multiple morphologies by their IDs."""
+        morphologies = []
+        for cell_morphology_id in cell_morphology_ids:
+            try:
+                morphology = self.db_client.get_entity(entity_id=cell_morphology_id, entity_type=CellMorphology)
+
+                for asset in morphology.assets:
+                    if asset.content_type == "application/swc":
+                        content = self.db_client.download_content(
+                            entity_id=morphology.id,
+                            entity_type=CellMorphology,
+                            asset_id=asset.id,
+                        ).decode(encoding="utf-8")
+
+                        neurom_morphology = load_morphology(io.StringIO(content), reader="swc")
+                        morphologies.append(neurom_morphology)
+                        break
+                else:
+                    raise ValueError(f"No SWC asset found for CellMorphology with ID {cell_morphology_id}")
+            except Exception as e:
+                # Handle individual failures gracefully
+                morphologies.append(None)
+        return morphologies
 
 
-# Create GraphQL enum for morphology metrics
-@strawberry.enum
-class MorphologyMetric(Enum):
-    """Enum for morphology metrics."""
-
-    ASPECT_RATIO = "aspect_ratio"
-    CIRCULARITY = "circularity"
-    LENGTH_FRACTION_ABOVE_SOMA = "length_fraction_above_soma"
-    MAX_RADIAL_DISTANCE = "max_radial_distance"
-    NUMBER_OF_NEURITES = "number_of_neurites"
-    SOMA_RADIUS = "soma_radius"
-    SOMA_SURFACE_AREA = "soma_surface_area"
-    TOTAL_LENGTH = "total_length"
-    TOTAL_HEIGHT = "total_height"
-    TOTAL_WIDTH = "total_width"
-    TOTAL_DEPTH = "total_depth"
-    TOTAL_AREA = "total_area"
-    TOTAL_VOLUME = "total_volume"
-    SECTION_LENGTHS = "section_lengths"
-    SEGMENT_RADII = "segment_radii"
-    NUMBER_OF_SECTIONS = "number_of_sections"
-    LOCAL_BIFURCATION_ANGLES = "local_bifurcation_angles"
-    REMOTE_BIFURCATION_ANGLES = "remote_bifurcation_angles"
-    SECTION_PATH_DISTANCES = "section_path_distances"
-    SECTION_RADIAL_DISTANCES = "section_radial_distances"
-    SECTION_BRANCH_ORDERS = "section_branch_orders"
-    SECTION_STRAHLER_ORDERS = "section_strahler_orders"
+# Context getter for GraphQL
+async def get_context(db_client: entitysdk.client.Client = Depends(get_client)) -> Dict[str, Any]:
+    """Create GraphQL context with dependencies."""
+    return {
+        "db_client": db_client,
+        "morphology_loader": MorphologyDataLoader(db_client)
+    }
 
 
-@pydantic_type(model=MorphologyMetricsOutput, all_fields=True)
-class MorphologyMetricsOutputType:
-    """Strawberry type for MorphologyMetricsOutput."""
+# Types
+@strawberry.type
+class MultipleValuesContainer:
+    values: list[float]
+    length: int
+    mean: float
+    std: float
 
 
-@pydantic_type(model=CircuitMetricsNodePopulation, all_fields=False)
-class CircuitMetricsNodePopulationType:
-    """Strawberry type for CircuitMetricsNodePopulation."""
-    # Define all fields explicitly, using JSON for dict fields
-    number_of_nodes: strawberry.auto
-    name: strawberry.auto
-    population_type: strawberry.auto
-    property_names: strawberry.auto
-    property_unique_values: JSON
-    property_value_counts: JSON
-    node_location_info: JSON | None
 
-
-@pydantic_type(model=CircuitMetricsEdgePopulation, all_fields=False)
-class CircuitMetricsEdgePopulationType:
-    """Strawberry type for CircuitMetricsEdgePopulation."""
-    # Define all fields explicitly, using JSON for dict fields
-    number_of_edges: strawberry.auto
-    name: strawberry.auto
-    population_type: strawberry.auto
-    property_names: strawberry.auto
-    property_stats: JSON | None
-    degree_stats: JSON | None
-
-
-@pydantic_type(model=CircuitMetricsOutput, all_fields=True)
-class CircuitMetricsOutputType:
-    """Strawberry type for CircuitMetricsOutput."""
+@strawberry.type
+class MorphologyMetrics:
+    """Morphology metrics container."""
+    
+    def __init__(self, morphology: Morphology):
+        self.morphology = morphology
+    
+    @strawberry.field(description="Aspect ratio of the morphology.")
+    def aspect_ratio(self) -> float:
+        return neurom.get("aspect_ratio", self.morphology)
+    
+    @strawberry.field(description="Total length of the morphology in micrometers.")
+    def total_length(self) -> float:
+        return neurom.get("total_length", self.morphology)
+    
+    @strawberry.field(description="Number of sections in the morphology.")
+    def number_of_sections(self) -> int:
+        return neurom.get("number_of_sections", self.morphology)
 
 
 @strawberry.type
 class Query:
     """GraphQL Query root for obi-one API."""
 
+    @strawberry.field(description="Get morphology metrics for a specific cell morphology ID.")
+    async def morphology_metrics(self, info: strawberry.Info, cell_morphology_id: str) -> MorphologyMetrics:
+        """Get morphology metrics for a specific cell morphology ID."""
+        morphology_loader = info.context["morphology_loader"]
+        # The DataLoader will handle caching and batching
+        morphology = await morphology_loader.load(cell_morphology_id)
+        return MorphologyMetrics(morphology)
+
     @strawberry.field
-    def hello(self) -> str:
+    async def hello(self) -> str:
         """Simple test query to verify GraphQL is working."""
         return "Hello from GraphQL!"
-
-    @strawberry.field
-    def morphology_metrics(
-        self,
-        cell_morphology_id: str,
-        requested_metrics: list[MorphologyMetric] | None = None,
-        info: strawberry.Info = strawberry.UNSET,
-    ) -> MorphologyMetricsOutputType:
-        """Get morphology metrics for a given cell morphology ID.
-
-        Args:
-            cell_morphology_id: The ID of the cell morphology
-            requested_metrics: Optional list of specific metrics to calculate (enum values)
-            info: Strawberry info object containing request context
-
-        Returns:
-            MorphologyMetricsOutputType containing the calculated metrics
-        """
-        # Get the db_client from the request context
-        db_client = info.context.get("db_client")
-        if not db_client:
-            raise ValueError("Database client not available in context")
-
-        # Convert enum values back to strings for the underlying function
-        metrics_strings = None
-        if requested_metrics:
-            metrics_strings = [metric.value for metric in requested_metrics]
-
-        # Get the Pydantic model instance
-        pydantic_result = get_morphology_metrics(
-            cell_morphology_id=cell_morphology_id,
-            db_client=db_client,
-            requested_metrics=metrics_strings,
-        )
-
-        # Convert Pydantic instance to Strawberry type
-        return MorphologyMetricsOutputType.from_pydantic(pydantic_result)
-
-    @strawberry.field
-    def circuit_metrics(
-        self,
-        circuit_id: str,
-        info: strawberry.Info = strawberry.UNSET,
-    ) -> CircuitMetricsOutputType:
-        """Get circuit metrics for a given circuit ID.
-
-        Args:
-            circuit_id: The ID of the circuit
-            info: Strawberry info object containing request context
-
-        Returns:
-            CircuitMetricsOutputType containing the calculated circuit metrics
-        """
-        # Get the db_client from the request context
-        db_client = info.context.get("db_client")
-        if not db_client:
-            raise ValueError("Database client not available in context")
-
-        # Auto-detect level of detail from query
-        level_of_detail_nodes = _detect_node_level_of_detail(info)
-        level_of_detail_edges = _detect_edge_level_of_detail(info)
-
-        # Convert enum values back to CircuitStatsLevelOfDetail
-        level_of_detail_nodes_dict = {
-            "_ALL_": level_of_detail_nodes
-        }
-        level_of_detail_edges_dict = {
-            "_ALL_": level_of_detail_edges
-        }
-
-        # Get the Pydantic model instance
-        pydantic_result = get_circuit_metrics(
-            circuit_id=circuit_id,
-            db_client=db_client,
-            level_of_detail_nodes=level_of_detail_nodes_dict,
-            level_of_detail_edges=level_of_detail_edges_dict,
-        )
-
-        # Convert Pydantic instance to Strawberry type
-        return CircuitMetricsOutputType.from_pydantic(pydantic_result)
-
-
-def _detect_node_level_of_detail(info: strawberry.Info) -> CircuitStatsLevelOfDetail:
-    """Detect the required level of detail for node populations based on the query."""
-    query_str = str(info.field_nodes)
-    
-    # Check for advanced fields that require higher levels of detail
-    if any(field in query_str for field in [
-        "nodeLocationInfo", "propertyUniqueValues", "propertyValueCounts"
-    ]):
-        return CircuitStatsLevelOfDetail.advanced
-    
-    # Check for basic fields that require basic level
-    if any(field in query_str for field in [
-        "biophysicalNodePopulations", "virtualNodePopulations", 
-        "propertyNames", "numberOfNodes"
-    ]):
-        return CircuitStatsLevelOfDetail.basic
-    
-    # Default to none if only basic counts are requested
-    return CircuitStatsLevelOfDetail.none
-
-
-def _detect_edge_level_of_detail(info: strawberry.Info) -> CircuitStatsLevelOfDetail:
-    """Detect the required level of detail for edge populations based on the query."""
-    query_str = str(info.field_nodes)
-    
-    # Check for advanced fields that require higher levels of detail
-    if any(field in query_str for field in [
-        "propertyStats", "degreeStats"
-    ]):
-        return CircuitStatsLevelOfDetail.advanced
-    
-    # Check for basic fields that require basic level
-    if any(field in query_str for field in [
-        "chemicalEdgePopulations", "electricalEdgePopulations",
-        "propertyNames", "numberOfEdges"
-    ]):
-        return CircuitStatsLevelOfDetail.basic
-    
-    # Default to none if only basic counts are requested
-    return CircuitStatsLevelOfDetail.none
 
 
 # Create strawberry schema
 schema = strawberry.Schema(query=Query)
 
 
-# Create GraphQL router with context dependency injection
-async def get_context(
-    db_client: entitysdk.client.Client = Depends(get_client),
-):
-    """Create GraphQL context with dependencies."""
-    return {"db_client": db_client}
-
-
 graphql_router = GraphQLRouter(
     schema,
-    allow_queries_via_get=False,
     context_getter=get_context,
+    allow_queries_via_get=False,
 )

--- a/app/endpoints/graphql.py
+++ b/app/endpoints/graphql.py
@@ -1,0 +1,116 @@
+"""GraphQL endpoints for the obi-one application."""
+
+from enum import Enum
+from typing import Annotated, Literal
+
+import entitysdk.client
+import strawberry
+from strawberry.experimental.pydantic import type as pydantic_type
+from strawberry.fastapi import GraphQLRouter
+from fastapi import Depends
+
+from app.dependencies.entitysdk import get_client
+from obi_one.scientific.library.morphology_metrics import (
+    MORPHOLOGY_METRICS,
+    MorphologyMetricsOutput,
+    get_morphology_metrics,
+)
+
+
+# Create GraphQL enum for morphology metrics
+@strawberry.enum
+class MorphologyMetric(Enum):
+    """Enum for morphology metrics."""
+    ASPECT_RATIO = "aspect_ratio"
+    CIRCULARITY = "circularity"
+    LENGTH_FRACTION_ABOVE_SOMA = "length_fraction_above_soma"
+    MAX_RADIAL_DISTANCE = "max_radial_distance"
+    NUMBER_OF_NEURITES = "number_of_neurites"
+    SOMA_RADIUS = "soma_radius"
+    SOMA_SURFACE_AREA = "soma_surface_area"
+    TOTAL_LENGTH = "total_length"
+    TOTAL_HEIGHT = "total_height"
+    TOTAL_WIDTH = "total_width"
+    TOTAL_DEPTH = "total_depth"
+    TOTAL_AREA = "total_area"
+    TOTAL_VOLUME = "total_volume"
+    SECTION_LENGTHS = "section_lengths"
+    SEGMENT_RADII = "segment_radii"
+    NUMBER_OF_SECTIONS = "number_of_sections"
+    LOCAL_BIFURCATION_ANGLES = "local_bifurcation_angles"
+    REMOTE_BIFURCATION_ANGLES = "remote_bifurcation_angles"
+    SECTION_PATH_DISTANCES = "section_path_distances"
+    SECTION_RADIAL_DISTANCES = "section_radial_distances"
+    SECTION_BRANCH_ORDERS = "section_branch_orders"
+    SECTION_STRAHLER_ORDERS = "section_strahler_orders"
+
+
+@pydantic_type(model=MorphologyMetricsOutput, all_fields=True)
+class MorphologyMetricsOutputType:
+    """Strawberry type for MorphologyMetricsOutput."""
+    pass
+
+
+@strawberry.type
+class Query:
+    """GraphQL Query root for obi-one API."""
+
+    @strawberry.field
+    def hello(self) -> str:
+        """Simple test query to verify GraphQL is working."""
+        return "Hello from GraphQL!"
+
+    @strawberry.field
+    def morphology_metrics(
+        self,
+        cell_morphology_id: str,
+        requested_metrics: list[MorphologyMetric] | None = None,
+        info: strawberry.Info = strawberry.UNSET,
+    ) -> MorphologyMetricsOutputType:
+        """
+        Get morphology metrics for a given cell morphology ID.
+        
+        Args:
+            cell_morphology_id: The ID of the cell morphology
+            requested_metrics: Optional list of specific metrics to calculate (enum values)
+            info: Strawberry info object containing request context
+            
+        Returns:
+            MorphologyMetricsOutputType containing the calculated metrics
+        """
+        # Get the db_client from the request context
+        db_client = info.context.get("db_client")
+        if not db_client:
+            raise ValueError("Database client not available in context")
+        
+        # Convert enum values back to strings for the underlying function
+        metrics_strings = None
+        if requested_metrics:
+            metrics_strings = [metric.value for metric in requested_metrics]
+        
+        # Get the Pydantic model instance
+        pydantic_result = get_morphology_metrics(
+            cell_morphology_id=cell_morphology_id,
+            db_client=db_client,
+            requested_metrics=metrics_strings,
+        )
+        
+        # Convert Pydantic instance to Strawberry type
+        return MorphologyMetricsOutputType.from_pydantic(pydantic_result)
+
+
+# Create strawberry schema
+schema = strawberry.Schema(query=Query)
+
+# Create GraphQL router with context dependency injection
+async def get_context(
+    db_client: entitysdk.client.Client = Depends(get_client),
+):
+    """Create GraphQL context with dependencies."""
+    return {"db_client": db_client}
+
+graphql_router = GraphQLRouter(
+    schema, 
+    allow_queries_via_get=False,
+    context_getter=get_context,
+)

--- a/app/endpoints/graphql.py
+++ b/app/endpoints/graphql.py
@@ -1,32 +1,26 @@
 """GraphQL endpoints for the obi-one application."""
 
 import io
-import json
-from enum import Enum
-from typing import Annotated, NewType, Dict, Any
-import numpy as np
+from typing import Annotated, Any
 
 import entitysdk.client
 import neurom
+import numpy as np
 import strawberry
 from entitysdk.models.cell_morphology import CellMorphology
 from fastapi import Depends
 from neurom import load_morphology
 from neurom.core.morphology import Morphology
-from strawberry.experimental.pydantic import type as pydantic_type
 from strawberry.fastapi import GraphQLRouter
 
 from app.dependencies.entitysdk import get_client
-from obi_one.scientific.library.morphology_metrics import (
-    MorphologyMetricsOutput,
-    get_morphology_metrics,
-)
+
 
 # Dependencies
 def get_morphologies(
-        cell_morphology_ids: list[str],
-        db_client: entitysdk.client.Client,
-    ) -> dict[str, Morphology]:
+    cell_morphology_ids: list[str],
+    db_client: entitysdk.client.Client,
+) -> dict[str, Morphology]:
     """Fetch multiple morphologies by IDs and return their metrics."""
     morphologies = {}
     for cell_morphology_id in cell_morphology_ids:
@@ -44,12 +38,15 @@ def get_morphologies(
                 morphologies[cell_morphology_id] = neurom_morphology
                 break
         else:
-            raise ValueError(f"No SWC asset found for CellMorphology with ID {cell_morphology_id}")
+            message = f"No SWC asset found for CellMorphology with ID {cell_morphology_id}"
+            raise ValueError(message)
     return morphologies
 
 
 # Context getter for GraphQL
-async def get_context(db_client: entitysdk.client.Client = Depends(get_client)) -> Dict[str, Any]:
+async def get_context(
+    db_client: Annotated[entitysdk.client.Client, Depends(get_client)],
+) -> dict[str, Any]:
     """Create GraphQL context with dependencies."""
     return {"db_client": db_client}
 
@@ -63,121 +60,127 @@ class MultipleValuesContainer:
     std: float
 
 
-
 @strawberry.type
 class MorphologyMetrics:
     """Morphology metrics container."""
-    
-    def __init__(self, morphology_id: str, morphology: Morphology):
+
+    def __init__(self, morphology_id: str, morphology: Morphology) -> None:
+        """Initialize with morphology ID and neurom Morphology object."""
         self.morphology_id = morphology_id
         self.morphology = morphology
-    
+
     def _get_list_metric(self, metric_name: str) -> MultipleValuesContainer:
         """Helper method to get list metrics and convert to MultipleValuesContainer."""
         values = neurom.get(metric_name, self.morphology)
         if values is None:
             return MultipleValuesContainer(values=[], length=0, mean=0.0, std=0.0)
-        
+
         # Convert numpy array to list of floats
-        values_list = values.tolist() if hasattr(values, 'tolist') else list(values)
+        values_list = values.tolist() if hasattr(values, "tolist") else list(values)
         values_array = np.array(values_list)
-        
+
         return MultipleValuesContainer(
             values=values_list,
             length=len(values_list),
             mean=float(np.mean(values_array)) if len(values_array) > 0 else 0.0,
-            std=float(np.std(values_array)) if len(values_array) > 0 else 0.0
+            std=float(np.std(values_array)) if len(values_array) > 0 else 0.0,
         )
-    
+
     @strawberry.field(description="ID of the morphology in the database.")
     def id(self) -> str:
         return self.morphology_id
-    
+
     @strawberry.field(description="Aspect ratio of the morphology.")
     def aspect_ratio(self) -> float:
         return neurom.get("aspect_ratio", self.morphology)
-    
+
     @strawberry.field(description="Circularity of the morphology points along the plane.")
     def circularity(self) -> float:
         return neurom.get("circularity", self.morphology)
-    
+
     @strawberry.field(description="Length fraction of segments with midpoints higher than soma.")
     def length_fraction_above_soma(self) -> float:
         return neurom.get("length_fraction_above_soma", self.morphology)
-    
+
     @strawberry.field(description="Maximum radial distance from the soma in micrometers.")
     def max_radial_distance(self) -> float:
         return neurom.get("max_radial_distance", self.morphology)
-    
+
     @strawberry.field(description="Number of neurites in the morphology.")
     def number_of_neurites(self) -> int:
         return neurom.get("number_of_neurites", self.morphology)
-    
+
     @strawberry.field(description="Radius of the soma in micrometers.")
     def soma_radius(self) -> float:
         return neurom.get("soma_radius", self.morphology)
-    
+
     @strawberry.field(description="Surface area of the soma in square micrometers.")
     def soma_surface_area(self) -> float:
         return neurom.get("soma_surface_area", self.morphology)
-    
+
     @strawberry.field(description="Total length of the morphology neurites in micrometers.")
     def total_length(self) -> float:
         return neurom.get("total_length", self.morphology)
-    
+
     @strawberry.field(description="Total height (Y-range) of the morphology in micrometers.")
     def total_height(self) -> float:
         return neurom.get("total_height", self.morphology)
-    
+
     @strawberry.field(description="Total width (X-range) of the morphology in micrometers.")
     def total_width(self) -> float:
         return neurom.get("total_width", self.morphology)
-    
+
     @strawberry.field(description="Total depth (Z-range) of the morphology in micrometers.")
     def total_depth(self) -> float:
         return neurom.get("total_depth", self.morphology)
-    
+
     @strawberry.field(description="Total surface area of all sections in square micrometers.")
     def total_area(self) -> float:
         return neurom.get("total_area", self.morphology)
-    
+
     @strawberry.field(description="Total volume of all sections in cubic micrometers.")
     def total_volume(self) -> float:
         return neurom.get("total_volume", self.morphology)
-    
+
     @strawberry.field(description="Distribution of lengths per section in micrometers.")
     def section_lengths(self) -> MultipleValuesContainer:
         return self._get_list_metric("section_lengths")
-    
+
     @strawberry.field(description="Distribution of radii of the morphology in micrometers.")
     def segment_radii(self) -> MultipleValuesContainer:
         return self._get_list_metric("segment_radii")
-    
+
     @strawberry.field(description="Number of sections in the morphology.")
     def number_of_sections(self) -> int:
         return neurom.get("number_of_sections", self.morphology)
-    
-    @strawberry.field(description="Angles between sections computed at bifurcation (local) in radians.")
+
+    @strawberry.field(
+        description="Angles between sections computed at bifurcation (local) in radians."
+    )
     def local_bifurcation_angles(self) -> MultipleValuesContainer:
         return self._get_list_metric("local_bifurcation_angles")
-    
-    @strawberry.field(description="Angles between sections computed at section ends (remote) in radians.")
+
+    @strawberry.field(
+        description="Angles between sections computed at section ends (remote) in radians."
+    )
     def remote_bifurcation_angles(self) -> MultipleValuesContainer:
         return self._get_list_metric("remote_bifurcation_angles")
-    
+
     @strawberry.field(description="Path distances from soma to section endpoints in micrometers.")
     def section_path_distances(self) -> MultipleValuesContainer:
         return self._get_list_metric("section_path_distances")
-    
+
     @strawberry.field(description="Radial distance from soma to section endpoints in micrometers.")
     def section_radial_distances(self) -> MultipleValuesContainer:
         return self._get_list_metric("section_radial_distances")
-    
+
     @strawberry.field(description="Distribution of branch orders of sections, computed from soma.")
     def section_branch_orders(self) -> MultipleValuesContainer:
         return self._get_list_metric("section_branch_orders")
-    
-    @strawberry.field(description="Distribution of strahler branch orders of sections, computed from terminals.")
+
+    @strawberry.field(
+        description="Distribution of strahler branch orders of sections, computed from terminals."
+    )
     def section_strahler_orders(self) -> MultipleValuesContainer:
         return self._get_list_metric("section_strahler_orders")
 
@@ -187,17 +190,17 @@ class Query:
     """GraphQL Query root for obi-one API."""
 
     @strawberry.field(description="Get morphology metrics for one or more cell morphology IDs.")
-    def morphology_metrics(self, info: strawberry.Info, cell_morphology_ids: list[str]) -> list[MorphologyMetrics]:
+    def morphology_metrics(  # noqa: PLR6301
+        self, info: strawberry.Info, cell_morphology_ids: list[str]
+    ) -> list[MorphologyMetrics]:
         """Get morphology metrics for one or more cell morphology IDs."""
         db_client = info.context["db_client"]
         morphologies_dict = get_morphologies(cell_morphology_ids, db_client)
         # Maintain the original order by iterating through the input list
-        return [MorphologyMetrics(morphology_id, morphologies_dict[morphology_id]) for morphology_id in cell_morphology_ids]
-
-    @strawberry.field
-    def hello(self) -> str:
-        """Simple test query to verify GraphQL is working."""
-        return "Hello from GraphQL!"
+        return [
+            MorphologyMetrics(morphology_id, morphologies_dict[morphology_id])
+            for morphology_id in cell_morphology_ids
+        ]
 
 
 # Create strawberry schema

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dependencies = [
     "bluecellulab>=2.6.62",
     # OBI NOTEBOOK
     "obi_notebook",
+    "strawberry-graphql[cli,fastapi]>=0.283.2",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -822,6 +822,15 @@ wheels = [
 ]
 
 [[package]]
+name = "graphql-core"
+version = "3.2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/16/7574029da84834349b60ed71614d66ca3afe46e9bf9c7b9562102acb7d4f/graphql_core-3.2.6.tar.gz", hash = "sha256:c08eec22f9e40f0bd61d805907e3b3b1b9a320bc606e23dc145eebca07c8fbab", size = 505353, upload-time = "2025-01-26T16:36:27.374Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/4f/7297663840621022bc73c22d7d9d80dbc78b4db6297f764b545cd5dd462d/graphql_core-3.2.6-py3-none-any.whl", hash = "sha256:78b016718c161a6fb20a7d97bbf107f331cd1afe53e45566c59f776ed7f0b45f", size = 203416, upload-time = "2025-01-26T16:36:24.868Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.2.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1376,6 +1385,37 @@ wheels = [
 ]
 
 [[package]]
+name = "lia-web"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1e/4e/847404ca9d36e3f5468c9e460aed565a02cbca0fdf81247da9f87fabc1b8/lia_web-0.2.3.tar.gz", hash = "sha256:ccc9d24cdc200806ea96a20b22fb68f4759e6becdb901bd36024df7921e848d7", size = 156761, upload-time = "2025-08-11T10:23:21.003Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/f2/c68a97c727c795119f1056ad2b7e716c23f26f004292517c435accf90b5c/lia_web-0.2.3-py3-none-any.whl", hash = "sha256:237c779c943cd4341527fc0adfcc3d8068f992ee051f4ef059b8474ee087f641", size = 13965, upload-time = "2025-08-11T10:23:20.215Z" },
+]
+
+[[package]]
+name = "libcst"
+version = "1.8.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/55/ca4552d7fe79a91b2a7b4fa39991e8a45a17c8bfbcaf264597d95903c777/libcst-1.8.5.tar.gz", hash = "sha256:e72e1816eed63f530668e93a4c22ff1cf8b91ddce0ec53e597d3f6c53e103ec7", size = 884582, upload-time = "2025-09-26T05:29:44.101Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/bb/c7abe0654fcf00292d6959256948ce4ae07785c4f65a45c3e25cc4637074/libcst-1.8.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:27c7733aba7b43239157661207b1e3a9f3711a7fc061a0eca6a33f0716fdfd21", size = 2196690, upload-time = "2025-09-26T05:28:17.839Z" },
+    { url = "https://files.pythonhosted.org/packages/49/25/e7c02209e8ce66e7b75a66d132118f6f812a8b03cd31ee7d96de56c733a1/libcst-1.8.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b8c3cfbbf6049e3c587713652e4b3c88cfbf7df7878b2eeefaa8dd20a48dc607", size = 2082616, upload-time = "2025-09-26T05:28:19.794Z" },
+    { url = "https://files.pythonhosted.org/packages/32/68/a4f49d99e3130256e225d639722440ba2682c12812a30ebd7ba64fd0fd31/libcst-1.8.5-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:31d86025d8997c853f85c4b5d494f04a157fb962e24f187b4af70c7755c9b27d", size = 2229037, upload-time = "2025-09-26T05:28:21.459Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/62/4fa21600a0bf3eb9f4d4f8bbb50ef120fb0b2990195eabba997b0b889566/libcst-1.8.5-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:ff9c535cfe99f0be79ac3024772b288570751fc69fc472b44fca12d1912d1561", size = 2292806, upload-time = "2025-09-26T05:28:23.033Z" },
+    { url = "https://files.pythonhosted.org/packages/14/df/a01e8d54b62060698e37e3e28f77559ecb70c7b93ffee00d17e40221f419/libcst-1.8.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e8204607504563d3606bbaea2b9b04e0cef2b3bdc14c89171a702c1e09b9318a", size = 2294836, upload-time = "2025-09-26T05:28:24.937Z" },
+    { url = "https://files.pythonhosted.org/packages/75/4f/c410e7f7ceda0558f688c1ca5dfb3a40ff8dfc527f8e6015fa749e11a650/libcst-1.8.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5e6cd3df72d47701b205fa3349ba8899566df82cef248c2fdf5f575d640419c4", size = 2396004, upload-time = "2025-09-26T05:28:26.582Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/07/bb77dcb94badad0ad3e5a1e992a4318dbdf40632eac3b5cf18299858ad7d/libcst-1.8.5-cp312-cp312-win_amd64.whl", hash = "sha256:197c2f86dd0ca5c6464184ddef7f6440d64c8da39b78d16fc053da6701ed1209", size = 2107301, upload-time = "2025-09-26T05:28:28.235Z" },
+    { url = "https://files.pythonhosted.org/packages/79/70/e688e6d99d6920c3f97bf8bbaec33ac2c71a947730772a1d32dd899dbbf1/libcst-1.8.5-cp312-cp312-win_arm64.whl", hash = "sha256:c5ca109c9a81dff3d947dceba635a08f9c3dfeb7f61b0b824a175ef0a98ea69b", size = 1990870, upload-time = "2025-09-26T05:28:29.858Z" },
+]
+
+[[package]]
 name = "libsonata"
 version = "0.1.31"
 source = { registry = "https://pypi.org/simple" }
@@ -1862,6 +1902,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "sqlalchemy" },
     { name = "starlette" },
+    { name = "strawberry-graphql", extra = ["cli", "fastapi"] },
     { name = "uvicorn" },
 ]
 
@@ -1913,6 +1954,7 @@ requires-dist = [
     { name = "python-multipart" },
     { name = "sqlalchemy" },
     { name = "starlette" },
+    { name = "strawberry-graphql", extras = ["cli", "fastapi"], specifier = ">=0.283.2" },
     { name = "uvicorn" },
 ]
 provides-extras = ["connectivity"]
@@ -2781,6 +2823,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2862,6 +2913,38 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a7/a5/d6f429d43394057b67a6b5bbe6eae2f77a6bf7459d961fdb224bf206eee6/starlette-0.48.0.tar.gz", hash = "sha256:7e8cee469a8ab2352911528110ce9088fdc6a37d9876926e73da7ce4aa4c7a46", size = 2652949, upload-time = "2025-09-13T08:41:05.699Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/72/2db2f49247d0a18b4f1bb9a5a39a0162869acf235f3a96418363947b3d46/starlette-0.48.0-py3-none-any.whl", hash = "sha256:0764ca97b097582558ecb498132ed0c7d942f233f365b86ba37770e026510659", size = 73736, upload-time = "2025-09-13T08:41:03.869Z" },
+]
+
+[[package]]
+name = "strawberry-graphql"
+version = "0.283.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "graphql-core" },
+    { name = "lia-web" },
+    { name = "packaging" },
+    { name = "python-dateutil" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/25/15475da816a58e261883debdae91499a9b780c8c9ef40727b7e7a538c837/strawberry_graphql-0.283.2.tar.gz", hash = "sha256:d8e63dcc0472e59d57e00c39de4d620699288127bc571698d82ab292498c744e", size = 212061, upload-time = "2025-10-07T17:26:16.776Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/4c/851fb4e30c3080e950201ab1ba45379072309b320c546edb239d3cf2f57d/strawberry_graphql-0.283.2-py3-none-any.whl", hash = "sha256:2442ab07ad408dc05c41a90685aa14038e617285e9b1abd6c73a8c43fb7ea399", size = 309811, upload-time = "2025-10-07T17:26:13.97Z" },
+]
+
+[package.optional-dependencies]
+cli = [
+    { name = "libcst" },
+    { name = "pygments" },
+    { name = "python-multipart" },
+    { name = "rich" },
+    { name = "starlette" },
+    { name = "typer" },
+    { name = "uvicorn" },
+    { name = "websockets" },
+]
+fastapi = [
+    { name = "fastapi" },
+    { name = "python-multipart" },
 ]
 
 [[package]]
@@ -2979,6 +3062,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8a/71/0578e44d2110f93c2136eb705f5b11e706e1e8ea3acaaaeac043bd40d8fd/traittypes-0.2.1.tar.gz", hash = "sha256:be6fa26294733e7489822ded4ae25da5b4824a8a7a0e0c2dccfde596e3489bd6", size = 13544, upload-time = "2018-06-16T07:34:00.929Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/d1/8d5bd662703cc1764d986f6908a608777305946fa634d34c470cd4a1e729/traittypes-0.2.1-py2.py3-none-any.whl", hash = "sha256:1340af133810b6eee1a2eb2e988f862b0d12b6c2d16f282aaf3207b782134c2e", size = 8550, upload-time = "2018-06-16T07:33:59.594Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/ca/950278884e2ca20547ff3eb109478c6baf6b8cf219318e6bc4f666fad8e8/typer-0.19.2.tar.gz", hash = "sha256:9ad824308ded0ad06cc716434705f691d4ee0bfd0fb081839d2e426860e7fdca", size = 104755, upload-time = "2025-09-23T09:47:48.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/22/35617eee79080a5d071d0f14ad698d325ee6b3bf824fc0467c03b30e7fa8/typer-0.19.2-py3-none-any.whl", hash = "sha256:755e7e19670ffad8283db353267cb81ef252f595aa6834a0d1ca9312d9326cb9", size = 46748, upload-time = "2025-09-23T09:47:46.777Z" },
 ]
 
 [[package]]
@@ -3102,6 +3200,26 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e6/30/fba0d96b4b5fbf5948ed3f4681f7da2f9f64512e1d303f94b4cc174c24a5/websocket_client-1.8.0.tar.gz", hash = "sha256:3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da", size = 54648, upload-time = "2024-04-23T22:16:16.976Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/84/44687a29792a70e111c5c477230a72c4b957d88d16141199bf9acb7537a3/websocket_client-1.8.0-py3-none-any.whl", hash = "sha256:17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526", size = 58826, upload-time = "2024-04-23T22:16:14.422Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437, upload-time = "2025-03-05T20:02:16.706Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096, upload-time = "2025-03-05T20:02:18.832Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332, upload-time = "2025-03-05T20:02:20.187Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152, upload-time = "2025-03-05T20:02:22.286Z" },
+    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096, upload-time = "2025-03-05T20:02:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523, upload-time = "2025-03-05T20:02:25.669Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790, upload-time = "2025-03-05T20:02:26.99Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165, upload-time = "2025-03-05T20:02:30.291Z" },
+    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160, upload-time = "2025-03-05T20:02:31.634Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395, upload-time = "2025-03-05T20:02:33.017Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841, upload-time = "2025-03-05T20:02:34.498Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #355 

# TODO
- [x] Integrate morphology metrics (the lazy way)
- [x] Integrate morphology metrics the proper way
 - No need to pass an argument `list[str]` that decides on what features will be extracted. Instead, each of the output fields is a separate resolver.
 - Also, it would be convenient for the metrics that spit out a `list[float]` to have some wrapper that also provides `lenght, mean, std, values` so that one does not always have to fetch all of them.
 - And now it makes me think maybe you could understand how the pagination across the `values` would work.
 - Support both single morphologies and bulk morphologies
- [ ] Integrate circuit metrics
  - [ ] Imply level of detail based on the query
  - [ ] Issue below
   ```    raise cls(f"{self.name} fields cannot be resolved. {error}") from error
   TypeError: CircuitMetricsNodePopulationType fields cannot be resolved. Unexpected type 'dict[str, list[str]]'
   ```
- [ ] Fix CI


# Comments
* I originally wanted to do it for ephys metrics but they I realized that the output type is basically just `dict[str, Any]` which is useless for GraphQL. I therefore decided to switch to morphometrics
