### PR TITLE
fix typo

### DIFF
--- a/obi_one/scientific/blocks/ion_channel_equations.py
+++ b/obi_one/scientific/blocks/ion_channel_equations.py
@@ -70,7 +70,7 @@ class ThermoFitMTauV2(IonChannelEquation):
 
 
 class BellFitMTau(IonChannelEquation):
-    equation_key: ClassVar[str] = "bellfit_mtau"
+    equation_key: ClassVar[str] = "bell_fit_mtau"
     title: ClassVar[str] = r"Bell equation for \tau_m"
 
     class Config:


### PR DESCRIPTION
this should be consistent with https://github.com/openbraininstitute/ion-channel-builder/blob/main/ion_channel_builder/create_model/__init__.py#L26
This should solve https://github.com/openbraininstitute/prod-build-ion-channel-model/issues/37