### PR TITLE
Treat empty and missing inputs in connectivity metrics endpoint consistently

### DIFF
--- a/obi_one/scientific/library/connectivity_metrics.py
+++ b/obi_one/scientific/library/connectivity_metrics.py
@@ -207,6 +207,16 @@ def get_connectivity_metrics(
         c = circuit.sonata_circuit
 
         # Check inputs
+        if not pre_selection:
+            pre_selection = None
+        if not post_selection:
+            post_selection = None
+
+        if not pre_node_set:
+            pre_node_set = None
+        if not post_node_set:
+            post_node_set = None
+
         if pre_node_set is None:
             pre_dict = pre_selection
         else:
@@ -218,6 +228,9 @@ def get_connectivity_metrics(
             node_set_dict = {"node_set": post_node_set}
             post_dict = node_set_dict if post_selection is None else post_selection | node_set_dict
         dist_props = None if max_distance is None else ["x", "y", "z"]
+
+        if not group_by:
+            group_by = None
 
         # Compute connection probability
         conn_dict = connectivity.compute(


### PR DESCRIPTION
Added more input checks so that the connectivity metrics endpoint would treat empty and missing inputs consistently:
- `group_by`: `""` treated in the same way as `None` (otherwise, `""` would raise an error)
- `pre/post_selection`: `{}` treated in the same way as `None` (otherwise, `{}` would be interpreted as empty selection)
- `pre/post_node_set`: `""` treated in the same way as `None` (otherwise, `""` would raise an error)

Related issue: https://github.com/openbraininstitute/obi-one/issues/472
