### PR TITLE
Fixed circuit metrics call for resource estimation

### DIFF
--- a/app/services/resource_estimation/circuit_extraction.py
+++ b/app/services/resource_estimation/circuit_extraction.py
@@ -85,7 +85,7 @@ def estimate_task_resources(  # noqa: PLR0914
     level_of_detail_nodes_dict = {"_ALL_": CircuitStatsLevelOfDetail.basic}
     level_of_detail_edges_dict = {"_ALL_": CircuitStatsLevelOfDetail.basic}
     circuit_metrics = get_circuit_metrics(
-        circuit_id=circuit_id,
+        circuit_id=str(circuit_id),
         db_client=db_client,
         level_of_detail_nodes=level_of_detail_nodes_dict,
         level_of_detail_edges=level_of_detail_edges_dict,

--- a/uv.lock
+++ b/uv.lock
@@ -843,14 +843,14 @@ wheels = [
 
 [[package]]
 name = "entitysdk"
-version = "0.14.1"
+version = "0.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/b8/4a7ebfad655a93b0513a5b7846bde29dd2dddc2f09fd02fc0d119b5bcc99/entitysdk-0.14.1.tar.gz", hash = "sha256:7c64b29b7e2bd6ae8e736e8588713906bf2753ae21b5554a312d0173af3ee204", size = 81684, upload-time = "2026-04-16T11:43:45.668Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/58/e9c64c49aa374521d0e0d4dfba53d8b3e7d6445bdd9494862ea4b549266d/entitysdk-0.14.2.tar.gz", hash = "sha256:d7f20501d9b185196ba944b9373cea0bda31336459730eddd30db1836321681e", size = 81763, upload-time = "2026-04-20T08:12:24.504Z" }
 
 [[package]]
 name = "executing"


### PR DESCRIPTION
Small type fix required after changes in [PR#679](https://github.com/openbraininstitute/obi-one/pull/679) in order to make resource estimation for circuit extraction work again.