### PR TITLE
Resolve circuit_simulation by target simulator and circuit scale

### DIFF
--- a/app/endpoints/task.py
+++ b/app/endpoints/task.py
@@ -48,6 +48,17 @@ def task_launch_endpoint(
     accounting_factory: AccountingSessionFactoryDep,
 ) -> TaskLaunchInfo:
     project_context = db_client.project_context
+
+    # circuit_simulation maps to a group of tasks. Select the correct one based on circuit
+    # metadata and config contents. For example circuit_simulation -> circuit_simulation_neuron
+    if json_model.task_type == TaskType.circuit_simulation:
+        task_type = task_service.select_simulation_task(
+            db_client=db_client,
+            config_id=json_model.config_id,
+            config_type=TASK_DEFINITIONS[json_model.task_type].config_type,
+        )
+        json_model = json_model.model_copy(update={"task_type": task_type})
+
     task_definition = TASK_DEFINITIONS[json_model.task_type]
 
     accounting_info = accounting_service.estimate_task_cost(

--- a/app/endpoints/task.py
+++ b/app/endpoints/task.py
@@ -58,6 +58,8 @@ def task_launch_endpoint(
             config_type=TASK_DEFINITIONS[json_model.task_type].config_type,
         )
         json_model = json_model.model_copy(update={"task_type": task_type})
+        msg = f"Mapped circuit_simulation -> {task_type}"
+        L.info(msg)
 
     task_definition = TASK_DEFINITIONS[json_model.task_type]
 
@@ -129,6 +131,18 @@ def estimate_endpoint(
     accounting_factory: AccountingSessionFactoryDep,
 ) -> TaskAccountingInfo:
     """Estimates the cost for launching a task."""
+    # circuit_simulation maps to a group of tasks. Select the correct one based on circuit
+    # metadata and config contents. For example circuit_simulation -> circuit_simulation_neuron
+    if json_model.task_type == TaskType.circuit_simulation:
+        task_type = task_service.select_simulation_task(
+            db_client=db_client,
+            config_id=json_model.config_id,
+            config_type=TASK_DEFINITIONS[json_model.task_type].config_type,
+        )
+        json_model = json_model.model_copy(update={"task_type": task_type})
+        msg = f"Mapped circuit_simulation -> {task_type}"
+        L.info(msg)
+
     return accounting_service.estimate_task_cost(
         db_client=db_client,
         config_id=json_model.config_id,

--- a/app/mappings.py
+++ b/app/mappings.py
@@ -76,7 +76,7 @@ TASK_DEFINITIONS: dict[TaskType, TaskDefinition] = {
         ),
         resources=MachineResources(
             cores=1,
-            memory=2,
+            memory=8,
             timelimit="00:10",
             compute_cell="local",
         ),
@@ -93,7 +93,7 @@ TASK_DEFINITIONS: dict[TaskType, TaskDefinition] = {
         ),
         resources=MachineResources(
             cores=1,
-            memory=2,
+            memory=8,
             timelimit="00:10",
             compute_cell="local",
         ),

--- a/app/mappings.py
+++ b/app/mappings.py
@@ -13,6 +13,7 @@ from app.schemas.task import (
     PythonRepositoryCode,
     TaskDefinition,
     TaskDefinitionLegacy,
+    TaskGroupLegacyDefinition,
 )
 from app.types import BuiltinScript, TaskType
 from obi_one.config import settings as obi_settings
@@ -58,7 +59,40 @@ TASK_DEFINITIONS: dict[TaskType, TaskDefinition] = {
             compute_cell="local",
         ),
     ),
-    TaskType.circuit_simulation: TaskDefinitionLegacy(
+    TaskType.circuit_simulation: TaskGroupLegacyDefinition(
+        task_type=TaskType.circuit_simulation,
+        config_type=models.Simulation,
+    ),
+    TaskType.circuit_simulation_inait_machine: TaskDefinitionLegacy(
+        task_type=TaskType.circuit_simulation_inait,
+        config_type=models.Simulation,
+        activity_type=models.SimulationExecution,
+        code=PythonRepositoryCode(
+            location="https://github.com/openbraininstitute-partners/inait",
+            ref="commit:54da893cbf445a9c28b1a116ae8b8d7d4ed8a6dd",
+            path="scripts/simulate-circuits/run.py",
+            dependencies="scripts/simulate-circuits/requirements.txt",
+            staged_directories=["wheels", "scripts/simulate-circuits/"],
+        ),
+        resources=MachineResources(
+            cores=1,
+            memory=2,
+            timelimit="00:10",
+            compute_cell="local",
+        ),
+    ),
+    TaskType.circuit_simulation_neuron: TaskDefinitionLegacy(
+        task_type=TaskType.circuit_simulation_neuron,
+        config_type=models.Simulation,
+        activity_type=models.SimulationExecution,
+        resources=MachineResources(
+            cores=1,
+            memory=2,
+            timelimit="00:10",
+            compute_cell="local",
+        ),
+    ),
+    TaskType.circuit_simulation_neurodamus_cluster: TaskDefinitionLegacy(
         task_type=TaskType.circuit_simulation,
         config_type=models.Simulation,
         activity_type=models.SimulationExecution,

--- a/app/mappings.py
+++ b/app/mappings.py
@@ -64,7 +64,7 @@ TASK_DEFINITIONS: dict[TaskType, TaskDefinition] = {
         config_type=models.Simulation,
     ),
     TaskType.circuit_simulation_inait_machine: TaskDefinitionLegacy(
-        task_type=TaskType.circuit_simulation_inait,
+        task_type=TaskType.circuit_simulation_inait_machine,
         config_type=models.Simulation,
         activity_type=models.SimulationExecution,
         code=PythonRepositoryCode(
@@ -85,6 +85,12 @@ TASK_DEFINITIONS: dict[TaskType, TaskDefinition] = {
         task_type=TaskType.circuit_simulation_neuron,
         config_type=models.Simulation,
         activity_type=models.SimulationExecution,
+        code=PythonRepositoryCode(
+            location=settings.OBI_ONE_REPO,
+            ref=APP_TAG,
+            path=OBI_ONE_CODE_PATH,
+            dependencies=str(OBI_ONE_DEPS_DIR / "default.txt"),
+        ),
         resources=MachineResources(
             cores=1,
             memory=2,
@@ -93,7 +99,7 @@ TASK_DEFINITIONS: dict[TaskType, TaskDefinition] = {
         ),
     ),
     TaskType.circuit_simulation_neurodamus_cluster: TaskDefinitionLegacy(
-        task_type=TaskType.circuit_simulation,
+        task_type=TaskType.circuit_simulation_neurodamus_cluster,
         config_type=models.Simulation,
         activity_type=models.SimulationExecution,
         code=BuiltinCode(

--- a/app/mappings.py
+++ b/app/mappings.py
@@ -77,7 +77,7 @@ TASK_DEFINITIONS: dict[TaskType, TaskDefinition] = {
         resources=MachineResources(
             cores=1,
             memory=8,
-            timelimit="00:10",
+            timelimit="02:00",
             compute_cell="local",
         ),
     ),

--- a/app/schemas/task.py
+++ b/app/schemas/task.py
@@ -28,6 +28,7 @@ class PythonRepositoryCode(Schema):
     path: str
     dependencies: str
     capabilities: Capabilities = Capabilities()
+    staged_directories: list[str] = []  # noqa: RUF012
 
 
 class BuiltinCode(Schema):
@@ -89,6 +90,11 @@ class TaskAccountingCreate(Schema):
 class TaskAccountingInfo(TaskAccountingCreate):
     cost: float
     parameters: AccountingParameters
+
+
+class TaskGroupLegacyDefinition(Schema):
+    task_type: TaskType
+    config_type: type[Entity]
 
 
 class TaskDefinition(Schema):

--- a/app/services/accounting.py
+++ b/app/services/accounting.py
@@ -103,7 +103,7 @@ def estimate_task_cost(
     )
 
 
-def _evaluate_accounting_parameters(  # noqa: PLR0911
+def _evaluate_accounting_parameters(
     *,
     db_client: Client,
     config_id: UUID,
@@ -121,17 +121,11 @@ def _evaluate_accounting_parameters(  # noqa: PLR0911
                 count=1,
                 service_subtype=ServiceSubtype.SMALL_CIRCUIT_SIM,
             )
-        case TaskType.circuit_simulation_neuron:
-            return _evaluate_circuit_simulation_parameters(
-                db_client=db_client,
-                simulation_id=config_id,
-            )
-        case TaskType.circuit_simulation_neurodamus_cluster:
-            return _evaluate_circuit_simulation_parameters(
-                db_client=db_client,
-                simulation_id=config_id,
-            )
-        case TaskType.circuit_simulation_inait_machine:
+        case (
+            TaskType.circuit_simulation_neuron
+            | TaskType.circuit_simulation_neurodamus_cluster
+            | TaskType.circuit_simulation_inait_machine
+        ):
             return _evaluate_circuit_simulation_parameters(
                 db_client=db_client,
                 simulation_id=config_id,

--- a/app/services/accounting.py
+++ b/app/services/accounting.py
@@ -103,7 +103,7 @@ def estimate_task_cost(
     )
 
 
-def _evaluate_accounting_parameters(
+def _evaluate_accounting_parameters(  # noqa: PLR0911
     *,
     db_client: Client,
     config_id: UUID,
@@ -121,7 +121,17 @@ def _evaluate_accounting_parameters(
                 count=1,
                 service_subtype=ServiceSubtype.SMALL_CIRCUIT_SIM,
             )
-        case TaskType.circuit_simulation:
+        case TaskType.circuit_simulation_neuron:
+            return _evaluate_circuit_simulation_parameters(
+                db_client=db_client,
+                simulation_id=config_id,
+            )
+        case TaskType.circuit_simulation_neurodamus_cluster:
+            return _evaluate_circuit_simulation_parameters(
+                db_client=db_client,
+                simulation_id=config_id,
+            )
+        case TaskType.circuit_simulation_inait_machine:
             return _evaluate_circuit_simulation_parameters(
                 db_client=db_client,
                 simulation_id=config_id,

--- a/app/services/task.py
+++ b/app/services/task.py
@@ -19,7 +19,8 @@ from app.schemas.task import (
     TaskLaunchInfo,
     TaskLaunchSubmit,
 )
-from app.types import CallBackAction, CallBackEvent, TargetSimulator, TaskType
+from app.types import CallBackAction, CallBackEvent, TaskType
+from obi_one.types import TargetSimulator
 from obi_one.utils import db_sdk
 
 
@@ -288,23 +289,37 @@ def select_simulation_task(
         },
     ).one()
     simulation_config = libsonata.SimulationConfig(sim_config_content, ".")
-    target_simulator = TargetSimulator(simulation_config.target_simulator.name)
 
-    circuit = db_client.get_entity(
-        entity_id=simulation_config.entity_id, entity_type=models.Circuit
-    )
-
-    circuit_config = db_sdk.get_json_asset_content(
-        client=db_client,
-        entity=circuit,
-        selection={
-            "label": AssetLabel.circuit_config,
-        },
-    )
-    target_simulator_circuit = circuit_config.get("target_simulator", TargetSimulator.NEURON)
+    if target_simulator_from_simulation := simulation_config.target_simulator:
+        target_simulator = target_simulator_from_simulation
+        msg = f"Target simulator '{target_simulator}' is used from simulation config."
+        L.info(msg)
+    else:
+        circuit = db_client.get_entity(
+            entity_id=simulation_config.entity_id,
+            entity_type=models.Circuit,
+        )
+        circuit_config = db_sdk.get_json_asset_content(
+            client=db_client,
+            entity=circuit,
+            selection={
+                "label": AssetLabel.circuit_config,
+            },
+        )
+        # TODO: Switch to libsonata
+        if target_simulator_from_circuit := circuit_config.get("target_simulator"):
+            target_simulator = target_simulator_from_circuit
+            msg = f"Target simulator '{target_simulator}' is used from circuit config."
+            L.info(msg)
+        else:
+            target_simulator = TargetSimulator.NEURON
+            msg = (
+                f"No target simulator found in circuit/simulation configs. "
+                f"Using default '{TargetSimulator.NEURON}'."
+            )
+            L.info(msg)
 
     circuit_scale = circuit.circuit_scale
-    assert target_simulator == target_simulator_circuit
 
     match target_simulator:
         case TargetSimulator.LEARNING_ENGINE:

--- a/app/services/task.py
+++ b/app/services/task.py
@@ -324,7 +324,7 @@ def select_simulation_task(
 
     if simulation_config.target_simulator is not None:
         target_simulator = TargetSimulator(simulation_config.target_simulator.name)
-        msg = f"Target simulator '{target_simulator}' is used from simulation config."
+        msg = f"Using target simulator '{target_simulator}' from simulation config."
         L.info(msg)
 
     circuit = db_client.get_entity(
@@ -334,6 +334,8 @@ def select_simulation_task(
 
     if target_simulator is None:
         target_simulator = circuit.target_simulator
+        msg = f"Using target simulator '{target_simulator}' from circuit config."
+        L.info(msg)
 
     match target_simulator:
         case TargetSimulator.LearningEngine:

--- a/app/services/task.py
+++ b/app/services/task.py
@@ -5,7 +5,14 @@ import entitysdk
 import httpx
 import libsonata
 from entitysdk import ProjectContext, models
-from entitysdk.types import ActivityStatus, AssetLabel, CircuitScale, ExecutorType
+from entitysdk.types import (
+    ActivityStatus,
+    AssetLabel,
+    CircuitScale,
+    ContentType,
+    ExecutorType,
+    TargetSimulator,
+)
 
 import app.services.resource_estimation.circuit_extraction
 import app.services.resource_estimation.circuit_simulation
@@ -20,7 +27,6 @@ from app.schemas.task import (
     TaskLaunchSubmit,
 )
 from app.types import CallBackAction, CallBackEvent, TaskType
-from obi_one.types import TargetSimulator
 from obi_one.utils import db_sdk
 
 
@@ -253,21 +259,7 @@ def estimate_task_resources(
                 task_definition=task_definition,
                 compute_cell=compute_cell,
             )
-        case TaskType.circuit_simulation_neuron:
-            return app.services.resource_estimation.circuit_simulation.estimate_task_resources(
-                json_model=json_model,
-                db_client=db_client,
-                task_definition=task_definition,
-                compute_cell=compute_cell,
-            )
         case TaskType.circuit_simulation_neurodamus_cluster:
-            return app.services.resource_estimation.circuit_simulation.estimate_task_resources(
-                json_model=json_model,
-                db_client=db_client,
-                task_definition=task_definition,
-                compute_cell=compute_cell,
-            )
-        case TaskType.circuit_simulation_inait_machine:
             return app.services.resource_estimation.circuit_simulation.estimate_task_resources(
                 json_model=json_model,
                 db_client=db_client,
@@ -282,50 +274,37 @@ def select_simulation_task(
     *, db_client: entitysdk.Client, config_id: UUID, config_type: models.Entity
 ) -> TaskType:
     simulation = db_client.get_entity(entity_id=config_id, entity_type=config_type)
-    sim_config_content = db_client.fetch_assets(
+
+    simulation_config_content = db_sdk.select_asset_content(
+        client=db_client,
         entity=simulation,
         selection={
-            "label": AssetLabel.simulation_config,
+            "label": AssetLabel.sonata_simulation_config,
+            "content_type": ContentType.application_json,
         },
-    ).one()
-    simulation_config = libsonata.SimulationConfig(sim_config_content, ".")
+    )
+    simulation_config = libsonata.SimulationConfig(simulation_config_content, ".")
 
-    if target_simulator_from_simulation := simulation_config.target_simulator:
-        target_simulator = target_simulator_from_simulation
+    target_simulator = None
+
+    if simulation_config.target_simulator is not None:
+        target_simulator = TargetSimulator(simulation_config.target_simulator.name)
         msg = f"Target simulator '{target_simulator}' is used from simulation config."
         L.info(msg)
-    else:
-        circuit = db_client.get_entity(
-            entity_id=simulation_config.entity_id,
-            entity_type=models.Circuit,
-        )
-        circuit_config = db_sdk.get_json_asset_content(
-            client=db_client,
-            entity=circuit,
-            selection={
-                "label": AssetLabel.circuit_config,
-            },
-        )
-        # TODO: Switch to libsonata
-        if target_simulator_from_circuit := circuit_config.get("target_simulator"):
-            target_simulator = target_simulator_from_circuit
-            msg = f"Target simulator '{target_simulator}' is used from circuit config."
-            L.info(msg)
-        else:
-            target_simulator = TargetSimulator.NEURON
-            msg = (
-                f"No target simulator found in circuit/simulation configs. "
-                f"Using default '{TargetSimulator.NEURON}'."
-            )
-            L.info(msg)
 
-    circuit_scale = circuit.circuit_scale
+    circuit = db_client.get_entity(
+        entity_id=simulation.entity_id,
+        entity_type=models.Circuit,
+    )
+
+    if target_simulator is None:
+        target_simulator = circuit.target_simulator
 
     match target_simulator:
-        case TargetSimulator.LEARNING_ENGINE:
+        case TargetSimulator.LearningEngine:
             return TaskType.circuit_simulation_inait_machine
         case TargetSimulator.NEURON | TargetSimulator.CORENEURON:
-            match circuit_scale:
+            match circuit.scale:
                 case CircuitScale.single | CircuitScale.pair | CircuitScale.small:
                     return TaskType.circuit_simulation_neuron
                 case _:

--- a/app/services/task.py
+++ b/app/services/task.py
@@ -326,6 +326,8 @@ def select_simulation_task(
         target_simulator = TargetSimulator(simulation_config.target_simulator.name)
         msg = f"Using target simulator '{target_simulator}' from simulation config."
         L.info(msg)
+    else:
+        L.info("No `target_simulator` found in simulation config.")
 
     circuit = db_client.get_entity(
         entity_id=simulation.entity_id,
@@ -336,6 +338,9 @@ def select_simulation_task(
         target_simulator = circuit.target_simulator
         msg = f"Using target simulator '{target_simulator}' from circuit config."
         L.info(msg)
+
+    msg = f"Circuit scale: {circuit.scale}"
+    L.info(msg)
 
     match target_simulator:
         case TargetSimulator.LearningEngine:

--- a/app/services/task.py
+++ b/app/services/task.py
@@ -72,6 +72,16 @@ def submit_task_job(
     all_callbacks = [failure_callback, *callbacks]
 
     match task_definition.task_type:
+        case TaskType.circuit_simulation_inait_machine:
+            executor_type = ExecutorType.single_node_job
+            job_data = _inait_job_data(
+                simulation_id=config_id,
+                simulation_execution_id=activity_id,
+                project_id=project_context.project_id,
+                virtual_lab_id=project_context.virtual_lab_id,
+                callbacks=callbacks,
+                task_definition=task_definition,
+            )
         case TaskType.circuit_simulation_neurodamus_cluster:
             executor_type = ExecutorType.distributed_job
             job_data = _circuit_simulation_job_data(
@@ -141,6 +151,31 @@ def _circuit_simulation_job_data(
             str(simulation_id),
             "--simulation-execution-id",
             str(simulation_execution_id),
+        ],
+        "project_id": str(project_id),
+        "callbacks": [c.model_dump(mode="json") for c in callbacks],
+    }
+
+
+def _inait_job_data(
+    *,
+    simulation_id: UUID,
+    simulation_execution_id: UUID,
+    project_id: UUID,
+    virtual_lab_id: UUID,
+    callbacks: list[CallBack],
+    task_definition: TaskDefinition,
+) -> dict:
+    resources = task_definition.resources.model_dump(mode="json")
+    return {
+        "code": task_definition.code.model_dump(mode="json"),
+        "resources": resources,
+        "inputs": [
+            "sonata-simulation-task",
+            f" --project-id {project_id}",
+            f" --virtual-lab-id {virtual_lab_id}",
+            f" --simulation-id {simulation_id}",
+            f" --simulation-execution-id {simulation_execution_id}",
         ],
         "project_id": str(project_id),
         "callbacks": [c.model_dump(mode="json") for c in callbacks],

--- a/app/services/task.py
+++ b/app/services/task.py
@@ -3,8 +3,9 @@ from uuid import UUID
 
 import entitysdk
 import httpx
+import libsonata
 from entitysdk import ProjectContext, models
-from entitysdk.types import ActivityStatus, ExecutorType
+from entitysdk.types import ActivityStatus, AssetLabel, CircuitScale, ExecutorType
 
 import app.services.resource_estimation.circuit_extraction
 import app.services.resource_estimation.circuit_simulation
@@ -18,7 +19,7 @@ from app.schemas.task import (
     TaskLaunchInfo,
     TaskLaunchSubmit,
 )
-from app.types import CallBackAction, CallBackEvent, TaskType
+from app.types import CallBackAction, CallBackEvent, TargetSimulator, TaskType
 from obi_one.utils import db_sdk
 
 
@@ -260,3 +261,46 @@ def estimate_task_resources(
             )
         case _:
             return task_definition.resources.model_copy(update={"compute_cell": compute_cell})
+
+
+def select_simulation_task(
+    *, db_client: entitysdk.Client, config_id: UUID, config_type: models.Entity
+) -> TaskType:
+    simulation = db_client.get_entity(entity_id=config_id, entity_type=config_type)
+    sim_config_content = db_client.fetch_assets(
+        entity=simulation,
+        selection={
+            "label": AssetLabel.simulation_config,
+        },
+    ).one()
+    simulation_config = libsonata.SimulationConfig(sim_config_content, ".")
+    target_simulator = TargetSimulator(simulation_config.target_simulator.name)
+
+    circuit = db_client.get_entity(
+        entity_id=simulation_config.entity_id, entity_type=models.Circuit
+    )
+
+    circuit_config = db_sdk.get_json_asset_content(
+        client=db_client,
+        entity=circuit,
+        selection={
+            "label": AssetLabel.circuit_config,
+        },
+    )
+    target_simulator_circuit = circuit_config.get("target_simulator", TargetSimulator.NEURON)
+
+    circuit_scale = circuit.circuit_scale
+    assert target_simulator == target_simulator_circuit
+
+    match target_simulator:
+        case TargetSimulator.LEARNING_ENGINE:
+            return TaskType.circuit_simulation_inait_machine
+        case TargetSimulator.NEURON | TargetSimulator.CORENEURON:
+            match circuit_scale:
+                case CircuitScale.single | CircuitScale.pair | CircuitScale.small:
+                    return TaskType.circuit_simulation_neuron
+                case _:
+                    return TaskType.circuit_simulation_neurodamus_cluster
+        case _:
+            msg = f"Unsupported target simulator {target_simulator}"
+            raise RuntimeError(msg)

--- a/app/services/task.py
+++ b/app/services/task.py
@@ -79,7 +79,7 @@ def submit_task_job(
                 simulation_execution_id=activity_id,
                 project_id=project_context.project_id,
                 virtual_lab_id=project_context.virtual_lab_id,
-                callbacks=callbacks,
+                callbacks=all_callbacks,
                 task_definition=task_definition,
             )
         case TaskType.circuit_simulation_neurodamus_cluster:

--- a/app/services/task.py
+++ b/app/services/task.py
@@ -65,7 +65,7 @@ def submit_task_job(
     all_callbacks = [failure_callback, *callbacks]
 
     match task_definition.task_type:
-        case TaskType.circuit_simulation:
+        case TaskType.circuit_simulation_neurodamus_cluster:
             executor_type = ExecutorType.distributed_job
             job_data = _circuit_simulation_job_data(
                 simulation_id=config_id,
@@ -252,7 +252,21 @@ def estimate_task_resources(
                 task_definition=task_definition,
                 compute_cell=compute_cell,
             )
-        case TaskType.circuit_simulation:
+        case TaskType.circuit_simulation_neuron:
+            return app.services.resource_estimation.circuit_simulation.estimate_task_resources(
+                json_model=json_model,
+                db_client=db_client,
+                task_definition=task_definition,
+                compute_cell=compute_cell,
+            )
+        case TaskType.circuit_simulation_neurodamus_cluster:
+            return app.services.resource_estimation.circuit_simulation.estimate_task_resources(
+                json_model=json_model,
+                db_client=db_client,
+                task_definition=task_definition,
+                compute_cell=compute_cell,
+            )
+        case TaskType.circuit_simulation_inait_machine:
             return app.services.resource_estimation.circuit_simulation.estimate_task_resources(
                 json_model=json_model,
                 db_client=db_client,

--- a/obi_one/types.py
+++ b/obi_one/types.py
@@ -16,9 +16,9 @@ class TaskType(StrEnum):
 
     circuit_extraction = auto()
     circuit_simulation = auto()
-    circuit_simulation_inait = auto()
+    circuit_simulation_inait_machine = auto()
     circuit_simulation_neuron = auto()
-    circuit_simulation_neurodamus = auto()
+    circuit_simulation_neurodamus_cluster = auto()
     morphology_skeletonization = auto()
     ion_channel_model_simulation_execution = auto()
     em_synapse_mapping = auto()

--- a/obi_one/types.py
+++ b/obi_one/types.py
@@ -22,9 +22,3 @@ class TaskType(StrEnum):
     morphology_skeletonization = auto()
     ion_channel_model_simulation_execution = auto()
     em_synapse_mapping = auto()
-
-
-class TargetSimulator(StrEnum):
-    NEURON = "NEURON"
-    CORENEURON = "CORENEURON"
-    LEARNING_ENGINE = "LearningEngine"

--- a/obi_one/types.py
+++ b/obi_one/types.py
@@ -16,6 +16,15 @@ class TaskType(StrEnum):
 
     circuit_extraction = auto()
     circuit_simulation = auto()
+    circuit_simulation_inait = auto()
+    circuit_simulation_neuron = auto()
+    circuit_simulation_neurodamus = auto()
     morphology_skeletonization = auto()
     ion_channel_model_simulation_execution = auto()
     em_synapse_mapping = auto()
+
+
+class TargetSimulator(StrEnum):
+    NEURON = "NEURON"
+    CORENEURON = "CORENEURON"
+    LEARNING_ENGINE = "LearningEngine"

--- a/obi_one/utils/db_sdk.py
+++ b/obi_one/utils/db_sdk.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from datetime import UTC, datetime
 from pathlib import Path
@@ -29,6 +30,13 @@ def get_entity_asset_by_label(*, client: Client, config: Entity, asset_label: As
         raise OBIONEError(msg) from e
 
 
+def get_task_config_asset(*, client: Client, config: Entity) -> Asset:
+    """Return task config asset from entity."""
+    return get_entity_asset_by_label(
+        client=client, config=config, asset_label=AssetLabel.task_config
+    )
+
+
 def create_activity(
     *,
     client: Client,
@@ -46,6 +54,14 @@ def create_activity(
     activity = client.register_entity(activity)
     L.info(f"Activity {activity.id} of type '{activity_type.__name__}' created")
     return activity
+
+
+def get_json_asset_content(*, client: Client, entity: Entity, selection: dict) -> dict:
+    bytes_content = client.fetch_assets(
+        entity=entity,
+        selection=selection,
+    ).one()
+    return json.loads(bytes_content)
 
 
 def create_generic_activity(

--- a/obi_one/utils/db_sdk.py
+++ b/obi_one/utils/db_sdk.py
@@ -97,14 +97,6 @@ def select_json_asset_content(
     return json.loads(bytes_content)
 
 
-def get_json_asset_content(*, client: Client, entity: Entity, selection: dict) -> dict:
-    bytes_content = client.fetch_assets(
-        entity=entity,
-        selection=selection,
-    ).one()
-    return json.loads(bytes_content)
-
-
 def create_generic_activity(
     *,
     client: Client,

--- a/obi_one/utils/db_sdk.py
+++ b/obi_one/utils/db_sdk.py
@@ -56,6 +56,47 @@ def create_activity(
     return activity
 
 
+def select_asset_content(
+    *,
+    client: Client,
+    entity: Entity | None = None,
+    entity_id: UUID | None = None,
+    entity_type: type[Entity] | None = None,
+    selection: dict,
+) -> bytes:
+    """Select an asset from an entity and fetch its content."""
+    if entity is None:
+        entity = client.get_entity(entity_id=entity_id, entity_type=entity_type)
+    asset = client.select_assets(
+        entity=entity,
+        selection=selection,
+    ).one()
+    return client.fetch_content(
+        entity_id=entity.id,
+        entity_type=type(entity),
+        asset_or_id=asset,
+    )
+
+
+def select_json_asset_content(
+    *,
+    client: Client,
+    entity: Entity | None = None,
+    entity_id: UUID | None = None,
+    entity_type: type[Entity] | None = None,
+    selection: dict,
+) -> dict:
+    """Select an asset from the entity and fetch its content."""
+    bytes_content = select_asset_content(
+        client=client,
+        entity=entity,
+        entity_id=entity_id,
+        entity_type=entity_type,
+        selection=selection | {"content_type": ContentType.application_json},
+    )
+    return json.loads(bytes_content)
+
+
 def get_json_asset_content(*, client: Client, entity: Entity, selection: dict) -> dict:
     bytes_content = client.fetch_assets(
         entity=entity,

--- a/tests/app/endpoints/test_task.py
+++ b/tests/app/endpoints/test_task.py
@@ -1,17 +1,24 @@
+import json
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
-from uuid import uuid4
+from uuid import UUID, uuid4
 
+import httpx
 import pytest
+from entitysdk.types import CircuitScale, TargetSimulator
 from obp_accounting_sdk.constants import ServiceSubtype
 
 from app.application import app
+from app.config import settings
 from app.dependencies.compute_cell import get_compute_cell
 from app.mappings import TASK_DEFINITIONS
 from app.schemas.accounting import AccountingParameters
 from app.schemas.callback import CallBack, CallBackAction, CallBackEvent, HttpRequestCallBackConfig
 from app.schemas.task import TaskAccountingInfo, TaskLaunchInfo
 from app.types import TaskType
+
+from tests.utils import PROJECT_ID, VIRTUAL_LAB_ID, assert_request
 
 
 @pytest.fixture
@@ -130,6 +137,289 @@ def test_task_launch_success(
         assert resp.status_code == 500
 
         accounting_session.finish.assert_called_once_with(exc_type=RuntimeError)
+
+
+def _simulation_config(target_simulator: str):
+    return {
+        "manifest": {"$OUTPUT_DIR": "./reporting", "$INPUT_DIR": "./"},
+        "run": {"tstop": 1000.0, "dt": 0.01, "spike_threshold": -15, "random_seed": 42},
+        "target_simulator": target_simulator,
+        "network": "$INPUT_DIR/circuit_config.json",
+        "conditions": {"celsius": 34.0, "v_init": -80, "other": "something"},
+        "node_sets_file": "$INPUT_DIR/node_sets_simple.json",
+        "mechanisms_dir": "../shared_components_mechanisms",
+        "inputs": {
+            "current_clamp_1": {
+                "input_type": "current_clamp",
+                "module": "linear",
+                "node_set": "Layer23",
+                "amp_start": 190.0,
+                "delay": 100.0,
+                "duration": 800.0,
+            },
+            "spikes_1": {
+                "input_type": "spikes",
+                "module": "synapse_replay",
+                "delay": 800,
+                "duration": 100,
+                "node_set": "Layer23",
+                "source": "Layer23",
+                "spike_file": "input_spikes.h5",
+            },
+        },
+        "output": {
+            "output_dir": "$OUTPUT_DIR",
+            "log_file": "log_spikes.log",
+            "spikes_file": "spikes.h5",
+            "spikes_sort_order": "by_time",
+        },
+        "reports": {},
+    }
+
+
+def _simulation_metadata(*, simulation_id, circuit_id, config_id):
+    return {
+        "id": str(simulation_id),
+        "name": "sim",
+        "simulation_campaign_id": str(uuid4()),
+        "entity_id": str(circuit_id),
+        "scan_parameters": {},
+        "number_neurons": 100,
+        "assets": [
+            {
+                "id": str(config_id),
+                "path": "simulation_config.json",
+                "full_path": "/simulation_config.json",
+                "entity_id": str(simulation_id),
+                "sha256_digest": None,
+                "created_by_id": str(uuid4()),
+                "updated_by_id": str(uuid4()),
+                "label": "sonata_simulation_config",
+                "storage_type": "aws_s3_internal",
+                "is_directory": False,
+                "content_type": "application/json",
+                "size": 0,
+            }
+        ],
+    }
+
+
+def _circuit_config():
+    return {
+        "manifest": {"$BASE_DIR": ".", "$COMPONENT_DIR": "$BASE_DIR", "$NETWORK_DIR": "./"},
+        "target_simulator": "NEURON",
+        "components": {
+            "biophysical_neuron_models_dir": "$COMPONENT_DIR/biophysical_neuron_models",
+            "morphologies_dir": "$COMPONENT_DIR/morphologies",
+        },
+        "node_sets_file": "$BASE_DIR/node_sets.json",
+        "networks": {
+            "nodes": [
+                {
+                    "nodes_file": "$NETWORK_DIR/nodes.h5",
+                    "populations": {
+                        "default": {"type": "biophysical"},
+                        "default2": {
+                            "type": "biophysical",
+                            "spatial_segment_index_dir": "path/to/node/dir",
+                        },
+                    },
+                }
+            ],
+            "edges": [],
+        },
+    }
+
+
+def _circuit_metadata(*, circuit_id: UUID, target_simulator: str, circuit_scale: str):
+    return {
+        "id": str(circuit_id),
+        "name": "circuit",
+        "number_neurons": 1000,
+        "number_synapses": 1_000_000_000,
+        "number_connections": 100_000_000,
+        "has_morphologies": True,
+        "has_point_neurons": True,
+        "has_spines": True,
+        "has_electrical_cell_models": True,
+        "root_circuit_id": None,
+        "atlas_id": str(uuid4()),
+        "subject_id": str(uuid4()),
+        "build_category": "em_reconstruction",
+        "authorized_project_id": PROJECT_ID,
+        "authorized_public": True,
+        "created_by_id": str(uuid4()),
+        "updated_by_id": str(uuid4()),
+        "brain_region_id": str(uuid4()),
+        "license_id": str(uuid4()),
+        "target_simulator": target_simulator,
+        "scale": circuit_scale,
+        "assets": [],
+    }
+
+
+@pytest.mark.parametrize(
+    "target_simulator",
+    [TargetSimulator.NEURON, TargetSimulator.CORENEURON, TargetSimulator.LearningEngine],
+)
+@pytest.mark.parametrize(
+    "circuit_scale",
+    [
+        CircuitScale.small,
+        CircuitScale.microcircuit,
+        CircuitScale.region,
+        CircuitScale.system,
+        CircuitScale.whole_brain,
+    ],
+)
+def test_task_launch_success__circuit_simulation(
+    client,
+    httpx_mock,
+    target_simulator,
+    circuit_scale,
+):
+    circuit_id = uuid4()
+    simulation_id = uuid4()
+    simulation_config_asset_id = uuid4()
+    simulation_execution_id = uuid4()
+    db_url = settings.ENTITYCORE_URL
+    job_id = uuid4()
+
+    # mock response from vlab manager for determining the compute_cell
+    httpx_mock.add_response(
+        url=settings.get_virtual_lab_url(VIRTUAL_LAB_ID),
+        method="GET",
+        json={"data": {"virtual_lab": {"compute_cell": "cell_a"}}},
+    )
+    # mock simulation metadata response fetched to toggle between simulation task types
+    httpx_mock.add_response(
+        url=f"{db_url}/simulation/{simulation_id}",
+        method="GET",
+        json=_simulation_metadata(
+            simulation_id=simulation_id, circuit_id=circuit_id, config_id=simulation_config_asset_id
+        ),
+        is_reusable=True,  # TODO: Refactor code to avoid multiple requests
+    )
+    # mock simulation config asset response used to access target_simulator from config
+    httpx_mock.add_response(
+        url=f"{db_url}/simulation/{simulation_id}/assets/{simulation_config_asset_id}/download",
+        method="GET",
+        json=_simulation_config(target_simulator=target_simulator),
+    )
+    # mock circuit metadata needed for fetching target_simulator/scale for toggling
+    httpx_mock.add_response(
+        url=f"{db_url}/circuit/{circuit_id}",
+        method="GET",
+        json=_circuit_metadata(
+            circuit_id=circuit_id, target_simulator=target_simulator, circuit_scale=circuit_scale
+        ),
+        is_reusable=True,  # TODO: Refactor code to avoid multiple requests
+    )
+    httpx_mock.add_response(
+        url=f"{settings.ACCOUNTING_BASE_URL}/estimate/oneshot",
+        method="POST",
+        json={"data": {"cost": 1000}},
+    )
+    httpx_mock.add_response(
+        url=f"{settings.ACCOUNTING_BASE_URL}/reservation/oneshot",
+        method="POST",
+        json={"data": {"job_id": str(job_id), "amount": 200.0}},
+    )
+    httpx_mock.add_callback(
+        lambda request: httpx.Response(
+            status_code=200,
+            json=json.loads(request.content) | {"id": str(simulation_execution_id)},
+        ),
+        url=f"{db_url}/simulation-execution",
+        method="POST",
+    )
+    # mock the call to the launch-system for launching the job
+    httpx_mock.add_response(
+        url=f"{settings.LAUNCH_SYSTEM_URL}/job",
+        method="POST",
+        json={"id": str(job_id)},
+    )
+    # when task is launched activity is updated
+    httpx_mock.add_callback(
+        lambda request: httpx.Response(
+            status_code=200,
+            json={
+                "id": str(simulation_execution_id),
+                "start_time": datetime.now(UTC).isoformat(),
+            }
+            | json.loads(request.content),
+        ),
+        url=f"{db_url}/simulation-execution/{simulation_execution_id}",
+        method="PATCH",
+    )
+
+    data = assert_request(
+        client.post,
+        url="/declared/task/launch",
+        json={
+            "task_type": TaskType.circuit_simulation,
+            "config_id": str(simulation_id),
+        },
+    ).json()
+
+    expected_task_type = {
+        (TargetSimulator.NEURON, CircuitScale.small): TaskType.circuit_simulation_neuron,
+        (
+            TargetSimulator.NEURON,
+            CircuitScale.microcircuit,
+        ): TaskType.circuit_simulation_neurodamus_cluster,
+        (
+            TargetSimulator.NEURON,
+            CircuitScale.region,
+        ): TaskType.circuit_simulation_neurodamus_cluster,
+        (
+            TargetSimulator.NEURON,
+            CircuitScale.system,
+        ): TaskType.circuit_simulation_neurodamus_cluster,
+        (
+            TargetSimulator.NEURON,
+            CircuitScale.whole_brain,
+        ): TaskType.circuit_simulation_neurodamus_cluster,
+        (TargetSimulator.CORENEURON, CircuitScale.small): TaskType.circuit_simulation_neuron,
+        (
+            TargetSimulator.CORENEURON,
+            CircuitScale.microcircuit,
+        ): TaskType.circuit_simulation_neurodamus_cluster,
+        (
+            TargetSimulator.CORENEURON,
+            CircuitScale.region,
+        ): TaskType.circuit_simulation_neurodamus_cluster,
+        (
+            TargetSimulator.CORENEURON,
+            CircuitScale.system,
+        ): TaskType.circuit_simulation_neurodamus_cluster,
+        (
+            TargetSimulator.CORENEURON,
+            CircuitScale.whole_brain,
+        ): TaskType.circuit_simulation_neurodamus_cluster,
+        (
+            TargetSimulator.LearningEngine,
+            CircuitScale.small,
+        ): TaskType.circuit_simulation_inait_machine,
+        (
+            TargetSimulator.LearningEngine,
+            CircuitScale.microcircuit,
+        ): TaskType.circuit_simulation_inait_machine,
+        (
+            TargetSimulator.LearningEngine,
+            CircuitScale.region,
+        ): TaskType.circuit_simulation_inait_machine,
+        (
+            TargetSimulator.LearningEngine,
+            CircuitScale.system,
+        ): TaskType.circuit_simulation_inait_machine,
+        (
+            TargetSimulator.LearningEngine,
+            CircuitScale.whole_brain,
+        ): TaskType.circuit_simulation_inait_machine,
+    }[target_simulator, circuit_scale]
+
+    assert data["task_type"] == expected_task_type
 
 
 @pytest.mark.parametrize(

--- a/tests/app/endpoints/test_task.py
+++ b/tests/app/endpoints/test_task.py
@@ -12,10 +12,11 @@ from obp_accounting_sdk.constants import ServiceSubtype
 from app.application import app
 from app.config import settings
 from app.dependencies.compute_cell import get_compute_cell
-from app.mappings import TASK_DEFINITIONS
+from app.mappings import APP_TAG, OBI_ONE_CODE_PATH, OBI_ONE_DEPS_DIR, TASK_DEFINITIONS
 from app.schemas.accounting import AccountingParameters
 from app.schemas.callback import CallBack, CallBackAction, CallBackEvent, HttpRequestCallBackConfig
 from app.schemas.task import TaskAccountingInfo, TaskLaunchInfo
+from app.services.accounting import CIRCUIT_SCALE_TO_SERVICE_SUBTYPE
 from app.types import TaskType
 
 from tests.utils import PROJECT_ID, VIRTUAL_LAB_ID, assert_request
@@ -419,7 +420,184 @@ def test_task_launch_success__circuit_simulation(
         ): TaskType.circuit_simulation_inait_machine,
     }[target_simulator, circuit_scale]
 
-    assert data["task_type"] == expected_task_type
+    response_task_type = data["task_type"]
+    task_def = TASK_DEFINITIONS[response_task_type]
+
+    assert response_task_type == expected_task_type
+
+    job_request = httpx_mock.get_request(
+        url=f"{settings.LAUNCH_SYSTEM_URL}/job",
+        method="POST",
+    )
+    job_payload = json.loads(job_request.content)
+
+    cluster_callbacks = [
+        {
+            "action_type": "http_request_with_token",
+            "event_type": "job_on_failure",
+            "config": {
+                "url": f"{settings.API_URL}/declared/task/callback/failure",
+                "method": "POST",
+                "params": {
+                    "task_type": response_task_type,
+                    "activity_id": str(simulation_execution_id),
+                },
+                "headers": {
+                    "virtual-lab-id": VIRTUAL_LAB_ID,
+                    "project-id": PROJECT_ID,
+                },
+                "payload": None,
+            },
+        },
+        {
+            "action_type": "http_request_with_token",
+            "event_type": "job_on_failure",
+            "config": {
+                "url": f"{settings.ACCOUNTING_BASE_URL}/reservation/oneshot/{job_id}",
+                "method": "DELETE",
+                "params": None,
+                "headers": None,
+                "payload": None,
+            },
+        },
+        {
+            "action_type": "http_request_with_token",
+            "event_type": "job_on_success",
+            "config": {
+                "url": f"{settings.API_URL}/declared/task/callback/success",
+                "method": "POST",
+                "params": None,
+                "headers": {
+                    "virtual-lab-id": VIRTUAL_LAB_ID,
+                    "project-id": PROJECT_ID,
+                },
+                "payload": {
+                    "task_type": response_task_type,
+                    "job_id": str(job_id),
+                    "accounting_service_subtype": str(
+                        CIRCUIT_SCALE_TO_SERVICE_SUBTYPE[circuit_scale]
+                    ),
+                    "count": 100,
+                },
+            },
+        },
+    ]
+
+    generic_callbacks = [
+        {
+            "action_type": "http_request_with_token",
+            "event_type": "job_on_failure",
+            "config": {
+                "url": f"{settings.API_URL}/declared/task/callback/failure",
+                "method": "POST",
+                "params": {
+                    "task_type": response_task_type,
+                    "activity_id": str(simulation_execution_id),
+                },
+                "headers": {
+                    "virtual-lab-id": VIRTUAL_LAB_ID,
+                    "project-id": PROJECT_ID,
+                },
+                "payload": None,
+            },
+        },
+        {
+            "action_type": "http_request_with_token",
+            "event_type": "job_on_failure",
+            "config": {
+                "url": f"{settings.ACCOUNTING_BASE_URL}/reservation/oneshot/{job_id}",
+                "method": "DELETE",
+                "params": None,
+                "headers": None,
+                "payload": None,
+            },
+        },
+        {
+            "action_type": "http_request_with_token",
+            "event_type": "job_on_success",
+            "config": {
+                "url": f"{settings.API_URL}/declared/task/callback/success",
+                "method": "POST",
+                "params": None,
+                "headers": {
+                    "virtual-lab-id": VIRTUAL_LAB_ID,
+                    "project-id": PROJECT_ID,
+                },
+                "payload": {
+                    "task_type": response_task_type,
+                    "job_id": str(job_id),
+                    "accounting_service_subtype": str(
+                        CIRCUIT_SCALE_TO_SERVICE_SUBTYPE[circuit_scale]
+                    ),
+                    "count": 100,
+                },
+            },
+        },
+    ]
+    match response_task_type:
+        case TaskType.circuit_simulation_inait_machine:
+            assert job_payload == {
+                "code": task_def.code.model_dump(mode="json"),
+                "resources": task_def.resources.model_dump(mode="json")
+                | {"compute_cell": "cell_a"},
+                "inputs": [
+                    "sonata-simulation-task",
+                    f" --project-id {PROJECT_ID}",
+                    f" --virtual-lab-id {VIRTUAL_LAB_ID}",
+                    f" --simulation-id {simulation_id}",
+                    f" --simulation-execution-id {simulation_execution_id}",
+                ],
+                "project_id": PROJECT_ID,
+                "callbacks": generic_callbacks,
+            }
+
+        case TaskType.circuit_simulation_neurodamus_cluster:
+            assert job_payload == {
+                "code": task_def.code.model_dump(mode="json"),
+                "resources": {
+                    "type": "cluster",
+                    "instances": 1,
+                    "instance_type": "large",
+                    "compute_cell": "cell_a",
+                    "timelimit": None,
+                },
+                "inputs": [
+                    "--simulation-id",
+                    str(simulation_id),
+                    "--simulation-execution-id",
+                    str(simulation_execution_id),
+                ],
+                "project_id": PROJECT_ID,
+                "callbacks": cluster_callbacks,
+            }
+
+        case _:
+            assert job_payload == {
+                "code": {
+                    "type": "python_repository",
+                    "location": "https://github.com/openbraininstitute/obi-one.git",
+                    "ref": APP_TAG,
+                    "path": OBI_ONE_CODE_PATH,
+                    "dependencies": str(OBI_ONE_DEPS_DIR / "default.txt"),
+                    "capabilities": {"private_packages": False, "env_secrets": []},
+                    "staged_directories": [],
+                },
+                "resources": task_def.resources.model_dump(mode="json")
+                | {"compute_cell": "cell_a"},
+                "inputs": [
+                    "--task-type circuit_simulation_neuron",
+                    "--config_entity_type Simulation",
+                    f"--config_entity_id {simulation_id}",
+                    "--entity_cache True",
+                    "--scan_output_root ./obi-output",
+                    f"--virtual_lab_id {VIRTUAL_LAB_ID}",
+                    f"--project_id {PROJECT_ID}",
+                    "--execution_activity_type SimulationExecution",
+                    f"--execution_activity_id {simulation_execution_id}",
+                ],
+                "project_id": PROJECT_ID,
+                "callbacks": generic_callbacks,
+            }
 
 
 @pytest.mark.parametrize(

--- a/tests/app/endpoints/test_task.py
+++ b/tests/app/endpoints/test_task.py
@@ -649,6 +649,71 @@ def test_task_estimate(client, task_type):
     assert data["parameters"]["count"] == 10
 
 
+@pytest.mark.parametrize(
+    "circuit_scale",
+    [
+        CircuitScale.small,
+        CircuitScale.microcircuit,
+        CircuitScale.region,
+        CircuitScale.system,
+        CircuitScale.whole_brain,
+    ],
+)
+@pytest.mark.parametrize(
+    "target_simulator",
+    [TargetSimulator.NEURON, TargetSimulator.CORENEURON, TargetSimulator.LearningEngine],
+)
+def test_task_estimate__circuit_simulation(client, target_simulator, circuit_scale, httpx_mock):
+    simulation_id = uuid4()
+    simulation_config_asset_id = uuid4()
+    circuit_id = uuid4()
+
+    db_url = settings.ENTITYCORE_URL
+
+    httpx_mock.add_response(
+        url=f"{db_url}/simulation/{simulation_id}",
+        method="GET",
+        json=_simulation_metadata(
+            simulation_id=simulation_id, circuit_id=circuit_id, config_id=simulation_config_asset_id
+        ),
+        is_reusable=True,  # TODO: Refactor code to avoid multiple requests
+    )
+    # mock simulation config asset response used to access target_simulator from config
+    httpx_mock.add_response(
+        url=f"{db_url}/simulation/{simulation_id}/assets/{simulation_config_asset_id}/download",
+        method="GET",
+        json=_simulation_config(target_simulator=target_simulator),
+    )
+    # mock circuit metadata needed for fetching target_simulator/scale for toggling
+    httpx_mock.add_response(
+        url=f"{db_url}/circuit/{circuit_id}",
+        method="GET",
+        json=_circuit_metadata(
+            circuit_id=circuit_id, target_simulator=target_simulator, circuit_scale=circuit_scale
+        ),
+        is_reusable=True,  # TODO: Refactor code to avoid multiple requests
+    )
+    httpx_mock.add_response(
+        url=f"{settings.ACCOUNTING_BASE_URL}/estimate/oneshot",
+        method="POST",
+        json={"data": {"cost": 1000}},
+    )
+
+    data = (
+        client.post(
+            url="/declared/task/estimate",
+            json={
+                "task_type": TaskType.circuit_simulation,
+                "config_id": str(simulation_id),
+            },
+        )
+        .raise_for_status()
+        .json()
+    )
+    assert data["config_id"] == str(simulation_id)
+    assert data["cost"] == 1000
+
+
 @pytest.mark.parametrize("task_type", TaskType)
 def test_task_failure_endpoint(client, task_type):
     activity_id = uuid4()

--- a/tests/app/endpoints/test_task.py
+++ b/tests/app/endpoints/test_task.py
@@ -29,7 +29,18 @@ def callbacks():
     ]
 
 
-@pytest.mark.parametrize("task_type", TaskType)
+@pytest.mark.parametrize(
+    "task_type",
+    [
+        TaskType.circuit_extraction,
+        TaskType.circuit_simulation_inait_machine,
+        TaskType.circuit_simulation_neuron,
+        TaskType.circuit_simulation_neurodamus_cluster,
+        TaskType.morphology_skeletonization,
+        TaskType.ion_channel_model_simulation_execution,
+        TaskType.em_synapse_mapping,
+    ],
+)
 def test_task_launch_success(
     client,
     callbacks,
@@ -121,7 +132,18 @@ def test_task_launch_success(
         accounting_session.finish.assert_called_once_with(exc_type=RuntimeError)
 
 
-@pytest.mark.parametrize("task_type", TaskType)
+@pytest.mark.parametrize(
+    "task_type",
+    [
+        TaskType.circuit_extraction,
+        TaskType.circuit_simulation_inait_machine,
+        TaskType.circuit_simulation_neuron,
+        TaskType.circuit_simulation_neurodamus_cluster,
+        TaskType.morphology_skeletonization,
+        TaskType.ion_channel_model_simulation_execution,
+        TaskType.em_synapse_mapping,
+    ],
+)
 def test_task_estimate(client, task_type):
     config_id = uuid4()
 

--- a/tests/app/services/test_accounting.py
+++ b/tests/app/services/test_accounting.py
@@ -197,21 +197,36 @@ def test_evaluate_circuit_simulation_parameters__error(db_client, httpx_mock):
         )
 
 
-@pytest.mark.parametrize("task_type", TaskType)
+@pytest.mark.parametrize(
+    "task_type",
+    [
+        TaskType.circuit_extraction,
+        TaskType.circuit_simulation_inait_machine,
+        TaskType.circuit_simulation_neuron,
+        TaskType.circuit_simulation_neurodamus_cluster,
+        TaskType.morphology_skeletonization,
+        TaskType.ion_channel_model_simulation_execution,
+        TaskType.em_synapse_mapping,
+    ],
+)
 def test_evaluate_accounting_parameters(db_client, task_type, accounting_parameters):
     config_id = uuid4()
     task_definition = TASK_DEFINITIONS[task_type]
 
     expected_subtype = {
         TaskType.circuit_extraction: ServiceSubtype.SMALL_CIRCUIT_SIM,
-        TaskType.circuit_simulation: ServiceSubtype.SMALL_SIM,
+        TaskType.circuit_simulation_neurodamus_cluster: ServiceSubtype.SMALL_SIM,
+        TaskType.circuit_simulation_inait_machine: ServiceSubtype.SMALL_SIM,
+        TaskType.circuit_simulation_neuron: ServiceSubtype.SMALL_SIM,
         TaskType.ion_channel_model_simulation_execution: ServiceSubtype.ION_CHANNEL_SIM,
         TaskType.morphology_skeletonization: ServiceSubtype.NEURON_MESH_SKELETONIZATION,
         TaskType.em_synapse_mapping: ServiceSubtype.SMALL_CIRCUIT_SIM,
     }
     expected_count = {
         TaskType.circuit_extraction: 1,
-        TaskType.circuit_simulation: 10,
+        TaskType.circuit_simulation_neurodamus_cluster: 10,
+        TaskType.circuit_simulation_inait_machine: 10,
+        TaskType.circuit_simulation_neuron: 10,
         TaskType.ion_channel_model_simulation_execution: 1,
         TaskType.morphology_skeletonization: 800,
         TaskType.em_synapse_mapping: 1,

--- a/tests/app/services/test_circuit_simulation.py
+++ b/tests/app/services/test_circuit_simulation.py
@@ -24,7 +24,7 @@ def _make_db_client(number_neurons: int) -> tuple[Mock, str]:
 
 def test_estimate_task_resources_success():
     json_model = TaskLaunchSubmit(task_type=TaskType.circuit_simulation, config_id=uuid4())
-    task_definition = TASK_DEFINITIONS[TaskType.circuit_simulation]
+    task_definition = TASK_DEFINITIONS[TaskType.circuit_simulation_neurodamus_cluster]
     db_client, circuit_id = _make_db_client(number_neurons=9)
     mocked_instances = {
         "cell_a": [

--- a/tests/app/services/test_task.py
+++ b/tests/app/services/test_task.py
@@ -19,6 +19,8 @@ from tests.utils import PROJECT_ID, VIRTUAL_LAB_ID
 
 ASSET_ID = uuid4()
 
+TASK_TYPES = [task_type for task_type in TaskType if task_type != TaskType.circuit_simulation]
+
 
 @pytest.fixture
 def db_client():
@@ -48,7 +50,7 @@ def callbacks(activity_id):
         url="http://failure",
         method="POST",
         params={
-            "task_type": TaskType.circuit_simulation,
+            "task_type": TaskType.circuit_simulation_neurodamus_cluster,
             "activity_id": str(activity_id),
         },
         headers={
@@ -95,7 +97,7 @@ def callbacks(activity_id):
             },
         ),
         (
-            TaskType.circuit_simulation,
+            TaskType.circuit_simulation_neurodamus_cluster,
             "simulation",
             {
                 "entity_id": str(uuid4()),
@@ -203,7 +205,7 @@ def test_submit_task_job__success(
             },
         ),
         (
-            TaskType.circuit_simulation,
+            TaskType.circuit_simulation_neurodamus_cluster,
             "simulation",
             {
                 "entity_id": str(uuid4()),
@@ -279,7 +281,9 @@ def test_submit_task_job__failure(
 
 
 def test_circuit_simulation_job_data(config_id, activity_id, callbacks):
-    task_definition = TASK_DEFINITIONS["circuit_simulation"]
+    task_type = TaskType.circuit_simulation_neurodamus_cluster
+
+    task_definition = TASK_DEFINITIONS[task_type]
 
     res = test_module._circuit_simulation_job_data(
         simulation_id=config_id,
@@ -316,7 +320,7 @@ def test_circuit_simulation_job_data(config_id, activity_id, callbacks):
                     "url": "http://failure",
                     "method": "POST",
                     "params": {
-                        "task_type": "circuit_simulation",
+                        "task_type": task_type,
                         "activity_id": str(activity_id),
                     },
                     "headers": {
@@ -365,6 +369,7 @@ def test_generic_job_data(config_id, activity_id, callbacks):
                 "private_packages": False,
                 "env_secrets": [],
             },
+            "staged_directories": [],
         },
         "inputs": [
             "--task-type circuit_extraction",
@@ -384,7 +389,7 @@ def test_generic_job_data(config_id, activity_id, callbacks):
                     "url": "http://failure",
                     "method": "POST",
                     "params": {
-                        "task_type": "circuit_simulation",
+                        "task_type": "circuit_simulation_neurodamus_cluster",
                         "activity_id": str(activity_id),
                     },
                     "headers": {
@@ -421,7 +426,7 @@ def test_generate_failure_callback(project_context, activity_id):
             "task-activity",
             {"task_activity_type": TaskActivityType.circuit_extraction__execution},
         ),
-        (TaskType.circuit_simulation, "simulation-execution", {}),
+        (TaskType.circuit_simulation_neurodamus_cluster, "simulation-execution", {}),
     ],
 )
 def test_handle_task_failure_callback(
@@ -461,7 +466,7 @@ def test_handle_task_failure_callback(
             "task-activity",
             {"task_activity_type": TaskActivityType.circuit_extraction__execution},
         ),
-        (TaskType.circuit_simulation, "simulation-execution", {}),
+        (TaskType.circuit_simulation_neurodamus_cluster, "simulation-execution", {}),
     ],
 )
 def test_handle_task_failure_callback__do_nothing(
@@ -531,10 +536,12 @@ def test_estimate_task_resources_circuit_extraction(db_client):
 
 
 def test_estimate_task_resources_circuit_simulation(db_client, config_id, httpx_mock):
-    task_definition = TASK_DEFINITIONS[TaskType.circuit_simulation]
+    task_definition = TASK_DEFINITIONS[TaskType.circuit_simulation_neurodamus_cluster]
 
     circuit_id = uuid4()
-    json_model = TaskLaunchSubmit(task_type=TaskType.circuit_simulation, config_id=config_id)
+    json_model = TaskLaunchSubmit(
+        task_type=TaskType.circuit_simulation_neurodamus_cluster, config_id=config_id
+    )
     mocked_instances = {
         "cell_a": [
             ClusterInstanceInfo(name="big", max_neurons=1_000_000, memory_per_instance_gb=100),

--- a/tests/app/services/test_task.py
+++ b/tests/app/services/test_task.py
@@ -280,6 +280,66 @@ def test_submit_task_job__failure(
         )
 
 
+def test_inait_job_data(config_id, activity_id, callbacks):
+    task_type = TaskType.circuit_simulation_inait_machine
+    task_definition = TASK_DEFINITIONS[task_type]
+
+    res = test_module._inait_job_data(
+        simulation_id=config_id,
+        simulation_execution_id=activity_id,
+        project_id=PROJECT_ID,
+        virtual_lab_id=VIRTUAL_LAB_ID,
+        callbacks=callbacks,
+        task_definition=task_definition,
+    )
+
+    assert res == {
+        "code": {
+            "type": "python_repository",
+            "location": "https://github.com/openbraininstitute-partners/inait",
+            "ref": "commit:54da893cbf445a9c28b1a116ae8b8d7d4ed8a6dd",
+            "path": "scripts/simulate-circuits/run.py",
+            "dependencies": "scripts/simulate-circuits/requirements.txt",
+            "capabilities": {"private_packages": False, "env_secrets": []},
+            "staged_directories": ["wheels", "scripts/simulate-circuits/"],
+        },
+        "resources": {
+            "type": "machine",
+            "cores": 1,
+            "memory": 8,
+            "compute_cell": "local",
+            "timelimit": "02:00",
+        },
+        "inputs": [
+            "sonata-simulation-task",
+            f" --project-id {PROJECT_ID}",
+            f" --virtual-lab-id {VIRTUAL_LAB_ID}",
+            f" --simulation-id {config_id}",
+            f" --simulation-execution-id {activity_id}",
+        ],
+        "project_id": PROJECT_ID,
+        "callbacks": [
+            {
+                "action_type": "http_request_with_token",
+                "event_type": "job_on_failure",
+                "config": {
+                    "url": "http://failure",
+                    "method": "POST",
+                    "params": {
+                        "task_type": "circuit_simulation_neurodamus_cluster",
+                        "activity_id": str(activity_id),
+                    },
+                    "headers": {
+                        "virtual-lab-id": VIRTUAL_LAB_ID,
+                        "project-id": PROJECT_ID,
+                    },
+                    "payload": None,
+                },
+            }
+        ],
+    }
+
+
 def test_circuit_simulation_job_data(config_id, activity_id, callbacks):
     task_type = TaskType.circuit_simulation_neurodamus_cluster
 

--- a/tests/app/services/test_task.py
+++ b/tests/app/services/test_task.py
@@ -1,6 +1,7 @@
 import json
 from datetime import UTC, datetime
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 from uuid import UUID, uuid4
 
 import entitysdk
@@ -463,6 +464,25 @@ def test_generic_job_data(config_id, activity_id, callbacks):
     }
 
 
+def test_generic_job_data_legacy(config_id, activity_id, callbacks):
+    task_definition = TASK_DEFINITIONS[TaskType.circuit_simulation_neuron]
+
+    res = test_module._generic_job_data(
+        config_id=config_id,
+        activity_id=activity_id,
+        project_id=UUID(PROJECT_ID),
+        virtual_lab_id=UUID(VIRTUAL_LAB_ID),
+        task_definition=task_definition,
+        entity_cache=True,
+        output_root="/foo",
+        callbacks=callbacks,
+    )
+
+    assert f"--config_entity_type {task_definition.config_type_name}" in res["inputs"]
+    assert f"--execution_activity_type {task_definition.activity_type_name}" in res["inputs"]
+    assert f"--execution_activity_id {activity_id}" in res["inputs"]
+
+
 def test_generate_failure_callback(project_context, activity_id):
     res = test_module._generate_failure_callback(
         callback_url="my-callback-url",
@@ -646,3 +666,103 @@ def test_estimate_task_resources_circuit_simulation(db_client, config_id, httpx_
     assert result.instance_type == "big"
     assert result.instances == 1
     assert result.compute_cell == "cell_a"
+
+
+@pytest.mark.parametrize(
+    ("target_simulator_name", "circuit_scale", "expected_task"),
+    [
+        ("LearningEngine", "system", TaskType.circuit_simulation_inait_machine),
+        ("NEURON", "small", TaskType.circuit_simulation_neuron),
+        ("CORENEURON", "microcircuit", TaskType.circuit_simulation_neurodamus_cluster),
+    ],
+)
+def test_select_simulation_task(
+    target_simulator_name,
+    circuit_scale,
+    expected_task,
+):
+    db_client = Mock()
+    config_id = uuid4()
+    simulation_entity_id = uuid4()
+
+    simulation = SimpleNamespace(entity_id=simulation_entity_id)
+    circuit = SimpleNamespace(
+        scale=circuit_scale,
+        target_simulator=target_simulator_name,
+    )
+    db_client.get_entity.side_effect = [simulation, circuit]
+
+    with (
+        patch.object(test_module.db_sdk, "select_asset_content", return_value="config_json"),
+        patch.object(
+            test_module.libsonata,
+            "SimulationConfig",
+            return_value=SimpleNamespace(
+                target_simulator=SimpleNamespace(name=target_simulator_name),
+            ),
+        ),
+    ):
+        task_type = test_module.select_simulation_task(
+            db_client=db_client,
+            config_id=config_id,
+            config_type=entitysdk.models.Simulation,
+        )
+
+    assert task_type == expected_task
+
+
+def test_select_simulation_task_falls_back_to_circuit_target_simulator():
+    db_client = Mock()
+    config_id = uuid4()
+    simulation_entity_id = uuid4()
+
+    simulation = SimpleNamespace(entity_id=simulation_entity_id)
+    circuit = SimpleNamespace(
+        scale="small",
+        target_simulator="NEURON",
+    )
+    db_client.get_entity.side_effect = [simulation, circuit]
+
+    with (
+        patch.object(test_module.db_sdk, "select_asset_content", return_value="config_json"),
+        patch.object(
+            test_module.libsonata,
+            "SimulationConfig",
+            return_value=SimpleNamespace(target_simulator=None),
+        ),
+    ):
+        task_type = test_module.select_simulation_task(
+            db_client=db_client,
+            config_id=config_id,
+            config_type=entitysdk.models.Simulation,
+        )
+
+    assert task_type == TaskType.circuit_simulation_neuron
+
+
+def test_select_simulation_task_raises_for_unsupported_target_simulator():
+    db_client = Mock()
+    config_id = uuid4()
+    simulation_entity_id = uuid4()
+
+    simulation = SimpleNamespace(entity_id=simulation_entity_id)
+    circuit = SimpleNamespace(
+        scale="small",
+        target_simulator="UNSUPPORTED",
+    )
+    db_client.get_entity.side_effect = [simulation, circuit]
+
+    with (
+        patch.object(test_module.db_sdk, "select_asset_content", return_value="config_json"),
+        patch.object(
+            test_module.libsonata,
+            "SimulationConfig",
+            return_value=SimpleNamespace(target_simulator=None),
+        ),
+        pytest.raises(RuntimeError, match="Unsupported target simulator"),
+    ):
+        test_module.select_simulation_task(
+            db_client=db_client,
+            config_id=config_id,
+            config_type=entitysdk.models.Simulation,
+        )

--- a/tests/obi_one/utils/test_db_sdk.py
+++ b/tests/obi_one/utils/test_db_sdk.py
@@ -55,6 +55,22 @@ def test_get_entity_asset_by_label(client, mock_entity_with_assets):
     assert result.label == AssetLabel.morphology
 
 
+def test_get_task_config_asset():
+    client = Mock()
+    config = Mock(spec=Entity)
+    config.id = uuid4()
+    expected_asset = Mock(spec=Asset, label=AssetLabel.task_config)
+    client.select_assets.return_value.one.return_value = expected_asset
+
+    result = test_module.get_task_config_asset(client=client, config=config)
+
+    assert result is expected_asset
+    client.select_assets.assert_called_once_with(
+        entity=config,
+        selection={"label": AssetLabel.task_config},
+    )
+
+
 def test_create_activity(client, mock_entity, httpx_mock):
     """Test successful activity creation."""
     activity_status = "pending"

--- a/tests/obi_one/utils/test_db_sdk.py
+++ b/tests/obi_one/utils/test_db_sdk.py
@@ -10,7 +10,7 @@ import httpx
 import pytest
 from entitysdk.exception import EntitySDKError
 from entitysdk.models import Asset, Entity, SimulationExecution
-from entitysdk.types import AssetLabel, ExecutorType, TaskActivityType
+from entitysdk.types import AssetLabel, ContentType, ExecutorType, TaskActivityType
 
 from obi_one.core.exception import OBIONEError
 from obi_one.utils import db_sdk as test_module
@@ -489,3 +489,61 @@ def test_add_image_assets_success_webp_and_png(tmp_path):
 
     assert assets == [uploaded_a, uploaded_b]
     assert client.upload_file.call_count == 2
+
+
+def test_select_json_asset_content(client, httpx_mock):
+    entity_id = uuid4()
+    asset_1_id = uuid4()
+    asset_2_id = uuid4()
+
+    entity = Entity(
+        id=entity_id,
+        name="foo",
+        assets=[
+            Asset(
+                id=asset_1_id,
+                path="config.json",
+                full_path="/config.json",
+                content_type=ContentType.application_json,
+                size=0,
+                storage_type="aws_s3_internal",
+                label=AssetLabel.sonata_simulation_config,
+                is_directory=False,
+            ),
+            Asset(
+                id=asset_2_id,
+                path="foo.swc",
+                full_path="/foo.swc",
+                content_type=ContentType.application_swc,
+                size=0,
+                storage_type="aws_s3_internal",
+                label=AssetLabel.morphology,
+                is_directory=False,
+            ),
+        ],
+    )
+    content = {"foo": "bar", "zee": "roo"}
+    httpx_mock.add_response(
+        url=f"{client.api_url}/entity/{entity_id}/assets/{asset_1_id}/download",
+        content=json.dumps(content),
+        is_reusable=True,
+    )
+    res = test_module.select_json_asset_content(
+        client=client,
+        entity=entity,
+        selection={"label": AssetLabel.sonata_simulation_config},
+    )
+    assert res == content
+
+    httpx_mock.add_response(
+        url=f"{client.api_url}/entity/{entity_id}",
+        json=entity.model_dump(mode="json"),
+    )
+
+    res = test_module.select_json_asset_content(
+        client=client,
+        entity_id=entity.id,
+        entity_type=type(entity),
+        selection={"label": AssetLabel.sonata_simulation_config},
+    )
+    assert res == content

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -55,3 +55,17 @@ class ClientProxy:
 
         method = getattr(self._client, name)
         return decorator(method) if name in self._methods else method
+
+
+def assert_response(response, expected_status_code=200, context=None):
+    assert response.status_code == expected_status_code, (
+        f"Request {response.request.method} {response.request.url}: "
+        f"expected={expected_status_code}, actual={response.status_code}, "
+        f"content={response.content}, context={context}"
+    )
+
+
+def assert_request(client_method, *, expected_status_code=200, context=None, **kwargs):
+    response = client_method(**kwargs)
+    assert_response(response, expected_status_code=expected_status_code, context=context)
+    return response


### PR DESCRIPTION
## Summary

This PR introduces deterministic routing from generic `circuit_simulation` requests to concrete simulation task types, based on simulator and circuit scale metadata from simulation config and circuit.
* `circuit_simulation` is now treated as a group task and resolved before launch/estimate.
* Resolution is done in `app/services/task.py::select_simulation_task`.
* Endpoints `POST /declared/task/launch` and `POST /declared/task/estimate` now map the task type and proceed with the mapped concrete task.

## How task selection works
`select_simulation_task` determines target_simulator in this order:

* Fetch simulation entity by config_id
* Load simulation config asset with:
  * label = sonata_simulation_config
  * content_type = application_json
* Parse with `libsonata.SimulationConfig`
* If `simulation_config.target_simulator exists`, use it
* Else fallback to `circuit.target_simulator` from the linked circuit (simulation.entity_id)

Resolved `target_simulator` is then used as follows:
* `LearningEngine` -> `TaskType.circuit_simulation_inait_machine`
* `NEURON` or `CORENEURON`:
  * `circuit.scale` in {single, pair, small} -> `TaskType.circuit_simulation_neuron`
  * otherwise -> `TaskType.circuit_simulation_neurodamus_cluster`
* any other simulator -> raises RuntimeError("Unsupported target simulator ...")

## Endpoint Behavior Changes
In `app/endpoints/task.py`:
* For both `/launch` and `/estimate`, when input `task_type == circuit_simulation`:
    * call select_simulation_task(...)
    * replace incoming model task type with concrete task type
After mapping, existing flow continues using `TASK_DEFINITIONS[resolved_task_type]`.

## Launch Payload / Executor Impact
In `submit_task_job` (`app/services/task.py`), concrete type controls payload and executor:

* circuit_simulation_inait_machine
  * payload: _inait_job_data
  * executor: single_node_job
* circuit_simulation_neurodamus_cluster
  * payload: _circuit_simulation_job_data
  * executor: distributed_job
* other tasks
  * payload: _generic_job_data
  * executor: single_node_job

Issue: https://github.com/openbraininstitute/prod-circuit-simulation/issues/97