### PR TITLE
Fix BlueRecording API: electrodes as list, require >=0.4.4

### DIFF
--- a/obi_one/scientific/tasks/create_recording_array/create_recording_array.py
+++ b/obi_one/scientific/tasks/create_recording_array/create_recording_array.py
@@ -216,14 +216,14 @@ class CreateExtracellularRecordingArrayTask(Task):
             save_weights,
         )
 
-        electrodes = {
-            f"electrode_{i}": Electrode(
+        electrodes = [
+            Electrode(
                 name=f"electrode_{i}",
                 position=np.array(loc, dtype=float),
                 type=BlueRecordingElectrodeType.POINT_SOURCE,
             )
             for i, loc in enumerate(electrode_xyz_locations)
-        }
+        ]
 
         circuit_config_path = Path(circuit_dest_dir) / "circuit_config.json"
         weights, positions_df, cols, neurite_types, population_name = compute_weights(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ all = [
 # Requires MPI-enabled h5py and NEURON built from source.
 # Use BlueRecording/dev_setup.sh for full setup, then pip install -e obi-one[bluerecording]
 bluerecording = [
-    "bluerecording",
+    "bluerecording>=0.4.4",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
- Pass electrodes as `list[Electrode]` instead of `dict[str, Electrode]` to match BlueRecording's actual API
- Require `bluerecording>=0.4.4` which includes the type hint fix and in-memory SimulationConfig
- It should work with the 0.4.3 but to be sure I increased the requirement to 0.4.4