### PR TITLE
Relax search for cell morphology protocol in skeletonization task

### DIFF
--- a/obi_one/scientific/tasks/skeletonization/registration.py
+++ b/obi_one/scientific/tasks/skeletonization/registration.py
@@ -49,10 +49,14 @@ def register_output_resource(
     protocol = None
     dset = metadata.em_dense_reconstruction_dataset
 
+    # in case of duplicates take the first in ascending order
     protocol = client.search_entity(
         entity_type=models.CellMorphologyProtocol,
-        query={"name": metadata.cell_morphology_protocol_name},
-    ).one_or_none()
+        query={
+            "name": metadata.cell_morphology_protocol_name,
+            "order_by": "+creation_date",
+        },
+    ).first()
     if not protocol:
         msg = f"Creating cell morphology protocol: {metadata.cell_morphology_protocol_name}"
         L.debug(msg)

--- a/tests/obi_one/scientific/tasks/skeletonization/test_skeletonization.py
+++ b/tests/obi_one/scientific/tasks/skeletonization/test_skeletonization.py
@@ -347,7 +347,7 @@ def test_register_output_resource_creates_protocol_when_missing(
         json={"data": [license_json], "pagination": PAGINATION},
     )
     httpx_mock.add_response(
-        url=f"{API_URL}/cell-morphology-protocol?name=Ultraliser+skeletonization&page=1",
+        url=f"{API_URL}/cell-morphology-protocol?name=Ultraliser+skeletonization&order_by=%2Bcreation_date&page=1",
         method="GET",
         json={"data": [], "pagination": PAGINATION},
     )
@@ -416,7 +416,7 @@ def test_register_output_resource_reuses_existing_protocol(
         json={"data": [license_json], "pagination": PAGINATION},
     )
     httpx_mock.add_response(
-        url=f"{API_URL}/cell-morphology-protocol?name=Ultraliser+skeletonization&page=1",
+        url=f"{API_URL}/cell-morphology-protocol?name=Ultraliser+skeletonization&order_by=%2Bcreation_date&page=1",
         method="GET",
         json={"data": [protocol_json], "pagination": PAGINATION},
     )


### PR DESCRIPTION
Relax assumption that cell morphology protocols are unique. Instead, fetch the first created protocol with that name and assume the rest are duplicates.