### PR TITLE
Introduce generic configs

### DIFF
--- a/app/mappings.py
+++ b/app/mappings.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from entitysdk import models
+from entitysdk.types import TaskActivityType, TaskConfigType
 from obp_accounting_sdk.constants import ServiceSubtype
 
 from app.config import settings
@@ -11,6 +12,7 @@ from app.schemas.task import (
     MachineResources,
     PythonRepositoryCode,
     TaskDefinition,
+    TaskDefinitionLegacy,
 )
 from app.types import BuiltinScript, TaskType
 
@@ -22,8 +24,8 @@ OBI_ONE_DEPS_DIR = Path(settings.OBI_ONE_LAUNCH_PATH) / "dependencies"
 TASK_DEFINITIONS: dict[TaskType, TaskDefinition] = {
     TaskType.circuit_extraction: TaskDefinition(
         task_type=TaskType.circuit_extraction,
-        config_type=models.CircuitExtractionConfig,
-        activity_type=models.CircuitExtractionExecution,
+        config_type=TaskConfigType.circuit_extraction__config,
+        activity_type=TaskActivityType.circuit_extraction__execution,
         accounting_service_subtype=ServiceSubtype.SMALL_CIRCUIT_SIM,
         code=PythonRepositoryCode(
             location=settings.OBI_ONE_REPO,
@@ -40,8 +42,8 @@ TASK_DEFINITIONS: dict[TaskType, TaskDefinition] = {
     ),
     TaskType.morphology_skeletonization: TaskDefinition(
         task_type=TaskType.morphology_skeletonization,
-        config_type=models.SkeletonizationConfig,
-        activity_type=models.SkeletonizationExecution,
+        config_type=TaskConfigType.skeletonization__config,
+        activity_type=TaskActivityType.skeletonization__execution,
         accounting_service_subtype=ServiceSubtype.NEURON_MESH_SKELETONIZATION,
         code=PythonRepositoryCode(
             location=settings.OBI_ONE_REPO,
@@ -57,7 +59,7 @@ TASK_DEFINITIONS: dict[TaskType, TaskDefinition] = {
             compute_cell="local",
         ),
     ),
-    TaskType.circuit_simulation: TaskDefinition(
+    TaskType.circuit_simulation: TaskDefinitionLegacy(
         task_type=TaskType.circuit_simulation,
         config_type=models.Simulation,
         activity_type=models.SimulationExecution,
@@ -72,7 +74,7 @@ TASK_DEFINITIONS: dict[TaskType, TaskDefinition] = {
             compute_cell="local",
         ),
     ),
-    TaskType.ion_channel_model_simulation_execution: TaskDefinition(
+    TaskType.ion_channel_model_simulation_execution: TaskDefinitionLegacy(
         task_type=TaskType.ion_channel_model_simulation_execution,
         config_type=models.Simulation,
         activity_type=models.SimulationExecution,

--- a/app/schemas/task.py
+++ b/app/schemas/task.py
@@ -103,12 +103,12 @@ class TaskDefinition(Schema):
     @property
     def config_type_name(self) -> str:
         """Return the name of the config class."""
-        return self.config_type.__name__
+        return self.config_type
 
     @property
     def activity_type_name(self) -> str:
         """Return the name of the activity class."""
-        return self.activity_type.__name__
+        return self.activity_type
 
 
 class TaskDefinitionLegacy(Schema):

--- a/app/schemas/task.py
+++ b/app/schemas/task.py
@@ -2,6 +2,7 @@ from typing import Annotated, Literal
 from uuid import UUID
 
 from entitysdk.models.activity import Activity, Entity
+from entitysdk.types import TaskActivityType, TaskConfigType
 from obp_accounting_sdk.constants import ServiceSubtype
 from pydantic import Field
 
@@ -90,6 +91,27 @@ class TaskAccountingInfo(TaskAccountingCreate):
 
 
 class TaskDefinition(Schema):
+    """Definition of a task type with its associated models and configuration."""
+
+    task_type: TaskType
+    config_type: TaskConfigType
+    activity_type: TaskActivityType
+    accounting_service_subtype: ServiceSubtype
+    code: Code
+    resources: Resources
+
+    @property
+    def config_type_name(self) -> str:
+        """Return the name of the config class."""
+        return self.config_type.__name__
+
+    @property
+    def activity_type_name(self) -> str:
+        """Return the name of the activity class."""
+        return self.activity_type.__name__
+
+
+class TaskDefinitionLegacy(Schema):
     """Definition of a task type with its associated models and configuration."""
 
     task_type: TaskType

--- a/app/services/task.py
+++ b/app/services/task.py
@@ -26,6 +26,7 @@ def submit_task_job(
     compute_cell: str,
 ) -> TaskLaunchInfo:
     """Creates an activity and submits a task as a job on the launch-system."""
+    # TODO: Remove once simulations are migrated to generic configs
     if isinstance(task_definition, TaskDefinitionLegacy):
         config_type = task_definition.config_type
         config = db_client.get_entity(entity_id=config_id, entity_type=config_type)

--- a/app/services/task.py
+++ b/app/services/task.py
@@ -26,29 +26,26 @@ def submit_task_job(
     compute_cell: str,
 ) -> TaskLaunchInfo:
     """Creates an activity and submits a task as a job on the launch-system."""
-    match task_definition:
-        case TaskDefinition():
-            config = db_client.get_entity(
-                entity_id=config_id,
-                entity_type=models.TaskConfig,
-            )
-            activity_id = db_sdk.create_generic_activity(
-                client=db_client,
-                used=[config],
-                activity_status=ActivityStatus.pending,
-                activity_type=task_definition.task_activity_type,
-            ).id
-        case TaskDefinitionLegacy():
-            config = db_client.get_entity(
-                entity_id=config_id,
-                entity_type=task_definition.config_type,
-            )
-            activity_id = db_sdk.create_activity(
-                client=db_client,
-                used=[config],
-                activity_status=ActivityStatus.pending,
-                activity_type=task_definition.activity_type,
-            ).id
+    if isinstance(task_definition, TaskDefinitionLegacy):
+        config_type = task_definition.config_type
+        config = db_client.get_entity(entity_id=config_id, entity_type=config_type)
+        activity_type = task_definition.activity_type
+        activity_id = db_sdk.create_activity(
+            client=db_client,
+            used=[config],
+            activity_status=ActivityStatus.pending,
+            activity_type=activity_type,
+        ).id
+    else:
+        config_type = models.TaskConfig
+        config = db_client.get_entity(entity_id=config_id, entity_type=config_type)
+        activity_type = models.TaskActivity
+        activity_id = db_sdk.create_generic_activity(
+            client=db_client,
+            used=[config],
+            activity_status=ActivityStatus.pending,
+            activity_type=task_definition.activity_type,
+        ).id
 
     failure_callback = _generate_failure_callback(
         activity_id=activity_id,
@@ -87,8 +84,8 @@ def submit_task_job(
         db_sdk.update_activity_status(
             client=db_client,
             activity_id=activity_id,
-            activity_type=task_definition.activity_type,
-            status="error",
+            activity_type=activity_type,
+            status=ActivityStatus.error,
         )
         msg = f"Job submission failed!\n{json.loads(response.text)}"
         raise RuntimeError(msg)
@@ -99,7 +96,7 @@ def submit_task_job(
     db_sdk.update_activity_executor(
         client=db_client,
         activity_id=activity_id,
-        activity_type=task_definition.activity_type,
+        activity_type=activity_type,
         execution_id=job_id,
         executor=ExecutorType.single_node_job,
     )
@@ -200,14 +197,20 @@ def handle_task_failure_callback(
     db_client: entitysdk.Client,
     task_definition: TaskDefinition,
 ) -> None:
+    # TODO: Remove once simulations are migrated to generic configs
+    if isinstance(task_definition, TaskDefinitionLegacy):
+        task_activity_type = task_definition.activity_type
+    else:
+        task_activity_type = models.TaskActivity
+
     current_status = db_client.get_entity(
-        entity_id=activity_id,
-        entity_type=task_definition.activity_type,
+        entity_id=activity_id, entity_type=task_activity_type
     ).status
 
     if current_status != ActivityStatus.done:
-        db_client.update_entity(
-            entity_id=activity_id,
-            entity_type=task_definition.activity_type,
-            attrs_or_entity={"status": ActivityStatus.error},
+        db_sdk.update_activity_status(
+            client=db_client,
+            activity_id=activity_id,
+            activity_type=task_activity_type,
+            status=ActivityStatus.error,
         )

--- a/app/services/task.py
+++ b/app/services/task.py
@@ -43,7 +43,7 @@ def submit_task_job(
                 entity_id=config_id,
                 entity_type=task_definition.config_type,
             )
-            activity_id = db_sdk.create_generic_activity(
+            activity_id = db_sdk.create_activity(
                 client=db_client,
                 used=[config],
                 activity_status=ActivityStatus.pending,

--- a/app/services/task.py
+++ b/app/services/task.py
@@ -3,13 +3,13 @@ from uuid import UUID
 
 import entitysdk
 import httpx
-from entitysdk import ProjectContext
+from entitysdk import ProjectContext, models
 from entitysdk.types import ActivityStatus, ExecutorType
 
 from app.config import settings
 from app.logger import L
 from app.schemas.callback import CallBack, HttpRequestCallBackConfig
-from app.schemas.task import TaskDefinition, TaskLaunchInfo
+from app.schemas.task import TaskDefinition, TaskDefinitionLegacy, TaskLaunchInfo
 from app.types import CallBackAction, CallBackEvent, TaskType
 from obi_one.utils import db_sdk
 
@@ -26,16 +26,30 @@ def submit_task_job(
     compute_cell: str,
 ) -> TaskLaunchInfo:
     """Creates an activity and submits a task as a job on the launch-system."""
-    config = db_client.get_entity(
-        entity_id=config_id,
-        entity_type=task_definition.config_type,
-    )
-    activity_id = db_sdk.create_activity(
-        client=db_client,
-        used=[config],
-        activity_status=ActivityStatus.pending,
-        activity_type=task_definition.activity_type,
-    ).id
+    match task_definition:
+        case TaskDefinition():
+            config = db_client.get_entity(
+                entity_id=config_id,
+                entity_type=models.TaskConfig,
+            )
+            activity_id = db_sdk.create_generic_activity(
+                client=db_client,
+                used=[config],
+                activity_status=ActivityStatus.pending,
+                activity_type=task_definition.task_activity_type,
+            ).id
+        case TaskDefinitionLegacy():
+            config = db_client.get_entity(
+                entity_id=config_id,
+                entity_type=task_definition.config_type,
+            )
+            activity_id = db_sdk.create_generic_activity(
+                client=db_client,
+                used=[config],
+                activity_status=ActivityStatus.pending,
+                activity_type=task_definition.activity_type,
+            ).id
+
     failure_callback = _generate_failure_callback(
         activity_id=activity_id,
         task_type=task_definition.task_type,

--- a/launch_scripts/launch_task_for_single_config_asset/code.py
+++ b/launch_scripts/launch_task_for_single_config_asset/code.py
@@ -10,26 +10,9 @@ from entitysdk.token_manager import TokenFromFunction
 from obi_auth import get_token
 
 from obi_one.core.run_tasks import run_task_type
+from obi_one.utils.db_sdk import update_activity_status
 
 L = logging.getLogger(__name__)
-
-
-def update_activity_status(
-    db_client: Client, execution_activity_type: str, execution_activity_id: str, status: ActivityStatus
-) -> None:
-    if not db_client:
-        return
-    if not execution_activity_id:
-        L.warning("Status update not possible since no execution activity provided!")
-        return
-
-    execution_activity_type_resolved = getattr(models, execution_activity_type)
-    status_dict = {"status": status}
-    db_client.update_entity(
-        entity_type=execution_activity_type_resolved,
-        entity_id=execution_activity_id,
-        attrs_or_entity=status_dict,
-    )
 
 
 def main() -> int:
@@ -99,7 +82,13 @@ def main() -> int:
 
     try:
         # Get entity type
-        config_entity_type = getattr(models, args.config_entity_type)
+        # TODO: Remove once legacy tasks are moved to generic configs/activities
+        if args.config_entity_type in TaskConfigType:
+            config_entity_type = TaskConfigType
+            execution_activity_type = TaskActivityType
+        else:
+            config_entity_type = getattr(models, args.config_entity_type)
+            execution_activity_type = getattr(models, args.execution_activity_type)
 
         # Get DB client (incl. file mounting)
         token_manager = TokenFromFunction(
@@ -120,9 +109,9 @@ def main() -> int:
             local_store=LocalAssetStore(prefix=local_store_prefix),
         )
         update_activity_status(
-            db_client=db_client,
-            execution_activity_type=args.execution_activity_type,
-            execution_activity_id=args.execution_activity_id,
+            client=db_client,
+            activity_id=args.execution_activity_id,
+            activity_type=execution_activity_type,
             status=ActivityStatus.running,
         )
         run_task_type(
@@ -138,17 +127,17 @@ def main() -> int:
         # Catch any error that may occur to make sure that error status is correctly set
         L.exception(f"Error launching task for single configuration asset: {e}")
         update_activity_status(
-            db_client=db_client,
-            execution_activity_type=args.execution_activity_type,
-            execution_activity_id=args.execution_activity_id,
+            client=db_client,
+            activity_id=args.execution_activity_id,
+            activity_type=execution_activity_type,
             status=ActivityStatus.error,
         )
         return 1
 
     update_activity_status(
-        db_client=db_client,
-        execution_activity_type=args.execution_activity_type,
-        execution_activity_id=args.execution_activity_id,
+        client=db_client,
+        activity_id=args.execution_activity_id,
+        activity_type=execution_activity_type,
         status=ActivityStatus.done,
     )
 

--- a/launch_scripts/launch_task_for_single_config_asset/code.py
+++ b/launch_scripts/launch_task_for_single_config_asset/code.py
@@ -81,11 +81,10 @@ def main() -> int:
         return 1
 
     try:
-        # Get entity type
         # TODO: Remove once legacy tasks are moved to generic configs/activities
         if args.config_entity_type in TaskConfigType:
-            config_entity_type = TaskConfigType
-            execution_activity_type = TaskActivityType
+            config_entity_type = models.TaskConfig
+            execution_activity_type = models.TaskActivity
         else:
             config_entity_type = getattr(models, args.config_entity_type)
             execution_activity_type = getattr(models, args.execution_activity_type)

--- a/obi_one/utils/db_sdk.py
+++ b/obi_one/utils/db_sdk.py
@@ -3,10 +3,10 @@ from datetime import UTC, datetime
 from uuid import UUID
 
 from entitysdk import Client
-from entitysdk.models import Entity
+from entitysdk.models import Entity, TaskActivity
 from entitysdk.models.activity import Activity
 from entitysdk.models.asset import Asset
-from entitysdk.types import AssetLabel, ExecutorType
+from entitysdk.types import ActivityStatus, AssetLabel, ExecutorType, TaskActivityType
 
 L = logging.getLogger(__name__)
 
@@ -20,7 +20,7 @@ def create_activity(
     *,
     client: Client,
     activity_type: type[Activity],
-    activity_status: str = "created",  # TODO: Use ActivityStatus when available
+    activity_status: ActivityStatus = ActivityStatus.created,
     used: list[Entity],
 ) -> Activity:
     """Creates and registers an activity of the given type."""
@@ -35,12 +35,30 @@ def create_activity(
     return activity
 
 
+def create_generic_activity(
+    *,
+    client: Client,
+    activity_type: TaskActivityType,
+    used: list[Entity],
+    activity_status: ActivityStatus = ActivityStatus.created,
+) -> TaskActivity:
+    activity = TaskActivity(
+        start_time=datetime.now(UTC),
+        used=used,
+        status=activity_status,
+        task_activity_type=activity_type,
+    )
+    activity = client.register_entity(activity)
+    L.info(f"Task activity {activity.id} of type '{activity_type.__name__}' created")
+    return activity
+
+
 def update_activity_status(
     *,
     client: Client,
     activity_id: UUID,
     activity_type: type[Activity],
-    status: str,
+    status: ActivityStatus,
 ) -> Activity:
     """Updates the activity by setting a new status."""
     return client.update_entity(

--- a/obi_one/utils/db_sdk.py
+++ b/obi_one/utils/db_sdk.py
@@ -49,7 +49,7 @@ def create_generic_activity(
         task_activity_type=activity_type,
     )
     activity = client.register_entity(activity)
-    L.info(f"Task activity {activity.id} of type '{activity_type.__name__}' created")
+    L.info(f"TaskActivity ({activity_type}) {activity.id} is created")
     return activity
 
 

--- a/tests/app/services/test_task.py
+++ b/tests/app/services/test_task.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 import entitysdk
 import httpx
 import pytest
-from entitysdk.types import AssetLabel
+from entitysdk.types import AssetLabel, TaskActivityType, TaskConfigType
 
 from app.mappings import TASK_DEFINITIONS
 from app.schemas.callback import CallBack, CallBackAction, CallBackEvent, HttpRequestCallBackConfig
@@ -63,14 +63,16 @@ def callbacks(activity_id):
 
 
 @pytest.mark.parametrize(
-    ("task_type", "config_route", "config_response", "activity_route"),
+    ("task_type", "config_route", "config_response", "activity_route", "activity_response"),
     [
         (
             TaskType.circuit_extraction,
-            "circuit-extraction-config",
+            "task-config",
             {
                 "circuit_id": str(uuid4()),
                 "scan_parameters": {},
+                "task_config_type": TaskConfigType.circuit_extraction__config,
+                "meta": {},
                 "assets": [
                     {
                         "id": str(ASSET_ID),
@@ -84,7 +86,10 @@ def callbacks(activity_id):
                     },
                 ],
             },
-            "circuit-extraction-execution",
+            "task-activity",
+            {
+                "task_activity_type": TaskActivityType.circuit_extraction__execution,
+            },
         ),
         (
             TaskType.circuit_simulation,
@@ -95,6 +100,7 @@ def callbacks(activity_id):
                 "scan_parameters": {},
             },
             "simulation-execution",
+            {},
         ),
     ],
 )
@@ -103,6 +109,7 @@ def test_submit_task_job__success(
     config_route,
     config_response,
     activity_route,
+    activity_response,
     db_client,
     ls_client,
     project_context,
@@ -121,7 +128,7 @@ def test_submit_task_job__success(
     httpx_mock.add_callback(
         lambda request: httpx.Response(
             status_code=200,
-            json=json.loads(request.content) | {"id": str(activity_id)},
+            json=json.loads(request.content) | activity_response | {"id": str(activity_id)},
         ),
         url=f"http://my-url/{activity_route}",
         method="POST",
@@ -142,6 +149,7 @@ def test_submit_task_job__success(
                 "start_time": datetime.now(UTC).isoformat(),
                 "status": "pending",
             }
+            | activity_response
             | json.loads(request.content),
         ),
         url=f"http://my-url/{activity_route}/{activity_id}",
@@ -164,11 +172,11 @@ def test_submit_task_job__success(
 
 
 @pytest.mark.parametrize(
-    ("task_type", "config_route", "config_response", "activity_route"),
+    ("task_type", "config_route", "config_response", "activity_route", "activity_response"),
     [
         (
             TaskType.circuit_extraction,
-            "circuit-extraction-config",
+            "task-config",
             {
                 "circuit_id": str(uuid4()),
                 "scan_parameters": {},
@@ -184,8 +192,13 @@ def test_submit_task_job__success(
                         "content_type": "application/json",
                     },
                 ],
+                "task_config_type": TaskConfigType.circuit_extraction__config,
+                "meta": {},
             },
-            "circuit-extraction-execution",
+            "task-activity",
+            {
+                "task_activity_type": TaskActivityType.circuit_extraction__execution,
+            },
         ),
         (
             TaskType.circuit_simulation,
@@ -196,6 +209,7 @@ def test_submit_task_job__success(
                 "scan_parameters": {},
             },
             "simulation-execution",
+            {},
         ),
     ],
 )
@@ -204,6 +218,7 @@ def test_submit_task_job__failure(
     config_route,
     config_response,
     activity_route,
+    activity_response,
     db_client,
     ls_client,
     project_context,
@@ -221,7 +236,7 @@ def test_submit_task_job__failure(
     httpx_mock.add_callback(
         lambda request: httpx.Response(
             status_code=200,
-            json=json.loads(request.content) | {"id": str(activity_id)},
+            json=json.loads(request.content) | activity_response | {"id": str(activity_id)},
         ),
         url=f"http://my-url/{activity_route}",
         method="POST",
@@ -242,6 +257,7 @@ def test_submit_task_job__failure(
                 "start_time": datetime.now(UTC).isoformat(),
                 "status": "pending",
             }
+            | activity_response
             | json.loads(request.content),
         ),
         url=f"http://my-url/{activity_route}/{activity_id}",
@@ -351,13 +367,13 @@ def test_generic_job_data(config_id, activity_id, callbacks):
         },
         "inputs": [
             "--task-type circuit_extraction",
-            "--config_entity_type CircuitExtractionConfig",
+            "--config_entity_type circuit_extraction__config",
             f"--config_entity_id {config_id}",
             "--entity_cache True",
             "--scan_output_root /foo",
             f"--virtual_lab_id {VIRTUAL_LAB_ID}",
             f"--project_id {PROJECT_ID}",
-            "--execution_activity_type CircuitExtractionExecution",
+            "--execution_activity_type circuit_extraction__execution",
             f"--execution_activity_id {activity_id}",
         ],
         "project_id": PROJECT_ID,
@@ -399,13 +415,19 @@ def test_generate_failure_callback(project_context, activity_id):
 
 
 @pytest.mark.parametrize(
-    ("task_type", "activity_route"),
+    ("task_type", "activity_route", "activity_response"),
     [
-        (TaskType.circuit_extraction, "circuit-extraction-execution"),
-        (TaskType.circuit_simulation, "simulation-execution"),
+        (
+            TaskType.circuit_extraction,
+            "task-activity",
+            {"task_activity_type": TaskActivityType.circuit_extraction__execution},
+        ),
+        (TaskType.circuit_simulation, "simulation-execution", {}),
     ],
 )
-def test_handle_task_failure_callback(db_client, task_type, activity_route, httpx_mock):
+def test_handle_task_failure_callback(
+    db_client, task_type, activity_route, activity_response, httpx_mock
+):
     activity_id = uuid4()
     activity_payload = {
         "id": str(activity_id),
@@ -415,12 +437,12 @@ def test_handle_task_failure_callback(db_client, task_type, activity_route, http
     httpx_mock.add_response(
         url=f"http://my-url/{activity_route}/{activity_id}",
         method="GET",
-        json=activity_payload,
+        json=activity_payload | activity_response,
     )
     httpx_mock.add_callback(
         lambda request: httpx.Response(
             status_code=200,
-            json=activity_payload | json.loads(request.content),
+            json=activity_payload | activity_response | json.loads(request.content),
         ),
         url=f"http://my-url/{activity_route}/{activity_id}",
         method="PATCH",
@@ -433,13 +455,19 @@ def test_handle_task_failure_callback(db_client, task_type, activity_route, http
 
 
 @pytest.mark.parametrize(
-    ("task_type", "activity_route"),
+    ("task_type", "activity_route", "activity_response"),
     [
-        (TaskType.circuit_extraction, "circuit-extraction-execution"),
-        (TaskType.circuit_simulation, "simulation-execution"),
+        (
+            TaskType.circuit_extraction,
+            "task-activity",
+            {"task_activity_type": TaskActivityType.circuit_extraction__execution},
+        ),
+        (TaskType.circuit_simulation, "simulation-execution", {}),
     ],
 )
-def test_handle_task_failure_callback__do_nothing(db_client, task_type, activity_route, httpx_mock):
+def test_handle_task_failure_callback__do_nothing(
+    db_client, task_type, activity_route, activity_response, httpx_mock
+):
     activity_id = uuid4()
 
     activity_payload = {
@@ -450,7 +478,7 @@ def test_handle_task_failure_callback__do_nothing(db_client, task_type, activity
     httpx_mock.add_response(
         url=f"http://my-url/{activity_route}/{activity_id}",
         method="GET",
-        json=activity_payload,
+        json=activity_payload | activity_response,
     )
     test_module.handle_task_failure_callback(
         activity_id=activity_id,

--- a/tests/obi_one/utils/test_db_sdk.py
+++ b/tests/obi_one/utils/test_db_sdk.py
@@ -7,7 +7,7 @@ import entitysdk
 import httpx
 import pytest
 from entitysdk.models import Asset, Entity, SimulationExecution
-from entitysdk.types import AssetLabel, ExecutorType
+from entitysdk.types import AssetLabel, ExecutorType, TaskActivityType
 
 from obi_one.utils import db_sdk as test_module
 
@@ -69,6 +69,30 @@ def test_create_activity(client, mock_entity, httpx_mock):
     result = test_module.create_activity(
         client=client,
         activity_type=SimulationExecution,
+        activity_status=activity_status,
+        used=[mock_entity],
+    )
+    assert result.status == activity_status
+
+
+def test_create_generic_activity(client, mock_entity, httpx_mock):
+    """Test successful activity creation."""
+    activity_status = "pending"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        """Return the request payload plus an id."""
+        payload = json.loads(request.content)
+        return httpx.Response(status_code=200, json=payload | {"id": str(uuid4())})
+
+    httpx_mock.add_callback(
+        handler,
+        url="http://my-url/task-activity",
+        method="POST",
+    )
+
+    result = test_module.create_generic_activity(
+        client=client,
+        activity_type=TaskActivityType.circuit_extraction__execution,
         activity_status=activity_status,
         used=[mock_entity],
     )


### PR DESCRIPTION
* Add generic configs for the task endpoints
* Do not adapt simulation tasks because they require a migration first

See https://github.com/openbraininstitute/prod-build-circuit/issues/23