### PR TITLE
fix neuron-set crash when SONATA files are missing

### DIFF
--- a/obi_one/scientific/library/connectivity_metrics.py
+++ b/obi_one/scientific/library/connectivity_metrics.py
@@ -1,20 +1,13 @@
-import tempfile
-from pathlib import Path
 from typing import Annotated
 
-import bluepysnap as snap
-import numpy as np
 import pandas as pd
 from connectome_manipulator.connectome_comparison import connectivity
 from entitysdk.client import Client
-from entitysdk.models import Asset
-from entitysdk.models.circuit import Circuit
-from entitysdk.types import FetchFileStrategy
-from httpx import HTTPStatusError
 from pydantic import BaseModel, Field
 from pydantic.types import PositiveFloat
 
 import obi_one as obi
+from obi_one.scientific.library.sonata_circuit_assets import TemporarySonataCircuit
 
 
 class ConnectivityMetricsRequest(BaseModel):
@@ -69,105 +62,6 @@ class ConnectivityMetricsOutput(BaseModel):
     ) = None
 
 
-class TemporaryPartialCircuit:
-    """Access partial circuit through symlinks or download circuit to temporary folder.
-
-    To avoid unnecessary data download, only the following circuit components are included:
-    Circuit config, node sets, selected edges, src/tgt nodes of selected edges
-    """
-
-    def __init__(self, db_client: Client, circuit_id: str, edge_population: str) -> None:
-        """Initialize TemporaryPartialCircuit."""
-        self._db_client = db_client
-        self._circuit_id = circuit_id
-        self._edge_population = edge_population
-
-    def _fetch_file(self, rel_path: str) -> Path:
-        temp_file_path = Path(self.temp_dir.name) / rel_path
-        if self.asset.id is None:
-            msg = "Asset must have an id"
-            raise ValueError(msg)
-        self._db_client.fetch_file(
-            entity_id=self._circuit_id,  # ty:ignore[invalid-argument-type]
-            entity_type=Circuit,
-            asset_id=self.asset.id,
-            output_path=temp_file_path,
-            asset_path=rel_path,  # ty:ignore[invalid-argument-type]
-            strategy=FetchFileStrategy.link_or_download,
-        )
-        return temp_file_path
-
-    def _get_sonata_asset(self) -> Asset:
-        circuit = self._db_client.get_entity(
-            entity_id=self._circuit_id,  # ty:ignore[invalid-argument-type]
-            entity_type=Circuit,
-        )
-        sonata_assets = [
-            a for a in circuit.assets if a.is_directory and a.label.value == "sonata_circuit"
-        ]
-        if len(sonata_assets) != 1:
-            msg = "Circuit must have exactly one SONATA circuit directory asset!"
-            raise ValueError(msg)
-        return sonata_assets[0]
-
-    def _get_edges_path(self, c: snap.Circuit) -> str:
-        edges_list = c.config["networks"]["edges"]
-        edges = [e for e in edges_list if self._edge_population in e["populations"]]
-        if len(edges) != 1:
-            msg = f"Edge population '{self._edge_population}' not found in the circuit!"
-            raise ValueError(msg)
-        return edges[0]["edges_file"]
-
-    @staticmethod
-    def _get_nodes_path(c: snap.Circuit, node_population: str) -> str:
-        nodes_list = c.config["networks"]["nodes"]
-        nodes = [n for n in nodes_list if node_population in n["populations"]]
-        if len(nodes) != 1:
-            msg = f"Node population '{node_population}' not found in the circuit!"
-            raise ValueError(msg)
-        return nodes[0]["nodes_file"]
-
-    def __enter__(self) -> Path:
-        """Enter."""
-        self.asset = self._get_sonata_asset()
-
-        # Fetch circuit files in temp directory
-        self.temp_dir = tempfile.TemporaryDirectory()
-        try:
-            # Fetch circuit config
-            circuit_config_file = self._fetch_file("circuit_config.json")
-            circuit = obi.Circuit(name=str(self._circuit_id), path=str(circuit_config_file))
-            c = circuit.sonata_circuit
-
-            # Fetch node sets file
-            rel_path = Path(c.config["node_sets_file"]).relative_to(
-                Path(self.temp_dir.name).resolve()
-            )
-            self._fetch_file(rel_path)  # ty:ignore[invalid-argument-type]
-
-            # Fetch edge population
-            edges_path = self._get_edges_path(c)
-            rel_path = Path(edges_path).relative_to(Path(self.temp_dir.name).resolve())
-            self._fetch_file(rel_path)  # ty:ignore[invalid-argument-type]
-
-            # Fetch src/tgt node populations
-            src_nodes = c.edges[self._edge_population].source.name
-            tgt_nodes = c.edges[self._edge_population].target.name
-            for npop in np.unique([src_nodes, tgt_nodes]):
-                nodes_path = self._get_nodes_path(c, npop)
-                rel_path = Path(nodes_path).relative_to(Path(self.temp_dir.name).resolve())
-                self._fetch_file(rel_path)  # ty:ignore[invalid-argument-type]
-        except HTTPStatusError:
-            self.temp_dir.__exit__(None, None, None)
-            raise
-        return circuit_config_file
-
-    def __exit__(self, *args) -> None:
-        """Exit."""
-        if self.temp_dir is not None:
-            self.temp_dir.__exit__(*args)
-
-
 def _get_stacked_dataframe(conn_dict: dict, data_sel: str) -> pd.DataFrame:
     df = pd.DataFrame(conn_dict[data_sel]["data"], columns=conn_dict["common"]["tgt_group_values"])
     df["pre"] = conn_dict["common"]["src_group_values"]
@@ -188,7 +82,9 @@ def get_connectivity_metrics(
 ) -> ConnectivityMetricsOutput:
     # Acces mounted circuit if possible, or download partial circuit otherwise
     # (incl. config, node sets, selected edges, src/tgt nodes of selected edges)
-    with TemporaryPartialCircuit(db_client, circuit_id, edge_population) as cfg_path:
+    with TemporarySonataCircuit(
+        db_client, circuit_id, edge_population=edge_population
+    ) as cfg_path:
         # Load circuit
         circuit = obi.Circuit(name=circuit_id, path=str(cfg_path))
         c = circuit.sonata_circuit

--- a/obi_one/scientific/library/neuronal_manipulation_properties.py
+++ b/obi_one/scientific/library/neuronal_manipulation_properties.py
@@ -12,15 +12,10 @@ Provides logic to:
 from __future__ import annotations
 
 import logging
-import tempfile
-from pathlib import Path
 from typing import TYPE_CHECKING
-from uuid import UUID
 
 from bluepysnap import Circuit as SnapCircuit
 from entitysdk.models import Derivation as DerivationModel
-from entitysdk.models.circuit import Circuit
-from entitysdk.types import FetchFileStrategy
 from libsonata import NodeStorage
 
 from obi_one.scientific.library.circuit import Circuit as ObiCircuit
@@ -31,9 +26,17 @@ from obi_one.scientific.library.memodel_circuit import (
     MechanismVariableDetail,
     _build_mechanism_variables_by_ion_channel_response,
 )
+from obi_one.scientific.library.sonata_circuit_assets import (
+    TemporarySonataCircuit,
+    asset_path_relative_to,
+    get_sonata_circuit_asset,
+)
 
 if TYPE_CHECKING:
+    from uuid import UUID
+
     import entitysdk.client
+    from entitysdk.models.circuit import Circuit
 
     from obi_one.scientific.blocks.neuron_sets.base import AbstractNeuronSet
 
@@ -45,19 +48,8 @@ def _get_circuit_asset(
     circuit_id: str,
 ) -> tuple[Circuit, UUID]:
     """Get circuit entity and its sonata_circuit directory asset ID."""
-    circuit_entity = db_client.get_entity(
-        entity_id=UUID(circuit_id),
-        entity_type=Circuit,
-    )
-
-    directory_assets = [
-        a for a in circuit_entity.assets if a.is_directory and a.label.value == "sonata_circuit"
-    ]
-    if len(directory_assets) != 1:
-        msg = f"Circuit {circuit_id} must have exactly one sonata_circuit directory asset."
-        raise ValueError(msg)
-
-    asset_id = directory_assets[0].id
+    circuit_entity, asset = get_sonata_circuit_asset(db_client, circuit_id)
+    asset_id = asset.id
     if asset_id is None:
         msg = f"Circuit {circuit_id} sonata_circuit asset has no ID."
         raise ValueError(msg)
@@ -84,22 +76,14 @@ def get_circuit_node_ids(
     """
     circuit_entity, asset_id = _get_circuit_asset(db_client, circuit_id)
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_config_path = Path(temp_dir) / "circuit_config.json"
-        db_client.fetch_file(
-            entity_id=UUID(circuit_id),
-            entity_type=Circuit,
-            asset_id=asset_id,
-            output_path=temp_config_path,
-            asset_path=Path("circuit_config.json"),
-            strategy=FetchFileStrategy.link_or_download,
-        )
-
+    staged_circuit = TemporarySonataCircuit(db_client, circuit_id, asset_id=asset_id)
+    with staged_circuit as temp_config_path:
         obi_circuit = ObiCircuit(name=circuit_entity.name or circuit_id, path=str(temp_config_path))
 
         if population is None:
             population = obi_circuit.default_population_name
 
+        staged_circuit.fetch_node_population(obi_circuit.sonata_circuit, population)
         node_ids = neuron_set.get_neuron_ids(obi_circuit, population).tolist()
 
     return population, node_ids
@@ -127,20 +111,13 @@ def get_model_template_for_nodes(
     Raises:
         ValueError: If model_template property is not available.
     """
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_config_path = Path(temp_dir) / "circuit_config.json"
-        db_client.fetch_file(
-            entity_id=UUID(circuit_id),
-            entity_type=Circuit,
-            asset_id=asset_id,
-            output_path=temp_config_path,
-            asset_path=Path("circuit_config.json"),
-            strategy=FetchFileStrategy.link_or_download,
-        )
-
+    staged_circuit = TemporarySonataCircuit(
+        db_client, circuit_id, asset_id=asset_id, include_node_sets=False
+    )
+    with staged_circuit as temp_config_path:
         snap_circuit = SnapCircuit(temp_config_path)
         nodes_h5_path = snap_circuit.nodes[population].h5_filepath
-        remote_path = Path(nodes_h5_path).relative_to(temp_dir)
+        remote_path = asset_path_relative_to(nodes_h5_path, staged_circuit.temp_dir_path)
 
         with TemporaryAsset(remote_path, db_client, circuit_id, str(asset_id)) as nodes_file:
             pop_obj = NodeStorage(nodes_file).open_population(population)
@@ -331,16 +308,10 @@ def _resolve_population_and_node_ids(
     """Resolve population name and node IDs from inputs."""
     if node_ids is not None:
         if population is None:
-            with tempfile.TemporaryDirectory() as temp_dir:
-                temp_config_path = Path(temp_dir) / "circuit_config.json"
-                db_client.fetch_file(
-                    entity_id=UUID(circuit_id),
-                    entity_type=Circuit,
-                    asset_id=asset_id,
-                    output_path=temp_config_path,
-                    asset_path=Path("circuit_config.json"),
-                    strategy=FetchFileStrategy.link_or_download,
-                )
+            staged_circuit = TemporarySonataCircuit(
+                db_client, circuit_id, asset_id=asset_id, include_node_sets=False
+            )
+            with staged_circuit as temp_config_path:
                 obi_circuit = ObiCircuit(
                     name=circuit_entity.name or circuit_id, path=str(temp_config_path)
                 )

--- a/obi_one/scientific/library/sonata_circuit_assets.py
+++ b/obi_one/scientific/library/sonata_circuit_assets.py
@@ -1,0 +1,163 @@
+"""Helpers for staging selected files from a SONATA circuit directory asset."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+import bluepysnap as snap
+import numpy as np
+from entitysdk.models.circuit import Circuit
+from entitysdk.types import FetchFileStrategy
+from httpx import HTTPStatusError
+
+if TYPE_CHECKING:
+    from entitysdk.client import Client
+    from entitysdk.models import Asset
+
+
+def asset_path_relative_to(path: str | Path, parent_dir: str | Path) -> Path:
+    """Convert a resolved local SONATA path back to its directory-asset path."""
+    return Path(path).resolve().relative_to(Path(parent_dir).resolve())
+
+
+def get_sonata_circuit_asset(db_client: Client, circuit_id: str) -> tuple[Circuit, Asset]:
+    """Return a circuit entity and its unique sonata_circuit directory asset."""
+    circuit = db_client.get_entity(
+        entity_id=UUID(circuit_id),
+        entity_type=Circuit,
+    )
+    sonata_assets = [
+        asset
+        for asset in circuit.assets
+        if asset.is_directory and asset.label.value == "sonata_circuit"
+    ]
+    if len(sonata_assets) != 1:
+        msg = "Circuit must have exactly one sonata_circuit directory asset."
+        raise ValueError(msg)
+    return circuit, sonata_assets[0]
+
+
+class TemporarySonataCircuit:
+    """Stage selected files from a SONATA circuit directory asset into a temp layout."""
+
+    def __init__(
+        self,
+        db_client: Client,
+        circuit_id: str,
+        *,
+        asset_id: UUID | None = None,
+        edge_population: str | None = None,
+        include_node_sets: bool = True,
+        node_populations: list[str] | tuple[str, ...] = (),
+    ) -> None:
+        """Initialize the staged circuit context."""
+        self._db_client = db_client
+        self._circuit_id = circuit_id
+        self._asset_id = asset_id
+        self._edge_population = edge_population
+        self._include_node_sets = include_node_sets
+        self._node_populations = node_populations
+
+    @property
+    def temp_dir_path(self) -> Path:
+        """Return the active temporary circuit directory path."""
+        return Path(self.temp_dir.name).resolve()
+
+    def fetch_file(self, rel_path: str | Path) -> Path:
+        """Fetch a directory-asset file into the corresponding temp circuit path."""
+        temp_file_path = self.temp_dir_path / rel_path
+        temp_file_path.parent.mkdir(parents=True, exist_ok=True)
+        if self._asset_id is None:
+            msg = "Asset must have an id."
+            raise ValueError(msg)
+        self._db_client.fetch_file(
+            entity_id=UUID(self._circuit_id),
+            entity_type=Circuit,
+            asset_id=self._asset_id,
+            output_path=temp_file_path,
+            asset_path=Path(rel_path),
+            strategy=FetchFileStrategy.link_or_download,
+        )
+        return temp_file_path
+
+    def _get_sonata_asset(self) -> Asset:
+        return get_sonata_circuit_asset(self._db_client, self._circuit_id)[1]
+
+    @staticmethod
+    def get_edges_path(circuit: snap.Circuit, edge_population: str) -> str:
+        """Return the edge HDF5 path for a SONATA edge population."""
+        edges = [
+            edge
+            for edge in circuit.config["networks"]["edges"]
+            if edge_population in edge["populations"]
+        ]
+        if len(edges) != 1:
+            msg = f"Edge population '{edge_population}' not found in the circuit."
+            raise ValueError(msg)
+        return edges[0]["edges_file"]
+
+    @staticmethod
+    def get_nodes_path(circuit: snap.Circuit, node_population: str) -> str:
+        """Return the node HDF5 path for a SONATA node population."""
+        nodes = [
+            node
+            for node in circuit.config["networks"]["nodes"]
+            if node_population in node["populations"]
+        ]
+        if len(nodes) != 1:
+            msg = f"Node population '{node_population}' not found in the circuit."
+            raise ValueError(msg)
+        return nodes[0]["nodes_file"]
+
+    def fetch_node_sets(self, circuit: snap.Circuit) -> Path | None:
+        """Fetch the node sets file referenced by a SONATA config, if present."""
+        node_sets_path = circuit.config.get("node_sets_file")
+        if not node_sets_path:
+            return None
+        rel_path = asset_path_relative_to(node_sets_path, self.temp_dir_path)
+        return self.fetch_file(rel_path)
+
+    def fetch_node_population(self, circuit: snap.Circuit, node_population: str) -> Path:
+        """Fetch the HDF5 file backing a node population."""
+        nodes_path = self.get_nodes_path(circuit, node_population)
+        rel_path = asset_path_relative_to(nodes_path, self.temp_dir_path)
+        return self.fetch_file(rel_path)
+
+    def fetch_edge_population(self, circuit: snap.Circuit, edge_population: str) -> Path:
+        """Fetch the HDF5 file backing an edge population."""
+        edges_path = self.get_edges_path(circuit, edge_population)
+        rel_path = asset_path_relative_to(edges_path, self.temp_dir_path)
+        return self.fetch_file(rel_path)
+
+    def __enter__(self) -> Path:
+        """Stage the requested partial circuit and return the config path."""
+        if self._asset_id is None:
+            self._asset_id = self._get_sonata_asset().id
+        self.temp_dir = tempfile.TemporaryDirectory()
+
+        try:
+            circuit_config_file = self.fetch_file("circuit_config.json")
+            circuit = snap.Circuit(circuit_config_file)
+            if self._include_node_sets:
+                self.fetch_node_sets(circuit)
+
+            if self._edge_population is not None:
+                self.fetch_edge_population(circuit, self._edge_population)
+                edge = circuit.edges[self._edge_population]
+                for node_population in np.unique([edge.source.name, edge.target.name]):
+                    self.fetch_node_population(circuit, node_population)
+
+            for node_population in self._node_populations:
+                self.fetch_node_population(circuit, node_population)
+        except HTTPStatusError:
+            self.temp_dir.__exit__(None, None, None)
+            raise
+        return circuit_config_file
+
+    def __exit__(self, *args: object) -> None:
+        """Clean up the staged circuit directory."""
+        if self.temp_dir is not None:
+            self.temp_dir.__exit__(*args)

--- a/tests/obi_one/scientific/library/test_neuronal_manipulation_properties.py
+++ b/tests/obi_one/scientific/library/test_neuronal_manipulation_properties.py
@@ -8,6 +8,8 @@ from uuid import uuid4
 import numpy as np
 import pytest
 
+from obi_one.core.tuple import NamedTuple
+from obi_one.scientific.blocks.neuron_sets.id import IDNeuronSet
 from obi_one.scientific.library.emodel_parameters import (
     ChannelInfo,
     ChannelSectionListMapping,
@@ -839,6 +841,27 @@ class TestGetCircuitNodeIds:
         # Default population for the tiny circuit is S1nonbarrel_neurons
         assert population == "S1nonbarrel_neurons"
         assert node_ids == [5, 6]
+
+    def test_fetches_node_h5_before_resolving_real_id_neuron_set(self, mock_db_client):
+        """Real IDNeuronSet resolution needs the population nodes.h5 beside the temp config."""
+
+        circuit_id = str(uuid4())
+        neuron_set = IDNeuronSet(
+            neuron_ids=NamedTuple(name="IDNeuronSet", elements=(0, 1)),
+        )
+
+        population, node_ids = get_circuit_node_ids(
+            mock_db_client, circuit_id, neuron_set, population="S1nonbarrel_neurons"
+        )
+
+        fetched_asset_paths = [
+            call.kwargs["asset_path"] for call in mock_db_client.fetch_file.mock_calls
+        ]
+        assert population == "S1nonbarrel_neurons"
+        assert node_ids == [0, 1]
+        assert Path("circuit_config.json") in fetched_asset_paths
+        assert Path("node_sets.json") in fetched_asset_paths
+        assert Path("S1nonbarrel_neurons/nodes.h5") in fetched_asset_paths
 
 
 class TestResolvePopulationAndNodeIdsNeuronSetBranch:


### PR DESCRIPTION
the endpoint was only staging circuit_config.json in a temp folder 
`BluePySnap` then tried to read node_sets.json and the selected population nodes.h5 from that same temp folder
but those files were not there, that made HDF5 throw an unable-to-open-file error and the api returned 500

the fix adds a shared `SONATA` staging helper and uses it before resolving neuron sets,  stages the config, node_sets.json, and the needed nodes.h5 file first, so `IDNeuronSet` and similar requests can resolve node ids without crashing

the old connectivity partial-circuit staging code now uses the same helper too