### PR TITLE
Fix accounting callback payload

### DIFF
--- a/app/schemas/task.py
+++ b/app/schemas/task.py
@@ -103,3 +103,9 @@ class TaskDefinition(Schema):
     def activity_type_name(self) -> str:
         """Return the name of the activity class."""
         return self.activity_type.__name__
+
+
+class TaskCallBackSuccessRequest(Schema):
+    task_type: TaskType
+    job_id: UUID
+    count: int

--- a/app/services/accounting.py
+++ b/app/services/accounting.py
@@ -1,13 +1,14 @@
-import time
 from http import HTTPStatus
 from uuid import UUID
 
+import httpx
 from entitysdk import Client, ProjectContext, models
 from entitysdk.types import CircuitScale
 from fastapi import HTTPException
 from obp_accounting_sdk import AccountingSessionFactory, OneshotSession
 from obp_accounting_sdk.constants import ServiceSubtype
 from obp_accounting_sdk.errors import BaseAccountingError, InsufficientFundsError
+from obp_accounting_sdk.utils import get_current_timestamp
 
 from app.config import settings
 from app.errors import ApiError, ApiErrorCode
@@ -17,6 +18,7 @@ from app.schemas.auth import UserContext
 from app.schemas.callback import CallBack, HttpRequestCallBackConfig
 from app.schemas.task import TaskAccountingInfo, TaskDefinition
 from app.types import CallBackAction, CallBackEvent, TaskType
+from app.utils.http import make_http_request
 
 CIRCUIT_SCALE_TO_SERVICE_SUBTYPE = {
     CircuitScale.small: ServiceSubtype.SMALL_SIM,
@@ -146,20 +148,24 @@ def _evaluate_circuit_simulation_parameters(
 
 
 def generate_accounting_callbacks(
+    task_type: TaskType,
     accounting_job_id: str,
-    service_subtype: ServiceSubtype,
     count: int,
+    virtual_lab_id: str,
     project_id: str,
+    callback_url: str,
 ) -> list[CallBack]:
     return [
         _generate_accounting_failure_callback(
             accounting_job_id=accounting_job_id,
         ),
         _generate_accounting_success_callback(
+            task_type=task_type,
             accounting_job_id=accounting_job_id,
-            service_subtype=service_subtype,
             count=count,
             project_id=project_id,
+            virtual_lab_id=virtual_lab_id,
+            callback_url=callback_url,
         ),
     ]
 
@@ -184,9 +190,11 @@ def _generate_accounting_failure_callback(
 
 
 def _generate_accounting_success_callback(
+    task_type: TaskType,
     accounting_job_id: str,
-    service_subtype: ServiceSubtype,
     count: int,
+    callback_url: str,
+    virtual_lab_id: str,
     project_id: str,
 ) -> CallBack:
     """Builds the callback URL and payload for accounting success (usage addition).
@@ -194,19 +202,43 @@ def _generate_accounting_success_callback(
     Points directly to the accounting service POST /usage/oneshot endpoint.
     """
     config = HttpRequestCallBackConfig(
-        url=f"{settings.ACCOUNTING_BASE_URL}/usage/oneshot",
+        url=f"{callback_url}/success",
         method="POST",
         payload={
-            "type": "oneshot",
-            "subtype": service_subtype,
-            "proj_id": project_id,
+            "task_type": task_type,
             "job_id": accounting_job_id,
-            "count": str(count),
-            "timestamp": str(int(time.time())),
+            "count": count,
+        },
+        headers={
+            "virtual-lab-id": str(virtual_lab_id),
+            "project-id": str(project_id),
         },
     )
     return CallBack(
-        config=config,
         event_type=CallBackEvent.job_on_success,
         action_type=CallBackAction.http_request_with_token,
+        config=config,
+    )
+
+
+def finish_accounting_session(
+    accounting_job_id: str,
+    service_subtype: ServiceSubtype,
+    count: int,
+    project_id: str,
+    http_client: httpx.Client,
+) -> None:
+    data = {
+        "type": "oneshot",
+        "subtype": service_subtype,
+        "proj_id": project_id,
+        "count": str(count),
+        "job_id": accounting_job_id,
+        "timestamp": get_current_timestamp(),
+    }
+    make_http_request(
+        url=f"{settings.ACCOUNTING_BASE_URL}/usage/oneshot",
+        method="POST",
+        json=data,
+        http_client=http_client,
     )

--- a/tests/app/endpoints/test_task.py
+++ b/tests/app/endpoints/test_task.py
@@ -157,3 +157,18 @@ def test_task_failure_endpoint(client, task_type):
                 "activity_id": str(activity_id),
             },
         ).raise_for_status()
+
+
+@pytest.mark.parametrize("task_type", TaskType)
+def test_task_success_endpoint(client, task_type):
+    job_id = uuid4()
+
+    with patch("app.services.accounting.finish_accounting_session", autospec=True):
+        client.post(
+            url="/declared/task/callback/success",
+            json={
+                "task_type": task_type,
+                "job_id": str(job_id),
+                "count": 11,
+            },
+        ).raise_for_status()


### PR DESCRIPTION
Error:
```
      {
        "status": "failure",
        "details": {
          "url": "https://staging.cell-a.openbraininstitute.org/api/accounting/usage/oneshot",
          "json": {
            "type": "oneshot",
            "count": 1,
            "job_id": "003e61b4-706d-4d5b-a860-73e5f2c823cf",
            "proj_id": "2720f785-a3a2-4472-969d-19a53891c817",
            "subtype": "small-circuit-sim",
            "timestamp": "2026-02-10T11:00:54.370659+00:00"
          },
          "method": "POST",
          "params": null
        },
        "event_type": "job_on_success",
        "action_type": "http_request_with_token",
        "error_reason": {
          "details": null,
          "message": "HTTP status error 422: {\"error_code\":\"INVALID_REQUEST\",\"message\":\"Validation error\",\"details\":[{\"type\":\"int_parsing\",\"loc\":[\"body\",\"timestamp\",0],\"msg\":\"Input should be a valid integer, unable to parse string as an integer\"}]}",
          "error_code": "GENERIC_ERROR",
          "http_status_code": 500
        }
      }
```
count needs to be passed as a string. Following a discussion with @pgetta I also changed the timestamp to be calculated the same way as in accounting sdk.