### PR TITLE
Make spike_location for sim configs from `AIS` to `soma`

### DIFF
--- a/obi_one/scientific/tasks/generate_simulations/config/base.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/base.py
@@ -176,7 +176,7 @@ class SimulationScanConfig(InfoScanConfig, abc.ABC):
         )
 
         _spike_location: Literal["AIS", "soma"] | list[Literal["AIS", "soma"]] = PrivateAttr(
-            default="AIS"
+            default="soma"
         )
         _timestep: list[PositiveFloat] | PositiveFloat = PrivateAttr(
             default=_SIMULATION_TIMESTEP_MILLISECONDS

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_simulation_campaign_generation.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_simulation_campaign_generation.py
@@ -137,7 +137,7 @@ def _check_generated_sonata_configs(tmp_path, scan):
         assert cfg.pop("conditions") == {
             "extracellular_calcium": 1.1,
             "v_init": -80.0,
-            "spike_location": "AIS",
+            "spike_location": "soma",
             "mechanisms": mech_dict,
         }
         assert cfg.pop("network") == str(instance.initialize.circuit.path)


### PR DESCRIPTION
- As mentioned in https://github.com/openbraininstitute/obi-one/issues/702, there are some circuits where the AIS may not exist in the me-model or morphology.  AIS resolves to `axon[1]` NEURON section in BlueCelluLab and probably the same section in Neurodamus.
- This PR changes the default [SONATA simulation configuration](https://sonata-extension.readthedocs.io/en/latest/sonata_simulation.html#conditions)'s [spike_location](url) from `AIS` to `soma`.