### PR TITLE
Require bluerecording>=0.4.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ all = [
 # Requires MPI-enabled h5py and NEURON built from source.
 # Use BlueRecording/dev_setup.sh for full setup, then pip install -e obi-one[bluerecording]
 bluerecording = [
-    "bluerecording>=0.4.4",
+    "bluerecording>=0.4.5",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
BlueRecording v0.4.5 includes the mkdir fix for save_weights (creates output directory if missing).