### PR TITLE
Add target simulator classvar to ion channel sim config

### DIFF
--- a/obi_one/scientific/tasks/generate_simulations/config/neuron/neuron_ion_channel_models.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/neuron/neuron_ion_channel_models.py
@@ -1,6 +1,7 @@
 import logging
 from typing import ClassVar, Self
 
+from libsonata import SimulatorType
 from pydantic import Field, NonNegativeFloat, PositiveFloat, model_validator
 
 from obi_one.core.exception import OBIONEError
@@ -44,6 +45,7 @@ class IonChannelModelSimulationScanConfig(BaseSimulationScanConfig):
     name: ClassVar[str] = "Ion Channel Model Simulation Campaign"
     description: ClassVar[str] = "Ion Channel Model SONATA simulation campaign"
 
+    _target_simulator: ClassVar[SimulatorType] = SimulatorType.NEURON
     _timestep: ClassVar[PositiveFloat] = SIMULATION_TIMESTEP_MILLISECONDS
 
     json_schema_extra_additions: ClassVar[dict] = {


### PR DESCRIPTION
* Add target simulator classvar to ion channel sim config

Note that ICM could eventually inherit from the NEURON Base but then we'd have to create a new intermediate class for scale neuron and above which has a soma location