### PR TITLE
Move distributions into separate GUI block group

### DIFF
--- a/obi_one/scientific/tasks/generate_simulations/config/base.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/base.py
@@ -56,6 +56,7 @@ class BlockGroup(StrEnum):
 
     SETUP_BLOCK_GROUP = "Setup"
     STIMULI_RECORDINGS_BLOCK_GROUP = "Stimuli & Recordings"
+    DISTRIBUTIONS_BLOCK_GROUP = "Distributions"
     CIRCUIT_COMPONENTS_BLOCK_GROUP = "Circuit Components"
     CIRCUIT_MANIPULATIONS_GROUP = "Manipulations"
     EVENTS_GROUP = "Events"

--- a/obi_one/scientific/tasks/generate_simulations/config/circuit.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/circuit.py
@@ -53,6 +53,7 @@ class CircuitSimulationScanConfig(SimulationScanConfig):
         SchemaKey.GROUP_ORDER: [
             BlockGroup.SETUP_BLOCK_GROUP,
             BlockGroup.STIMULI_RECORDINGS_BLOCK_GROUP,
+            BlockGroup.DISTRIBUTIONS_BLOCK_GROUP,
             BlockGroup.CIRCUIT_COMPONENTS_BLOCK_GROUP,
             BlockGroup.CIRCUIT_MANIPULATIONS_GROUP,
             BlockGroup.EVENTS_GROUP,
@@ -134,7 +135,7 @@ class CircuitSimulationScanConfig(SimulationScanConfig):
             SchemaKey.UI_ELEMENT: UIElement.BLOCK_DICTIONARY,
             SchemaKey.REFERENCE_TYPE: AllDistributionsReference.__name__,
             SchemaKey.SINGULAR_NAME: "Distribution",
-            SchemaKey.GROUP: BlockGroup.STIMULI_RECORDINGS_BLOCK_GROUP,
+            SchemaKey.GROUP: BlockGroup.DISTRIBUTIONS_BLOCK_GROUP,
             SchemaKey.GROUP_ORDER: 2,
         },
     )

--- a/obi_one/scientific/tasks/generate_simulations/config/circuit.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/circuit.py
@@ -136,7 +136,7 @@ class CircuitSimulationScanConfig(SimulationScanConfig):
             SchemaKey.REFERENCE_TYPE: AllDistributionsReference.__name__,
             SchemaKey.SINGULAR_NAME: "Distribution",
             SchemaKey.GROUP: BlockGroup.DISTRIBUTIONS_BLOCK_GROUP,
-            SchemaKey.GROUP_ORDER: 2,
+            SchemaKey.GROUP_ORDER: 0,
         },
     )
 


### PR DESCRIPTION
Moves distributions out of the “Stimuli & Recordings” GUI section into their own dedicated “Distributions” block group for clearer organization and reuse across features.