### PR TITLE
Ignore files classified as "AGS Script" from repositoty languages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
 *.asc linguist-detectable=false
 *.hoc linguist-detectable=false
 *.mod linguist-detectable=false
-*.ipynb linguist-detectable=false


### PR DESCRIPTION
* Currently the repository is classified as a repository primarily of "AGS Script" rather than Python. I think this is caused be some of the hoc, mod, or asc files being classified by "Linguist"
* Installing "Linguist" to test this using Ruby was difficult (I encounted lots of compiler errors etc) so I wasn't able to test the new classification. I'm hopeful this will work though. If it doesn't I'll test before making another PR