### PR TITLE
Move code and resources declaration to task definition

### DIFF
--- a/app/mappings.py
+++ b/app/mappings.py
@@ -5,8 +5,14 @@ from entitysdk.types import AssetLabel
 from obp_accounting_sdk.constants import ServiceSubtype
 
 from app.config import settings
-from app.schemas.task import TaskDefinition
-from app.types import TaskType
+from app.schemas.task import (
+    BuiltinCode,
+    ClusterResources,
+    MachineResources,
+    PythonRepositoryCode,
+    TaskDefinition,
+)
+from app.types import BuiltinScript, TaskType
 
 OBI_ONE_CODE_PATH = str(Path(settings.OBI_ONE_LAUNCH_PATH) / "code.py")
 OBI_ONE_DEPS_PATH = str(Path(settings.OBI_ONE_LAUNCH_PATH) / "requirements.txt")
@@ -19,19 +25,17 @@ TASK_DEFINITIONS: dict[TaskType, TaskDefinition] = {
         activity_type=models.CircuitExtractionExecution,
         accounting_service_subtype=ServiceSubtype.SMALL_CIRCUIT_SIM,
         config_asset_label=AssetLabel.circuit_extraction_config,
-        code={
-            "type": "python_repository",
-            "location": settings.OBI_ONE_REPO,
-            "ref": "tag:2026.1.7",
-            "path": OBI_ONE_CODE_PATH,
-            "dependencies": OBI_ONE_DEPS_PATH,
-        },
-        resources={
-            "type": "machine",
-            "cores": 1,
-            "memory": 2,
-            "timelimit": "00:10",
-        },
+        code=PythonRepositoryCode(
+            location=settings.OBI_ONE_REPO,
+            ref="tag:2026.1.7",
+            path=OBI_ONE_CODE_PATH,
+            dependencies=OBI_ONE_DEPS_PATH,
+        ),
+        resources=MachineResources(
+            cores=1,
+            memory=2,
+            timelimit="00:10",
+        ),
     ),
     TaskType.circuit_simulation: TaskDefinition(
         task_type=TaskType.circuit_simulation,
@@ -39,14 +43,13 @@ TASK_DEFINITIONS: dict[TaskType, TaskDefinition] = {
         activity_type=models.SimulationExecution,
         accounting_service_subtype=ServiceSubtype.SMALL_SIM,  # May be overridden by circuit scale
         config_asset_label=AssetLabel.sonata_simulation_config,
-        code={
-            "type": "builtin",
-            "script": "circuit_simulation",
-        },
-        resources={
-            "type": "cluster",
-            "instances": 1,
-            "instance_type": "small",
-        },
+        code=BuiltinCode(
+            script=BuiltinScript.circuit_simulation,
+        ),
+        resources=ClusterResources(
+            instances=1,
+            instance_type="small",
+            timelimit="00:10",
+        ),
     ),
 }

--- a/app/schemas/task.py
+++ b/app/schemas/task.py
@@ -1,12 +1,62 @@
+from typing import Annotated, Literal
 from uuid import UUID
 
 from entitysdk.models.activity import Activity, Entity
 from entitysdk.types import AssetLabel
 from obp_accounting_sdk.constants import ServiceSubtype
+from pydantic import Field
 
 from app.schemas.accounting import AccountingParameters
 from app.schemas.base import Schema
-from app.types import TaskType
+from app.types import (
+    BuiltinScript,
+    CodeType,
+    ResourcesConfigType,
+    TaskType,
+)
+
+
+class PythonRepositoryCode(Schema):
+    type: Literal[CodeType.python_repository] = CodeType.python_repository
+    location: str
+    ref: str
+    path: str
+    dependencies: str
+
+
+class BuiltinCode(Schema):
+    type: Literal[CodeType.builtin] = CodeType.builtin
+    script: BuiltinScript
+
+
+Code = Annotated[
+    PythonRepositoryCode | BuiltinCode,
+    Field(discriminator="type"),
+]
+
+
+class MachineResources(Schema):
+    """MachineResources schema to be used when reading existing jobs."""
+
+    type: Literal[ResourcesConfigType.machine] = ResourcesConfigType.machine
+    cores: int = 1
+    memory: int = 2
+    timelimit: str | None = None
+
+
+class ClusterResources(Schema):
+    """ClusterResources schema to be used when reading existing jobs."""
+
+    type: Literal[ResourcesConfigType.cluster] = ResourcesConfigType.cluster
+    instances: int
+    instance_type: str
+    timelimit: str | None = None
+
+
+Resources = Annotated[
+    MachineResources | ClusterResources,
+    Field(discriminator="type"),
+]
 
 
 class TaskLaunchSubmit(Schema):
@@ -41,8 +91,8 @@ class TaskDefinition(Schema):
     activity_type: type[Activity]
     accounting_service_subtype: ServiceSubtype
     config_asset_label: AssetLabel
-    code: dict
-    resources: dict
+    code: Code
+    resources: Resources
 
     @property
     def config_type_name(self) -> str:

--- a/app/services/task.py
+++ b/app/services/task.py
@@ -109,8 +109,8 @@ def _circuit_simulation_job_data(
     task_definition: TaskDefinition,
 ) -> dict:
     return {
-        "code": task_definition.code,
-        "resources": task_definition.resources,
+        "code": task_definition.code.model_dump(mode="json"),
+        "resources": task_definition.resources.model_dump(mode="json"),
         "inputs": [
             "--simulation-id",
             str(simulation_id),
@@ -135,8 +135,8 @@ def _generic_job_data(
     task_definition: TaskDefinition,
 ) -> dict:
     return {
-        "code": task_definition.code,
-        "resources": task_definition.resources,
+        "code": task_definition.code.model_dump(mode="json"),
+        "resources": task_definition.resources.model_dump(mode="json"),
         "inputs": [
             f"--entity_type {task_definition.config_type_name}",
             f"--entity_id {config_id}",

--- a/app/types.py
+++ b/app/types.py
@@ -17,3 +17,23 @@ class CallBackEvent(StrEnum):
 class CallBackAction(StrEnum):
     http_request = auto()
     http_request_with_token = auto()
+
+
+class ResourcesConfigType(StrEnum):
+    """Resources configuration type."""
+
+    machine = auto()
+    cluster = auto()
+
+
+class CodeType(StrEnum):
+    """Code type."""
+
+    python_repository = auto()
+    builtin = auto()
+
+
+class BuiltinScript(StrEnum):
+    """Builtin script."""
+
+    circuit_simulation = auto()

--- a/tests/app/services/test_task.py
+++ b/tests/app/services/test_task.py
@@ -275,6 +275,7 @@ def test_circuit_simulation_job_data(config_id, activity_id, callbacks):
             "type": "cluster",
             "instances": 1,
             "instance_type": "small",
+            "timelimit": "00:10",
         },
         "inputs": [
             "--simulation-id",
@@ -329,7 +330,7 @@ def test_generic_job_data(config_id, activity_id, callbacks):
         "code": {
             "type": "python_repository",
             "location": "https://github.com/openbraininstitute/obi-one.git",
-            "ref": task_definition.code["ref"],
+            "ref": task_definition.code.ref,
             "path": "launch_scripts/launch_task_for_single_config_asset/code.py",
             "dependencies": "launch_scripts/launch_task_for_single_config_asset/requirements.txt",
         },


### PR DESCRIPTION
Move code and resources definitions at the task definition side to allow declaring different values per task.

I also made the tag ref explicit and not depend dynamically on the latest release.