### PR TITLE
Refactor morphology validation endpoint

### DIFF
--- a/app/dependencies/file.py
+++ b/app/dependencies/file.py
@@ -1,0 +1,23 @@
+import shutil
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import Depends
+
+
+def _create_temp_dir() -> Iterator[Path]:
+    """Create a temporary directory, to be used as a dependency with scope=request.
+
+    The directory is deleted only after the response is sent back to the client,
+    and even in case of uncaught exception.
+    """
+    temp_dir = Path(tempfile.mkdtemp())
+    try:
+        yield temp_dir
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+TempDirDep = Annotated[Path, Depends(_create_temp_dir, scope="request")]

--- a/app/endpoints/morphology_validation.py
+++ b/app/endpoints/morphology_validation.py
@@ -1,222 +1,70 @@
-import asyncio
-import pathlib
-import shutil
-import tempfile
-import zipfile
 from http import HTTPStatus
+from pathlib import Path
 from typing import Annotated
 
-import morphio
-import neurom
-from fastapi import APIRouter, BackgroundTasks, Depends, File, HTTPException, Query, UploadFile
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from fastapi.responses import FileResponse
-from morph_tool import convert
-from neurom.exceptions import NeuroMError
 
 from app.dependencies.auth import user_verified
+from app.dependencies.file import TempDirDep
 from app.errors import ApiErrorCode
-from app.logger import L
+from app.services import file as file_service, morphology as morphology_service
+from app.services.morphology import ALLOWED_EXTENSIONS, DEFAULT_SINGLE_POINT_SOMA_BY_EXT
 
 router = APIRouter(prefix="/declared", tags=["declared"], dependencies=[Depends(user_verified)])
 
-DEFAULT_SINGLE_POINT_SOMA_BY_EXT: dict[str, bool] = {
-    ".h5": False,
-    ".swc": True,
-    ".asc": False,
-}
 
-
-def _handle_empty_file(file: UploadFile) -> None:
-    L.error(f"Empty file uploaded: {file.filename}")
-    raise HTTPException(
-        status_code=HTTPStatus.BAD_REQUEST,
-        detail={
-            "code": ApiErrorCode.INVALID_REQUEST,
-            "detail": "Uploaded file is empty",
-        },
-    )
-
-
-async def process_and_convert_morphology(
-    temp_file_path: str,
-    file_extension: str,
-    *,
-    output_basename: str | None = None,
-    single_point_soma_by_ext: dict[str, bool] | None = None,
-) -> tuple[str, str]:
-    try:
-        morphio.set_raise_warnings(False)
-        morphio.Morphology(temp_file_path)
-
-        temp_path = pathlib.Path(temp_file_path)
-        out_dir = temp_path.parent
-        stem = output_basename or temp_path.stem
-
-        if file_extension == ".swc":
-            target_exts = (".h5", ".asc")
-        elif file_extension == ".h5":
-            target_exts = (".swc", ".asc")
-        else:
-            target_exts = (".swc", ".h5")
-
-        outputfile1 = out_dir / f"{stem}{target_exts[0]}"
-        outputfile2 = out_dir / f"{stem}{target_exts[1]}"
-
-        mapping = single_point_soma_by_ext or DEFAULT_SINGLE_POINT_SOMA_BY_EXT
-
-        convert(
-            temp_file_path,
-            str(outputfile1),
-            single_point_soma=mapping.get(target_exts[0], False),
-        )
-        convert(
-            temp_file_path,
-            str(outputfile2),
-            single_point_soma=mapping.get(target_exts[1], False),
-        )
-
-    except Exception as e:
+def _validate_soma_diameter(file_path: Path) -> None:
+    if not morphology_service.validate_soma_diameter(file_path=file_path):
         raise HTTPException(
             status_code=HTTPStatus.BAD_REQUEST,
             detail={
                 "code": ApiErrorCode.INVALID_REQUEST,
-                "detail": f"Failed to load and convert the file: {e!s}",
-            },
-        ) from e
-    else:
-        return str(outputfile1), str(outputfile2)
-
-
-def _create_zip_file_sync(zip_path: str, file1: str, file2: str) -> None:
-    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as my_zip:
-        my_zip.write(file1, arcname=f"{pathlib.Path(file1).name}")
-        my_zip.write(file2, arcname=f"{pathlib.Path(file2).name}")
-
-
-def _cleanup_zip_dir(temp_dir: str) -> None:
-    shutil.rmtree(temp_dir, ignore_errors=True)
-
-
-async def _create_and_return_zip(
-    outputfile1: str, outputfile2: str, background_tasks: BackgroundTasks
-) -> FileResponse:
-    temp_dir = tempfile.mkdtemp()
-    zip_path = pathlib.Path(temp_dir) / "morph_archive.zip"
-    try:
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(
-            None,
-            _create_zip_file_sync,
-            str(zip_path),
-            outputfile1,
-            outputfile2,
-        )
-    except Exception as e:
-        L.error(f"Error creating zip file: {e!s}")
-        _cleanup_zip_dir(temp_dir)
-        raise HTTPException(
-            status_code=HTTPStatus.BAD_REQUEST,
-            detail={
-                "code": ApiErrorCode.INVALID_REQUEST,
-                "detail": f"Error creating zip file: {e!s}",
-            },
-        ) from e
-    else:
-        L.info(f"Created zip file: {zip_path}")
-        background_tasks.add_task(_cleanup_zip_dir, temp_dir)
-        return FileResponse(
-            path=str(zip_path), filename="morph_archive.zip", media_type="application/zip"
-        )
-
-
-async def _validate_and_read_file(file: UploadFile) -> tuple[bytes, str]:
-    L.info(f"Received file upload: {file.filename}")
-    allowed_extensions = {".swc", ".h5", ".asc"}
-    file_extension = f".{file.filename.split('.')[-1].lower()}" if file.filename else ""
-
-    if not file.filename or file_extension not in allowed_extensions:
-        L.error(f"Invalid file extension: {file_extension}")
-        valid_extensions = ", ".join(allowed_extensions)
-        raise HTTPException(
-            status_code=HTTPStatus.BAD_REQUEST,
-            detail={
-                "code": ApiErrorCode.INVALID_REQUEST,
-                "detail": f"Invalid file extension. Must be one of {valid_extensions}",
+                "detail": "Unrealistic soma diameter detected.",
             },
         )
-
-    content = await file.read()
-    if not content:
-        _handle_empty_file(file)
-
-    return content, file_extension
-
-
-def _validate_soma_diameter(file_path: str, threshold: float = 100.0) -> bool:
-    try:
-        m = neurom.load_morphology(file_path)
-        radius = m.soma.radius
-        if radius is None:
-            return False
-    except (NeuroMError, OSError, AttributeError) as e:
-        L.error(f"Error validating soma diameter for {file_path}: {e!s}")
-        return False
-    else:
-        if radius > 0:
-            return float(radius) <= threshold
-        return False
 
 
 @router.post(
     "/test-neuron-file",
-    summary="Validate morphology format and returns the conversion to other formats.",
-    description="Tests a neuron file (.swc, .h5, or .asc) with basic validation.",
+    summary="Validate a morphology and return the conversion to other formats.",
+    description=(
+        "Validate a morphology in a supported format (.swc, .h5, or .asc), "
+        "and return a zip file containing the morphology converted to the other formats."
+    ),
 )
-async def validate_neuron_file(
+def validate_neuron_file(
     file: Annotated[UploadFile, File(description="Neuron file to upload (.swc, .h5, or .asc)")],
-    background_tasks: BackgroundTasks,
+    temp_dir: TempDirDep,
     *,
     single_point_soma: Annotated[bool, Query(description="Convert soma to single point")] = False,
 ) -> FileResponse:
-    content, file_extension = await _validate_and_read_file(file)
+    input_morphology = file_service.save_upload_file(
+        upload_file=file,
+        output_dir=temp_dir,
+        output_stem="input",
+        allowed_extensions=ALLOWED_EXTENSIONS,
+        force_lower_case=True,
+    )
 
-    temp_file_path = ""
-    outputfile1, outputfile2 = "", ""
-    try:
-        with tempfile.NamedTemporaryFile(delete=False, suffix=file_extension) as temp_file:
-            temp_file.write(content)
-            temp_file_path = temp_file.name
+    _validate_soma_diameter(input_morphology)
 
-        if not _validate_soma_diameter(temp_file_path):
-            L.error(f"Unrealistic soma diameter detected in {file.filename}")
-            raise HTTPException(
-                status_code=HTTPStatus.BAD_REQUEST,
-                detail={
-                    "code": ApiErrorCode.INVALID_REQUEST,
-                    "detail": "Unrealistic soma diameter detected.",
-                },
-            )
+    if single_point_soma:
+        single_point_soma_by_ext = dict.fromkeys(DEFAULT_SINGLE_POINT_SOMA_BY_EXT, True)
+    else:
+        single_point_soma_by_ext = DEFAULT_SINGLE_POINT_SOMA_BY_EXT
 
-        if single_point_soma:
-            single_point_soma_by_ext = dict.fromkeys(DEFAULT_SINGLE_POINT_SOMA_BY_EXT, True)
-        else:
-            single_point_soma_by_ext = DEFAULT_SINGLE_POINT_SOMA_BY_EXT
+    morphology = morphology_service.convert_morphology(
+        input_file=input_morphology,
+        output_dir=input_morphology.parent,
+        single_point_soma_by_ext=single_point_soma_by_ext,
+    )
 
-        outputfile1, outputfile2 = await process_and_convert_morphology(
-            temp_file_path=temp_file_path,
-            file_extension=file_extension,
-            single_point_soma_by_ext=single_point_soma_by_ext,
-        )
+    zip_file = temp_dir / "morph_archive.zip"
+    file_service.create_zip_file(input_files=morphology, output_file=zip_file, delete_input=True)
 
-        return await _create_and_return_zip(outputfile1, outputfile2, background_tasks)
-
-    finally:
-        if temp_file_path:
-            try:
-                pathlib.Path(temp_file_path).unlink(missing_ok=True)
-                if outputfile1:
-                    pathlib.Path(outputfile1).unlink(missing_ok=True)
-                if outputfile2:
-                    pathlib.Path(outputfile2).unlink(missing_ok=True)
-            except OSError as e:
-                L.error(f"Error deleting temporary files: {e!s}")
+    return FileResponse(
+        path=zip_file,
+        filename=zip_file.name,
+        media_type="application/zip",
+    )

--- a/app/services/file.py
+++ b/app/services/file.py
@@ -1,0 +1,107 @@
+import shutil
+import zipfile
+from collections.abc import Iterable
+from http import HTTPStatus
+from pathlib import Path
+
+from fastapi import HTTPException, UploadFile
+
+from app.errors import ApiErrorCode
+
+MAX_FILE_SIZE = 128 * 1024 * 1024  # bytes
+
+
+def _validate_file_extension(
+    filename: str | None, *, allowed_extensions: set[str], force_lower_case: bool
+) -> str:
+    """Validate the file name and extension."""
+    if not filename:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail={
+                "code": ApiErrorCode.INVALID_REQUEST,
+                "detail": "No filename provided",
+            },
+        )
+
+    file_extension = Path(filename).suffix
+    if force_lower_case:
+        file_extension = file_extension.lower()
+
+    if file_extension not in allowed_extensions:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail={
+                "code": ApiErrorCode.INVALID_REQUEST,
+                "detail": f"Invalid file extension. Must be one of {', '.join(allowed_extensions)}",
+            },
+        )
+    return file_extension
+
+
+def _validate_file_size(size: float | None, max_file_size: float) -> None:
+    if not size or size <= 0:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail={
+                "code": ApiErrorCode.INVALID_REQUEST,
+                "detail": "File size is 0 or could not be determined.",
+            },
+        )
+    if size > max_file_size:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail={
+                "code": ApiErrorCode.INVALID_REQUEST,
+                "detail": f"File size exceeds the maximum size of {max_file_size / (1024**2)} MB",
+            },
+        )
+
+
+def save_upload_file(
+    upload_file: UploadFile,
+    output_dir: Path,
+    *,
+    output_stem: str,
+    allowed_extensions: set[str],
+    force_lower_case: bool,
+) -> Path:
+    """Validate the upload file and save it to the given directory.
+
+    Args:
+        upload_file: file uploaded by the user.
+        output_dir: directory where to save the file.
+        output_stem: stem of the output file (without extension).
+        allowed_extensions: set of allowed file extensions (e.g. {".swc", ".h5", ".asc"}).
+        force_lower_case: whether to convert the file extension to lower case before validating it.
+    """
+    _validate_file_size(
+        size=upload_file.size,
+        max_file_size=MAX_FILE_SIZE,
+    )
+    file_extension = _validate_file_extension(
+        filename=upload_file.filename,
+        allowed_extensions=allowed_extensions,
+        force_lower_case=force_lower_case,
+    )
+    output_file = output_dir / f"{output_stem}{file_extension}"
+
+    with output_file.open("wb") as f:
+        shutil.copyfileobj(upload_file.file, f)
+
+    return output_file
+
+
+def create_zip_file(input_files: Iterable[Path], output_file: Path, *, delete_input: bool) -> None:
+    """Create a zip file from the given input files, optionally deleting them once consumed.
+
+    Args:
+        input_files: iterable of files to include in the zip file.
+        output_file: path of the output zip file.
+        delete_input: whether to delete the input files after adding them to the zip file.
+    """
+    with zipfile.ZipFile(output_file, "w", zipfile.ZIP_DEFLATED) as zip_file:
+        for input_file in input_files:
+            zip_file.write(input_file, arcname=input_file.name)
+            if delete_input:
+                input_file.unlink()

--- a/app/services/morphology.py
+++ b/app/services/morphology.py
@@ -1,0 +1,81 @@
+import logging
+from collections.abc import Iterable
+from http import HTTPStatus
+from pathlib import Path
+
+import morph_tool
+import morphio
+import neurom
+from fastapi import HTTPException
+from morphio import RawDataError
+from neurom.exceptions import NeuroMError
+
+from app.errors import ApiErrorCode
+
+DEFAULT_SINGLE_POINT_SOMA_BY_EXT: dict[str, bool] = {
+    ".h5": False,
+    ".swc": True,
+    ".asc": False,
+}
+ALLOWED_EXTENSIONS = set(DEFAULT_SINGLE_POINT_SOMA_BY_EXT)
+SOMA_RADIUS_THRESHOLD = 100.0
+
+L = logging.getLogger(__name__)
+
+
+def validate_soma_diameter(file_path: Path, threshold: float = SOMA_RADIUS_THRESHOLD) -> bool:
+    """Validate the soma diameter of the given morphology."""
+    try:
+        m = neurom.load_morphology(file_path)
+        radius = m.soma.radius
+        return radius is not None and 0 < float(radius) <= threshold
+    except (NeuroMError, RawDataError, OSError, AttributeError) as e:
+        L.warning(f"Error validating soma diameter for {file_path}: {e!s}")
+        return False
+
+
+def convert_morphology(
+    input_file: Path,
+    *,
+    output_dir: Path,
+    single_point_soma_by_ext: dict[str, bool],
+    target_exts: Iterable[str] | None = None,
+    output_stem: str | None = None,
+) -> list[Path]:
+    """Convert a morphology to other formats.
+
+    Args:
+        input_file: input morphology.
+        output_dir: directory where to save the generated morphologies.
+        single_point_soma_by_ext: map the extensions to single_point_soma (bool).
+        target_exts: iterable of formats to generate, given as extensions (e.g. [".h5", ".asc"]).
+            If None, generate all the formats different from the original.
+        output_stem: stem of the output files. If None, use the same as the input file.
+    """
+    try:
+        morphio.set_raise_warnings(False)
+        morphio.Morphology(input_file)
+
+        file_extension = input_file.suffix
+        output_stem = output_stem or input_file.stem
+        target_exts = target_exts or ALLOWED_EXTENSIONS - {file_extension}
+        output_files = []
+        for ext in target_exts:
+            output_file = output_dir / f"{output_stem}{ext}"
+            single_point_soma = single_point_soma_by_ext.get(ext, False)
+            morph_tool.convert(
+                input_file=str(input_file),
+                output_file=str(output_file),
+                single_point_soma=single_point_soma,
+            )
+            output_files.append(output_file)
+
+    except Exception as e:
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail={
+                "code": ApiErrorCode.INVALID_REQUEST,
+                "detail": f"Failed to load and convert the file: {e!s}",
+            },
+        ) from e
+    return output_files

--- a/tests/routers/declared/test_morphology_validation.py
+++ b/tests/routers/declared/test_morphology_validation.py
@@ -1,0 +1,112 @@
+import zipfile
+from http import HTTPStatus
+from io import BytesIO
+
+import pytest
+
+from app.errors import ApiErrorCode
+
+from tests.utils import DATA_DIR
+
+ROUTE = "/declared/test-neuron-file"
+
+
+def get_error_code(response_json: dict) -> str:
+    if isinstance(response_json.get("detail"), dict):
+        return response_json["detail"].get("code")
+    return response_json.get("code")
+
+
+def get_error_detail(response_json: dict) -> str:
+    if isinstance(response_json.get("detail"), dict):
+        return response_json["detail"].get("detail")
+    return response_json.get("detail")
+
+
+@pytest.fixture
+def morphology_swc():
+    return (DATA_DIR / "cell_morphology.swc").read_bytes()
+
+
+@pytest.fixture
+def morphology_asc():
+    return (DATA_DIR / "cell_morphology.asc").read_bytes()
+
+
+def test_validate_neuron_file_success(client, morphology_swc):
+    files = {"file": ("neuron.swc", BytesIO(morphology_swc), "application/octet-stream")}
+    response = client.post(ROUTE, files=files)
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.headers["content-type"] == "application/zip"
+
+    # Verify zip contains converted files
+    with zipfile.ZipFile(BytesIO(response.content)) as zf:
+        names = zf.namelist()
+        assert "input.h5" in names
+        assert "input.asc" in names
+
+
+def test_validate_neuron_file_with_single_point_soma(client, morphology_swc):
+    files = {"file": ("neuron.swc", BytesIO(morphology_swc), "application/octet-stream")}
+    response = client.post(ROUTE, files=files, params={"single_point_soma": True})
+
+    assert response.status_code == HTTPStatus.OK
+    with zipfile.ZipFile(BytesIO(response.content)) as zf:
+        assert len(zf.namelist()) == 2
+
+
+def test_validate_neuron_file_invalid_extension(client):
+    files = {"file": ("neuron.txt", BytesIO(b"data"), "text/plain")}
+    response = client.post(ROUTE, files=files)
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert get_error_code(response.json()) == ApiErrorCode.INVALID_REQUEST
+    assert "Invalid file extension" in get_error_detail(response.json())
+
+
+def test_validate_neuron_file_missing_extension(client):
+    files = {"file": ("neuron", BytesIO(b"data"), "text/plain")}
+    response = client.post(ROUTE, files=files)
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert get_error_code(response.json()) == ApiErrorCode.INVALID_REQUEST
+    assert "Invalid file extension" in get_error_detail(response.json())
+
+
+def test_validate_neuron_file_invalid_soma_diameter(client):
+    # Create SWC with unrealistic soma radius (>100)
+    swc_content = b"1 1 0 0 0 150 -1\n"
+    files = {"file": ("bad.swc", BytesIO(swc_content), "application/octet-stream")}
+    response = client.post(ROUTE, files=files)
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert get_error_code(response.json()) == ApiErrorCode.INVALID_REQUEST
+    assert "Unrealistic soma diameter" in get_error_detail(response.json())
+
+
+def test_validate_neuron_file_invalid_morphology(client):
+    # Invalid SWC content
+    files = {"file": ("invalid.swc", BytesIO(b"invalid data"), "application/octet-stream")}
+    response = client.post(ROUTE, files=files)
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_validate_neuron_file_asc_format(client, morphology_asc):
+    files = {"file": ("neuron.asc", BytesIO(morphology_asc), "application/octet-stream")}
+    response = client.post(ROUTE, files=files)
+
+    assert response.status_code == HTTPStatus.OK
+    with zipfile.ZipFile(BytesIO(response.content)) as zf:
+        names = zf.namelist()
+        assert "input.swc" in names
+        assert "input.h5" in names
+
+
+def test_validate_neuron_file_empty_file(client):
+    files = {"file": ("empty.swc", BytesIO(b""), "application/octet-stream")}
+    response = client.post(ROUTE, files=files)
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert "File size is 0" in get_error_detail(response.json())


### PR DESCRIPTION
Main changes:
- convert the async endpoint to sync so it's executed in the fastapi thread pool, since most of the logic is blocking and was executed in threads anyway
- move the morphology and file logic to a separate file so it can be reused
- simplify the cleanup of the temp directory

Note:
the endpoint is called `test-neuron-file`, but I wonder if it should be changed to something different, since this endpoint is not just validation but also conversion to other formats.
