### PR TITLE
Added optional obi-one dependency to launch script

### DIFF
--- a/launch_scripts/launch_task_for_single_config_asset/requirements.txt
+++ b/launch_scripts/launch_task_for_single_config_asset/requirements.txt
@@ -1,4 +1,3 @@
 entitysdk==0.11.1
 obi_auth==1.0.0
-connectome-analysis>=1.0.1
-obi-one
+obi-one[connectivity]


### PR DESCRIPTION
- Added optional `obi-one[connectivity]` dependency which is required for basic connectivity plots