### PR TITLE
Add to numeric value schema check

### DIFF
--- a/scripts/validate_block.py
+++ b/scripts/validate_block.py
@@ -64,13 +64,13 @@ def determine_minimum_valid_numeric_value(schema: dict) -> float | int:
         minimum = single_type.get("minimum", None)
         if minimum is None:
             minimum = single_type.get("exclusiveMinimum", -sys.maxsize)
-            minimum = minimum + math.ulp(minimum)
+            minimum = minimum + 1
 
 
         maximum = single_type.get("maximum", None)
         if maximum is None:
             maximum = single_type.get("exclusiveMaximum", sys.maxsize)
-            maximum = maximum - math.ulp(maximum)
+            maximum = maximum - 1
 
     elif single_type.get("type") == "number":
         minimum = single_type.get("minimum", None)


### PR DESCRIPTION
* Logic to choose an appropriate value for numeric schema check (as using 1.0 failed for a skeletonization task parameter with constraints 0.1 < x < 0.5
*  Logical checks on default, minimum, maximum values
* Check list[numeric] is second value in union with matching constraints as first numeric in union

* Note: Need to return to solution for handling exclusive min/max values