### PR TITLE
default_block_reference_labels added to json_schema_extra

### DIFF
--- a/obi_one/scientific/tasks/generate_simulation_configs.py
+++ b/obi_one/scientific/tasks/generate_simulation_configs.py
@@ -26,7 +26,6 @@ from obi_one.scientific.from_id.circuit_from_id import CircuitFromID
 from obi_one.scientific.from_id.memodel_from_id import MEModelFromID
 from obi_one.scientific.library.circuit import Circuit
 from obi_one.scientific.library.memodel_circuit import MEModelCircuit
-from obi_one.scientific.blocks.neuron_sets import AllNeurons
 from obi_one.scientific.unions.unions_manipulations import (
     SynapticManipulationsReference,
     SynapticManipulationsUnion,
@@ -86,7 +85,7 @@ class SimulationScanConfig(ScanConfig, abc.ABC):
             ],
             "default_block_reference_labels": {
                 NeuronSetReference.__name__: DEFAULT_NODE_SET_NAME,
-            }
+            },
         }
 
     timestamps: dict[str, TimestampsUnion] = Field(

--- a/obi_one/scientific/tasks/generate_simulation_task.py
+++ b/obi_one/scientific/tasks/generate_simulation_task.py
@@ -18,9 +18,9 @@ from obi_one.scientific.library.sonata_circuit_helpers import (
     write_circuit_node_set_file,
 )
 from obi_one.scientific.tasks.generate_simulation_configs import (
+    DEFAULT_NODE_SET_NAME,
     SONATA_VERSION,
     TARGET_SIMULATOR,
-    DEFAULT_NODE_SET_NAME,
     CircuitSimulationSingleConfig,
     MEModelSimulationSingleConfig,
 )
@@ -28,7 +28,6 @@ from obi_one.scientific.unions.unions_neuron_sets import (
     NeuronSetReference,
     resolve_neuron_set_ref_to_node_set,
 )
-
 
 L = logging.getLogger(__name__)
 


### PR DESCRIPTION
* default_block_reference_labels added to json_schema_extra to allow UI to display custom default string in dropdown for block reference parameter types (the same label would be selected by default when there are no blocks of the corresponding type in the corresponding route dictionary)
* For example, "Default All Biophysical Neurons" could be selected for any NeuronSetReference parameter, and would be selected by default
* The name is not stored as an annotation of each NeuronSetReference parameter, as the exact default is defined at the level of the SimulationGenerationScanConfig, not within the NeuronSets which might have different defaults in other contexts