### PR TITLE
remove neuron set reference for IC and MEModel simulations

### DIFF
--- a/obi_one/scientific/tasks/generate_simulations/config/ion_channel_models.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/ion_channel_models.py
@@ -17,7 +17,6 @@ from obi_one.scientific.library.entity_property_types import (
 )
 from obi_one.scientific.library.ion_channel_model_circuit import CircuitFromIonChannelModels
 from obi_one.scientific.tasks.generate_simulations.config.base import (
-    DEFAULT_NODE_SET_NAME,
     DEFAULT_TIMESTAMPS_NAME,
     BlockGroup,
     SimulationScanConfig,
@@ -26,9 +25,6 @@ from obi_one.scientific.tasks.generate_simulations.config.base import (
 from obi_one.scientific.unions.unions_ion_channel_model import (
     IonChannelModelReference,
     IonChannelModelUnion,
-)
-from obi_one.scientific.unions.unions_neuron_sets import (
-    NeuronSetReference,
 )
 from obi_one.scientific.unions.unions_recordings import (
     IonChannelModelRecordingUnion,
@@ -61,7 +57,6 @@ class IonChannelModelSimulationScanConfig(SimulationScanConfig):
             BlockGroup.EVENTS_GROUP,
         ],
         "default_block_reference_labels": {
-            NeuronSetReference.__name__: DEFAULT_NODE_SET_NAME,
             TimestampsReference.__name__: DEFAULT_TIMESTAMPS_NAME,
         },
         "property_endpoints": {

--- a/obi_one/scientific/tasks/generate_simulations/config/me_model.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/me_model.py
@@ -7,14 +7,10 @@ from obi_one.core.single import SingleConfigMixin
 from obi_one.scientific.from_id.memodel_from_id import MEModelFromID
 from obi_one.scientific.library.memodel_circuit import MEModelCircuit
 from obi_one.scientific.tasks.generate_simulations.config.base import (
-    DEFAULT_NODE_SET_NAME,
     DEFAULT_TIMESTAMPS_NAME,
     BlockGroup,
     SimulationScanConfig,
     SimulationSingleConfigMixin,
-)
-from obi_one.scientific.unions.unions_neuron_sets import (
-    NeuronSetReference,
 )
 from obi_one.scientific.unions.unions_neuronal_manipulations import (
     NeuronalManipulationReference,
@@ -93,7 +89,6 @@ class MEModelSimulationScanConfig(SimulationScanConfig):
             BlockGroup.EVENTS_GROUP,
         ],
         "default_block_reference_labels": {
-            NeuronSetReference.__name__: DEFAULT_NODE_SET_NAME,
             TimestampsReference.__name__: DEFAULT_TIMESTAMPS_NAME,
         },
     }


### PR DESCRIPTION
Ion Channel and MEModel simulations should not reference any neuron sets, since they only simulate one neuron