### PR TITLE
fix latex for bell equation

### DIFF
--- a/obi_one/scientific/blocks/ion_channel_equations.py
+++ b/obi_one/scientific/blocks/ion_channel_equations.py
@@ -75,7 +75,7 @@ class BellFitMTau(IonChannelEquation):
 
     class Config:
         json_schema_extra: ClassVar[dict] = {
-            "latex_equation": r"\frac{1.}{e^{ \frac{ (v - v_{half}) ^ 2 }{k} }}"
+            "latex_equation": r"\frac{A}{e^{ \frac{ (v - v_{half}) ^ 2 }{k} }}"
         }
 
 


### PR DESCRIPTION
The bell equation has been modified in [this PR](https://github.com/openbraininstitute/ion-channel-builder/pull/13) to fix [this issue](https://github.com/openbraininstitute/prod-build-ion-channel-model/issues/37).
This change is to keep the latex display up to date with these changes.