### PR TITLE
Unify pyproject.toml's depdency group style

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,15 +57,15 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# New group for the private dependency
-meshing = [
-    "neuromorphomesh",
-]
-
 # CONNECTIVITY - optional, needed for analysis & plot generation
 connectivity = [
     "connectome-analysis>=1.0.1",
     "networkx>=3.4.2",
+]
+
+# MESHING - optional, private dependency needed to create meshes from morphologies
+meshing = [
+    "neuromorphomesh",
 ]
 
 # NOTEBOOKS - optional, needed to run the notebooks locally

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ service = [
 
 # ALL - convenience alias to install all optional dependencies
 all = [
-    "obi-one[connectivity,notebooks,service,meshing]",
+    "obi-one[connectivity,meshing,notebooks,service]",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -2225,7 +2225,7 @@ requires-dist = [
     { name = "starlette", marker = "extra == 'service'" },
     { name = "uvicorn", marker = "extra == 'service'" },
 ]
-provides-extras = ["meshing", "connectivity", "notebooks", "service", "all"]
+provides-extras = ["connectivity", "meshing", "notebooks", "service", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
A new meshing dependency group was added in #649 . I've reordered the group to follow the already existing alphabetical order and unified the description comment.