### PR TITLE
New neuron sets - Functional implementation

### DIFF
--- a/app/endpoints/circuit_properties.py
+++ b/app/endpoints/circuit_properties.py
@@ -148,8 +148,20 @@ def mapped_circuit_properties_endpoint(
         mapped_circuit_properties[CircuitMappedProperties.BIOPHYSICAL_NEURONAL_POPULATION] = (
             circuit_metrics.names_of_biophys_node_populations
         )
+        mapped_circuit_properties[CircuitMappedProperties.POINT_NEURONAL_POPULATION] = (
+            []  # TODO: Implement names_of_point_node_populations in circuit metrics
+        )
         mapped_circuit_properties[CircuitMappedProperties.VIRTUAL_NEURONAL_POPULATION] = (
             circuit_metrics.names_of_virtual_node_populations
+        )
+        mapped_circuit_properties[CircuitMappedProperties.NONVIRTUAL_NEURONAL_POPULATION] = (
+            circuit_metrics.names_of_biophys_node_populations
+            + []  # TODO: Implement names_of_point_node_populations in circuit metrics
+        )
+        mapped_circuit_properties[CircuitMappedProperties.NEURONAL_POPULATION] = (
+            circuit_metrics.names_of_biophys_node_populations
+            + []  # TODO: Implement names_of_point_node_populations in circuit metrics
+            + circuit_metrics.names_of_virtual_node_populations
         )
         mapped_circuit_properties[
             CircuitMappedProperties.NODE_PROPERTY_UNIQUE_VALUES_BY_POPULATION

--- a/app/endpoints/circuit_properties.py
+++ b/app/endpoints/circuit_properties.py
@@ -149,18 +149,18 @@ def mapped_circuit_properties_endpoint(
             circuit_metrics.names_of_biophys_node_populations
         )
         mapped_circuit_properties[CircuitMappedProperties.POINT_NEURONAL_POPULATION] = (
-            []  # TODO: Implement names_of_point_node_populations in circuit metrics
+            circuit_metrics.names_of_point_node_populations
         )
         mapped_circuit_properties[CircuitMappedProperties.VIRTUAL_NEURONAL_POPULATION] = (
             circuit_metrics.names_of_virtual_node_populations
         )
         mapped_circuit_properties[CircuitMappedProperties.NONVIRTUAL_NEURONAL_POPULATION] = (
             circuit_metrics.names_of_biophys_node_populations
-            + []  # TODO: Implement names_of_point_node_populations in circuit metrics
+            + circuit_metrics.names_of_point_node_populations
         )
         mapped_circuit_properties[CircuitMappedProperties.NEURONAL_POPULATION] = (
             circuit_metrics.names_of_biophys_node_populations
-            + []  # TODO: Implement names_of_point_node_populations in circuit metrics
+            + circuit_metrics.names_of_point_node_populations
             + circuit_metrics.names_of_virtual_node_populations
         )
         mapped_circuit_properties[
@@ -169,6 +169,7 @@ def mapped_circuit_properties_endpoint(
             pop.name: pop.property_unique_values
             for pop in (
                 *circuit_metrics.biophysical_node_populations,
+                *circuit_metrics.point_node_populations,
                 *circuit_metrics.virtual_node_populations,
             )
             if pop is not None
@@ -216,20 +217,24 @@ def mapped_circuit_properties_endpoint(
                     circuit_metrics.names_of_biophys_node_populations
                 )
                 > 0,
-                # TODO: Use point neuron populations from circuit_metrics
-                CircuitUsability.SHOW_POINT_NEURON_SETS: False,
+                CircuitUsability.SHOW_POINT_NEURON_SETS: len(
+                    circuit_metrics.names_of_point_node_populations
+                )
+                > 0,
                 CircuitUsability.SHOW_VIRTUAL_NEURON_SETS: len(
                     circuit_metrics.names_of_virtual_node_populations
                 )
                 > 0,
                 CircuitUsability.SHOW_NONVIRTUAL_NEURON_SETS: (
                     len(circuit_metrics.names_of_biophys_node_populations)
-                )  # TODO: Include point neuron populations
+                    + len(circuit_metrics.names_of_point_node_populations)
+                )
                 > 0,
                 CircuitUsability.SHOW_NEURON_SETS: (
                     len(circuit_metrics.names_of_biophys_node_populations)
+                    + len(circuit_metrics.names_of_point_node_populations)
                     + len(circuit_metrics.names_of_virtual_node_populations)
-                )  # TODO: Include point neuron populations
+                )
                 > 0,
             }
             mapped_circuit_properties["usability"] = simulation_options_usability
@@ -252,6 +257,8 @@ def mapped_circuit_properties_endpoint(
             CircuitUsability.SHOW_BIOPHYSICAL_NEURON_SETS: False,
             CircuitUsability.SHOW_POINT_NEURON_SETS: False,
             CircuitUsability.SHOW_VIRTUAL_NEURON_SETS: False,
+            CircuitUsability.SHOW_NONVIRTUAL_NEURON_SETS: False,
+            CircuitUsability.SHOW_NEURON_SETS: False,
         }
 
     return mapped_circuit_properties

--- a/app/endpoints/circuit_properties.py
+++ b/app/endpoints/circuit_properties.py
@@ -1,3 +1,4 @@
+import logging
 from http import HTTPStatus
 from typing import Annotated
 
@@ -23,6 +24,8 @@ from obi_one.scientific.library.entity_property_types import (
 from obi_one.scientific.library.memodel_circuit import (
     try_get_mechanism_variables,
 )
+
+L = logging.getLogger(__name__)
 
 INPUT_RESISTANCE_DYNAMIC_PARAM = "input_resistance"
 router = APIRouter(prefix="/declared", tags=["declared"], dependencies=[Depends(user_verified)])
@@ -161,8 +164,11 @@ def mapped_circuit_properties_endpoint(
     except (entitysdk.exception.EntitySDKError, ValueError):
         # Expected for MEModel entities or entities without proper circuit configuration
         # Continue to try mechanism variables
-        L.info(f"Could not retrieve circuit metrics for entity {circuit_id}. This may be expected if the entity is not a Circuit or is missing circuit configuration.")
-        pass
+        L.info(
+            f"Could not retrieve circuit metrics for entity {circuit_id}."
+            " This may be expected if the entity is not a Circuit"
+            " or is missing circuit configuration.",
+        )
 
     # Try fetching mechanism variables (succeeds for MEModel entities).
     mechanism_variables_response = try_get_mechanism_variables(
@@ -198,10 +204,20 @@ def mapped_circuit_properties_endpoint(
                     circuit_metrics.names_of_biophys_node_populations
                 )
                 > 0,
+                # TODO: Use point neuron populations from circuit_metrics
                 CircuitUsability.SHOW_POINT_NEURON_SETS: False,
                 CircuitUsability.SHOW_VIRTUAL_NEURON_SETS: len(
                     circuit_metrics.names_of_virtual_node_populations
                 )
+                > 0,
+                CircuitUsability.SHOW_NONVIRTUAL_NEURON_SETS: (
+                    len(circuit_metrics.names_of_biophys_node_populations)
+                )  # TODO: Include point neuron populations
+                > 0,
+                CircuitUsability.SHOW_NEURON_SETS: (
+                    len(circuit_metrics.names_of_biophys_node_populations)
+                    + len(circuit_metrics.names_of_virtual_node_populations)
+                )  # TODO: Include point neuron populations
                 > 0,
             }
             mapped_circuit_properties["usability"] = simulation_options_usability
@@ -213,6 +229,8 @@ def mapped_circuit_properties_endpoint(
                 CircuitUsability.SHOW_BIOPHYSICAL_NEURON_SETS: False,
                 CircuitUsability.SHOW_POINT_NEURON_SETS: False,
                 CircuitUsability.SHOW_VIRTUAL_NEURON_SETS: False,
+                CircuitUsability.SHOW_NONVIRTUAL_NEURON_SETS: False,
+                CircuitUsability.SHOW_NEURON_SETS: False,
             }
     else:
         # For MEModel entities, set default usability

--- a/examples/B_blocks/neuron_set_2_example.ipynb
+++ b/examples/B_blocks/neuron_set_2_example.ipynb
@@ -68,7 +68,7 @@
    "outputs": [],
    "source": [
     "from obi_one.scientific.blocks.neuron_sets_2.combined import BiophysicalCombinedNeuronSet, SetOperation\n",
-    "from obi_one.scientific.blocks.neuron_sets_2.id import IDNeuronSet, BiophysicalIDNeuronSet\n",
+    "from obi_one.scientific.blocks.neuron_sets_2.id import BiophysicalIDNeuronSet\n",
     "from obi_one.scientific.blocks.neuron_sets_2.population import PopulationNeuronSet, BiophysicalPopulationNeuronSet\n",
     "from obi_one.scientific.blocks.neuron_sets_2.predefined import PredefinedNeuronSet, PredefinedPopulationNeuronSet, PredefinedVirtualPopulationNeuronSet\n",
     "from obi_one.scientific.blocks.neuron_sets_2.property import PropertyNeuronSet\n",

--- a/examples/B_blocks/neuron_set_2_example.ipynb
+++ b/examples/B_blocks/neuron_set_2_example.ipynb
@@ -67,12 +67,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from obi_one.scientific.blocks.neuron_sets_2.population import PopulationNeuronSet, BiophysicalPopulationNeuronSet\n",
-    "from obi_one.scientific.blocks.neuron_sets_2.predefined import PredefinedNeuronSet, PredefinedPopulationNeuronSet\n",
+    "from obi_one.scientific.blocks.neuron_sets_2.combined import BiophysicalCombinedNeuronSet, SetOperation\n",
     "from obi_one.scientific.blocks.neuron_sets_2.id import IDNeuronSet, BiophysicalIDNeuronSet\n",
+    "from obi_one.scientific.blocks.neuron_sets_2.population import PopulationNeuronSet, BiophysicalPopulationNeuronSet\n",
+    "from obi_one.scientific.blocks.neuron_sets_2.predefined import PredefinedNeuronSet, PredefinedPopulationNeuronSet, PredefinedVirtualPopulationNeuronSet\n",
     "from obi_one.scientific.blocks.neuron_sets_2.property import PropertyNeuronSet\n",
     "from obi_one.scientific.blocks.neuron_sets_2.property import NeuronPropertyFilter\n",
     "from obi_one.scientific.blocks.neuron_sets_2.specific import AllNeurons, AllBiophysicalNeurons\n",
+    "from obi_one.scientific.unions.unions_neuron_sets_2 import BiophysicalNeuronSetReference\n",
     "from obi_one.core.tuple import NamedTuple"
    ]
   },
@@ -175,6 +177,24 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Wrong population type\n",
+    "nset = PredefinedVirtualPopulationNeuronSet(\n",
+    "    node_set=\"Layer6\", population=\"S1nonbarrel_neurons\", sample_percentage=50, sample_seed=42\n",
+    ")\n",
+    "\n",
+    "# This should raise a ValueError about wrong population type\n",
+    "try:\n",
+    "    nset_def, combined = nset.get_node_set_definition(circuit)\n",
+    "except ValueError as e:\n",
+    "    print(f\"Caught expected error: {e}\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -250,11 +270,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from obi_one.scientific.blocks.neuron_sets_2.combined import (\n",
-    "    BiophysicalCombinedNeuronSet, SetOperation,\n",
-    ")\n",
-    "from obi_one.scientific.unions.unions_neuron_sets_2 import BiophysicalNeuronSetReference\n",
-    "\n",
     "# Create two base neuron sets to combine\n",
     "nset_a = PredefinedPopulationNeuronSet(node_set=\"All\", population=\"S1nonbarrel_neurons\", sample_percentage=50, sample_seed=0)\n",
     "nset_a.set_block_name(\"nset_a\")\n",
@@ -362,6 +377,29 @@
     "    combined_x.get_neuron_ids(circuit)\n",
     "except ValueError as e:\n",
     "    print(f\"Caught expected error: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create two base neuron sets to combine\n",
+    "nset_a = PredefinedPopulationNeuronSet(node_set=\"All\", population=\"S1nonbarrel_neurons\", sample_percentage=50, sample_seed=0)\n",
+    "nset_a.set_block_name(\"nset_a\")\n",
+    "\n",
+    "nset_b = PredefinedPopulationNeuronSet(node_set=\"All\", population=\"S1nonbarrel_neurons\", sample_percentage=50, sample_seed=1)\n",
+    "nset_b.set_block_name(\"nset_b\")\n",
+    "\n",
+    "# Wrap in BlockReferences (as required by the combined neuron set fields)\n",
+    "ref_a = BiophysicalNeuronSetReference(block_dict_name=\"neuron_sets\", block_name=\"nset_a\")\n",
+    "ref_a.block = nset_a\n",
+    "ref_b = BiophysicalNeuronSetReference(block_dict_name=\"neuron_sets\", block_name=\"nset_b\")\n",
+    "ref_b.block = nset_b\n",
+    "\n",
+    "print(f\"Set A (50%, seed 0): {nset_a.get_neuron_ids(circuit)}\")\n",
+    "print(f\"Set B (50%, seed 1): {nset_b.get_neuron_ids(circuit)}\")"
    ]
   },
   {

--- a/examples/B_blocks/neuron_set_2_example.ipynb
+++ b/examples/B_blocks/neuron_set_2_example.ipynb
@@ -138,6 +138,7 @@
    "outputs": [],
    "source": [
     "nset = PredefinedNeuronSet(node_set=\"AllPopulations\")\n",
+    "nset.set_block_name(\"nset\")\n",
     "\n",
     "ids = nset.get_neuron_ids(circuit)\n",
     "nset_def, combined = nset.get_node_set_definition(circuit)\n",
@@ -380,16 +381,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### (i) CombinedNeuronSet — union kept symbolic"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Create two base neuron sets to combine\n",
-    "nset_a = PredefinedPopulationNeuronSet(node_set=\"All\", population=\"S1nonbarrel_neurons\", sample_percentage=50, sample_seed=0)\n",
+    "nset_a = PredefinedPopulationNeuronSet(node_set=\"Layer3\", population=\"S1nonbarrel_neurons\")\n",
     "nset_a.set_block_name(\"nset_a\")\n",
     "\n",
-    "nset_b = PredefinedPopulationNeuronSet(node_set=\"All\", population=\"S1nonbarrel_neurons\", sample_percentage=50, sample_seed=1)\n",
+    "nset_b = PredefinedPopulationNeuronSet(node_set=\"Layer6\", population=\"S1nonbarrel_neurons\")\n",
     "nset_b.set_block_name(\"nset_b\")\n",
     "\n",
     "# Wrap in BlockReferences (as required by the combined neuron set fields)\n",
@@ -398,15 +406,26 @@
     "ref_b = BiophysicalNeuronSetReference(block_dict_name=\"neuron_sets\", block_name=\"nset_b\")\n",
     "ref_b.block = nset_b\n",
     "\n",
-    "print(f\"Set A (50%, seed 0): {nset_a.get_neuron_ids(circuit)}\")\n",
-    "print(f\"Set B (50%, seed 1): {nset_b.get_neuron_ids(circuit)}\")"
+    "print(f\"Set A ({nset_a.node_set}): {nset_a.get_node_set_definition(circuit)}\")\n",
+    "print(f\"Set B ({nset_b.node_set}): {nset_b.get_node_set_definition(circuit)}\")\n",
+    "\n",
+    "combined_union = BiophysicalCombinedNeuronSet(\n",
+    "    base_neuron_set=ref_a, combined_with=ref_b, operation=SetOperation.UNION\n",
+    ")\n",
+    "combined_union.set_block_name(\"union_ab\")\n",
+    "print(\"Union:\")\n",
+    "print(f\"  Node set def: {combined_union.get_node_set_definition(circuit)}\")\n",
+    "\n",
+    "# Add to circuit and resolve\n",
+    "nset_name, sonata_circuit = combined_union.add_node_set_definition_to_sonata_circuit(circuit)\n",
+    "ntab = sonata_circuit.nodes[\"S1nonbarrel_neurons\"].get(nset_name)\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### (i) AllNeurons — select all neurons (specific neuron sets)"
+    "#### (j) AllNeurons — select all neurons (specific neuron sets)"
    ]
   },
   {
@@ -459,7 +478,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### (j) Writing a node set to file"
+    "#### (k) Writing a node set to file"
    ]
   },
   {
@@ -510,7 +529,7 @@
     "    population=\"S1nonbarrel_neurons\",\n",
     "    property_filter=NeuronPropertyFilter(filter_dict={\"layer\": [\"6\"], \"synapse_class\": [\"EXC\"]}),\n",
     ")\n",
-    "nset.set_block_name(\"L6_EXC_added\")\n",
+    "nset.set_block_name(\"L6_EXC\")\n",
     "\n",
     "nset_name, sonata_circuit = nset.add_node_set_definition_to_sonata_circuit(circuit)\n",
     "print(f\"Added node set '{nset_name}' to SONATA circuit\")\n",

--- a/examples/B_blocks/neuron_set_2_example.ipynb
+++ b/examples/B_blocks/neuron_set_2_example.ipynb
@@ -515,7 +515,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### (k) Adding a node set definition to a SONATA circuit object"
+    "#### (l) Adding a node set definition to a SONATA circuit object"
    ]
   },
   {

--- a/examples/B_blocks/neuron_set_2_example.ipynb
+++ b/examples/B_blocks/neuron_set_2_example.ipynb
@@ -69,10 +69,9 @@
    "source": [
     "from obi_one.scientific.blocks.neuron_sets_2.combined import BiophysicalCombinedNeuronSet, SetOperation\n",
     "from obi_one.scientific.blocks.neuron_sets_2.id import BiophysicalPopulationIDNeuronSet\n",
-    "from obi_one.scientific.blocks.neuron_sets_2.population import PopulationNeuronSet, BiophysicalPopulationNeuronSet\n",
-    "from obi_one.scientific.blocks.neuron_sets_2.predefined import PredefinedNeuronSet, PredefinedPopulationNeuronSet, VirtualPopulationPredefinedNeuronSet\n",
-    "from obi_one.scientific.blocks.neuron_sets_2.property import PropertyNeuronSet\n",
-    "from obi_one.scientific.blocks.neuron_sets_2.property import NeuronPropertyFilter\n",
+    "from obi_one.scientific.blocks.neuron_sets_2.population import BiophysicalPopulationNeuronSet\n",
+    "from obi_one.scientific.blocks.neuron_sets_2.predefined import BiophysicalPopulationPredefinedNeuronSet, PredefinedNeuronSet, VirtualPopulationPredefinedNeuronSet\n",
+    "from obi_one.scientific.blocks.neuron_sets_2.property import BiophysicalPopulationPropertyNeuronSet, NeuronPropertyFilter\n",
     "from obi_one.scientific.blocks.neuron_sets_2.specific import AllNeurons, AllBiophysicalNeurons\n",
     "from obi_one.scientific.unions.unions_neuron_sets_2 import BiophysicalNeuronSetReference\n",
     "from obi_one.core.tuple import NamedTuple"
@@ -82,7 +81,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### (a) PopulationNeuronSet — sample % from a population"
+    "#### (a) BiophysicalPopulationNeuronSet — sample % from a population"
    ]
   },
   {
@@ -91,7 +90,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nset = PopulationNeuronSet(population=\"S1nonbarrel_neurons\", sample_percentage=50, sample_seed=1)\n",
+    "nset = BiophysicalPopulationNeuronSet(population=\"S1nonbarrel_neurons\", sample_percentage=50, sample_seed=1)\n",
     "\n",
     "ids = nset.get_neuron_ids(circuit)\n",
     "nset_def, combined = nset.get_node_set_definition(circuit)\n",
@@ -105,7 +104,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### (b) PopulationNeuronSet — full population (symbolic expression)"
+    "#### (b) BiophysicalPopulationNeuronSet — full population (symbolic expression)"
    ]
   },
   {
@@ -156,7 +155,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### (d) PredefinedPopulationNeuronSet — predefined node set resolved in one population (with sampling)"
+    "#### (d) BiophysicalPopulationPredefinedNeuronSet — predefined node set resolved in one population (with sampling)"
    ]
   },
   {
@@ -165,7 +164,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nset = PredefinedPopulationNeuronSet(\n",
+    "nset = BiophysicalPopulationPredefinedNeuronSet(\n",
     "    node_set=\"Layer6\", population=\"S1nonbarrel_neurons\", sample_percentage=50, sample_seed=42\n",
     ")\n",
     "\n",
@@ -199,7 +198,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### (e) IDNeuronSet — by neuron IDs"
+    "#### (e) BiophysicalPopulationIDNeuronSet — by neuron IDs"
    ]
   },
   {
@@ -225,7 +224,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### (f) PropertyNeuronSet — by neuron properties"
+    "#### (f) BiophysicalPopulationPropertyNeuronSet — by neuron properties"
    ]
   },
   {
@@ -234,7 +233,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nset = PropertyNeuronSet(\n",
+    "nset = BiophysicalPopulationPropertyNeuronSet(\n",
     "    population=\"S1nonbarrel_neurons\",\n",
     "    property_filter=NeuronPropertyFilter(filter_dict={\"layer\": [\"6\"], \"synapse_class\": [\"EXC\"]}),\n",
     ")\n",
@@ -247,7 +246,7 @@
     "print(f\"  Node set definition: {nset_def}\")\n",
     "\n",
     "# With sampling\n",
-    "nset_sampled = PropertyNeuronSet(\n",
+    "nset_sampled = BiophysicalPopulationPropertyNeuronSet(\n",
     "    population=\"S1nonbarrel_neurons\",\n",
     "    property_filter=NeuronPropertyFilter(filter_dict={\"layer\": [\"6\"], \"synapse_class\": [\"EXC\"]}),\n",
     "    sample_percentage=50,\n",
@@ -262,7 +261,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### (g) CombinedNeuronSet — union, intersection, difference"
+    "#### (g) BiophysicalCombinedNeuronSet — union, intersection, difference"
    ]
   },
   {
@@ -272,10 +271,10 @@
    "outputs": [],
    "source": [
     "# Create two base neuron sets to combine\n",
-    "nset_a = PredefinedPopulationNeuronSet(node_set=\"All\", population=\"S1nonbarrel_neurons\", sample_percentage=50, sample_seed=0)\n",
+    "nset_a = BiophysicalPopulationPredefinedNeuronSet(node_set=\"All\", population=\"S1nonbarrel_neurons\", sample_percentage=50, sample_seed=0)\n",
     "nset_a.set_block_name(\"nset_a\")\n",
     "\n",
-    "nset_b = PredefinedPopulationNeuronSet(node_set=\"All\", population=\"S1nonbarrel_neurons\", sample_percentage=50, sample_seed=1)\n",
+    "nset_b = BiophysicalPopulationPredefinedNeuronSet(node_set=\"All\", population=\"S1nonbarrel_neurons\", sample_percentage=50, sample_seed=1)\n",
     "nset_b.set_block_name(\"nset_b\")\n",
     "\n",
     "# Wrap in BlockReferences (as required by the combined neuron set fields)\n",
@@ -384,7 +383,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### (i) CombinedNeuronSet — union kept symbolic"
+    "#### (i) BiophysicalCombinedNeuronSet — union kept symbolic"
    ]
   },
   {
@@ -394,10 +393,10 @@
    "outputs": [],
    "source": [
     "# Create two base neuron sets to combine\n",
-    "nset_a = PredefinedPopulationNeuronSet(node_set=\"Layer3\", population=\"S1nonbarrel_neurons\")\n",
+    "nset_a = BiophysicalPopulationPredefinedNeuronSet(node_set=\"Layer3\", population=\"S1nonbarrel_neurons\")\n",
     "nset_a.set_block_name(\"nset_a\")\n",
     "\n",
-    "nset_b = PredefinedPopulationNeuronSet(node_set=\"Layer6\", population=\"S1nonbarrel_neurons\")\n",
+    "nset_b = BiophysicalPopulationPredefinedNeuronSet(node_set=\"Layer6\", population=\"S1nonbarrel_neurons\")\n",
     "nset_b.set_block_name(\"nset_b\")\n",
     "\n",
     "# Wrap in BlockReferences (as required by the combined neuron set fields)\n",
@@ -525,7 +524,7 @@
    "outputs": [],
    "source": [
     "# Create a neuron set and add it directly to the SONATA circuit object\n",
-    "nset = PropertyNeuronSet(\n",
+    "nset = BiophysicalPopulationPropertyNeuronSet(\n",
     "    population=\"S1nonbarrel_neurons\",\n",
     "    property_filter=NeuronPropertyFilter(filter_dict={\"layer\": [\"6\"], \"synapse_class\": [\"EXC\"]}),\n",
     ")\n",

--- a/examples/B_blocks/neuron_set_2_example.ipynb
+++ b/examples/B_blocks/neuron_set_2_example.ipynb
@@ -1,0 +1,454 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Neuron set examples\n",
+    "\n",
+    "Examples for how to use different types of neuron sets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import obi_one as obi\n",
+    "from pathlib import Path"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### __Initialization:__ Loading a circuit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "circuit_name = \"N_10__top_nodes_dim6\"\n",
+    "\n",
+    "circuit_path_prefix = Path(\"../data/tiny_circuits\")\n",
+    "matrix_path_prefix = Path(\"../data/connectivity_matrices\")  # OPTIONAL: Connectivity matrix path only required for some of the node sets in this example notebook; can be set to None\n",
+    "\n",
+    "circuit_path = circuit_path_prefix / circuit_name / \"circuit_config.json\"\n",
+    "if matrix_path_prefix is None:\n",
+    "    matrix_path = None\n",
+    "else:\n",
+    "    matrix_path = matrix_path_prefix / circuit_name / \"connectivity_matrix.h5\"\n",
+    "circuit = obi.Circuit(name=circuit_name, path=str(circuit_path), matrix_path=str(matrix_path))\n",
+    "\n",
+    "print(f\"Circuit '{circuit}' with {circuit.sonata_circuit.nodes[circuit.default_population_name].size} neurons and {circuit.sonata_circuit.edges[circuit.default_edge_population_name].size} synapses\")\n",
+    "print(f\"Node populations: '{circuit.sonata_circuit.nodes.population_names}'\")\n",
+    "print(f\"Edge populations: '{circuit.sonata_circuit.edges.population_names}'\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### **New neuron set examples**\n",
+    "\n",
+    "The new neuron sets have `population` as a field (not a method argument).\n",
+    "They return:\n",
+    "- `dict[str, list[int]]` from `get_neuron_ids`: Neuron IDs by population\n",
+    "- `tuple[dict|list, dict]` from `get_node_set_definition`: Base expression + additional definitions in case of compound expression"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from obi_one.scientific.blocks.neuron_sets_2.population import PopulationNeuronSet, BiophysicalPopulationNeuronSet\n",
+    "from obi_one.scientific.blocks.neuron_sets_2.predefined import PredefinedNeuronSet, PredefinedPopulationNeuronSet\n",
+    "from obi_one.scientific.blocks.neuron_sets_2.id import IDNeuronSet, BiophysicalIDNeuronSet\n",
+    "from obi_one.scientific.blocks.neuron_sets_2.property import PropertyNeuronSet\n",
+    "from obi_one.scientific.blocks.neuron_sets_2.property import NeuronPropertyFilter\n",
+    "from obi_one.core.tuple import NamedTuple"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### (a) PopulationNeuronSet — sample % from a population"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nset = PopulationNeuronSet(population=\"S1nonbarrel_neurons\", sample_percentage=50, sample_seed=1)\n",
+    "\n",
+    "ids = nset.get_neuron_ids(circuit)\n",
+    "nset_def, combined = nset.get_node_set_definition(circuit)\n",
+    "print(f\"PopulationNeuronSet (50%)\")\n",
+    "print(f\"  Populations: {nset.get_populations(circuit)}\")\n",
+    "print(f\"  Neuron IDs: {ids}\")\n",
+    "print(f\"  Node set definition: {nset_def}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### (b) PopulationNeuronSet — full population (symbolic expression)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nset = BiophysicalPopulationNeuronSet(population=\"S1nonbarrel_neurons\")\n",
+    "\n",
+    "ids = nset.get_neuron_ids(circuit)\n",
+    "nset_def, combined = nset.get_node_set_definition(circuit)\n",
+    "print(f\"BiophysicalPopulationNeuronSet (100%)\")\n",
+    "print(f\"  Populations: {nset.get_populations(circuit)}\")\n",
+    "print(f\"  Neuron IDs: {ids}\")\n",
+    "print(f\"  Node set definition (symbolic): {nset_def}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### (c) PredefinedNeuronSet — use an existing node set (multi-population)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nset = PredefinedNeuronSet(node_set=\"AllPopulations\")\n",
+    "\n",
+    "ids = nset.get_neuron_ids(circuit)\n",
+    "nset_def, combined = nset.get_node_set_definition(circuit)\n",
+    "print(f\"PredefinedNeuronSet '{nset.node_set}'\")\n",
+    "print(f\"  Populations: {nset.get_populations(circuit)}\")\n",
+    "print(f\"  Neuron IDs: {ids}\")\n",
+    "print(f\"  Node set definition (symbolic): {nset_def} {combined}\")\n",
+    "\n",
+    "# Force resolve IDs\n",
+    "nset_def_resolved, combined_resolved = nset.get_node_set_definition(circuit, force_resolve_ids=True)\n",
+    "print(f\"  Node set definition (resolved): {nset_def_resolved} {combined_resolved}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### (d) PredefinedPopulationNeuronSet — predefined node set resolved in one population (with sampling)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nset = PredefinedPopulationNeuronSet(\n",
+    "    node_set=\"Layer6\", population=\"S1nonbarrel_neurons\", sample_percentage=50, sample_seed=42\n",
+    ")\n",
+    "\n",
+    "ids = nset.get_neuron_ids(circuit)\n",
+    "nset_def, combined = nset.get_node_set_definition(circuit)\n",
+    "print(f\"PredefinedPopulationNeuronSet 'Layer6' (50% sample)\")\n",
+    "print(f\"  Populations: {nset.get_populations(circuit)}\")\n",
+    "print(f\"  Neuron IDs: {ids}\")\n",
+    "print(f\"  Node set definition: {nset_def}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### (e) IDNeuronSet — by neuron IDs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nset = BiophysicalIDNeuronSet(\n",
+    "    population=\"S1nonbarrel_neurons\",\n",
+    "    neuron_ids=NamedTuple(name=\"my_ids\", elements=(0, 2, 5, 8)),\n",
+    ")\n",
+    "\n",
+    "ids = nset.get_neuron_ids(circuit)\n",
+    "nset_def, combined = nset.get_node_set_definition(circuit)\n",
+    "print(f\"BiophysicalIDNeuronSet\")\n",
+    "print(f\"  Populations: {nset.get_populations(circuit)}\")\n",
+    "print(f\"  Neuron IDs: {ids}\")\n",
+    "print(f\"  Node set definition: {nset_def}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### (f) PropertyNeuronSet — by neuron properties"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nset = PropertyNeuronSet(\n",
+    "    population=\"S1nonbarrel_neurons\",\n",
+    "    property_filter=NeuronPropertyFilter(filter_dict={\"layer\": [\"6\"], \"synapse_class\": [\"EXC\"]}),\n",
+    ")\n",
+    "\n",
+    "ids = nset.get_neuron_ids(circuit)\n",
+    "nset_def, combined = nset.get_node_set_definition(circuit)\n",
+    "print(f\"PropertyNeuronSet (layer=6, synapse_class=EXC)\")\n",
+    "print(f\"  Populations: {nset.get_populations(circuit)}\")\n",
+    "print(f\"  Neuron IDs: {ids}\")\n",
+    "print(f\"  Node set definition: {nset_def}\")\n",
+    "\n",
+    "# With sampling\n",
+    "nset_sampled = PropertyNeuronSet(\n",
+    "    population=\"S1nonbarrel_neurons\",\n",
+    "    property_filter=NeuronPropertyFilter(filter_dict={\"layer\": [\"6\"], \"synapse_class\": [\"EXC\"]}),\n",
+    "    sample_percentage=50,\n",
+    "    sample_seed=7,\n",
+    ")\n",
+    "nset_sampled.set_block_name(\"prop_nset_sampled\")\n",
+    "ids_sampled = nset_sampled.get_neuron_ids(circuit)\n",
+    "print(f\"\\n  With 50% sampling: {ids_sampled}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### (g) CombinedNeuronSet — union, intersection, difference"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from obi_one.scientific.blocks.neuron_sets_2.combined import (\n",
+    "    BiophysicalCombinedNeuronSet, SetOperation,\n",
+    ")\n",
+    "from obi_one.scientific.unions.unions_neuron_sets_2 import BiophysicalNeuronSetReference\n",
+    "\n",
+    "# Create two base neuron sets to combine\n",
+    "nset_a = PredefinedPopulationNeuronSet(node_set=\"All\", population=\"S1nonbarrel_neurons\", sample_percentage=50, sample_seed=0)\n",
+    "nset_a.set_block_name(\"nset_a\")\n",
+    "\n",
+    "nset_b = PredefinedPopulationNeuronSet(node_set=\"All\", population=\"S1nonbarrel_neurons\", sample_percentage=50, sample_seed=1)\n",
+    "nset_b.set_block_name(\"nset_b\")\n",
+    "\n",
+    "# Wrap in BlockReferences (as required by the combined neuron set fields)\n",
+    "ref_a = BiophysicalNeuronSetReference(block_dict_name=\"neuron_sets\", block_name=\"nset_a\")\n",
+    "ref_a.block = nset_a\n",
+    "ref_b = BiophysicalNeuronSetReference(block_dict_name=\"neuron_sets\", block_name=\"nset_b\")\n",
+    "ref_b.block = nset_b\n",
+    "\n",
+    "print(f\"Set A (50%, seed 0): {nset_a.get_neuron_ids(circuit)}\")\n",
+    "print(f\"Set B (50%, seed 1): {nset_b.get_neuron_ids(circuit)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Union\n",
+    "combined_union = BiophysicalCombinedNeuronSet(\n",
+    "    base_neuron_set=ref_a, combined_with=ref_b, operation=SetOperation.UNION\n",
+    ")\n",
+    "combined_union.set_block_name(\"union_ab\")\n",
+    "print(f\"Union: {combined_union.get_neuron_ids(circuit)}\")\n",
+    "print(f\"  Populations: {combined_union.get_populations(circuit)}\")\n",
+    "print(f\"  Neuron IDs: {combined_union.get_neuron_ids(circuit)}\")\n",
+    "print(f\"  Node set def: {combined_union.get_node_set_definition(circuit)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Intersection\n",
+    "combined_intersect = BiophysicalCombinedNeuronSet(\n",
+    "    base_neuron_set=ref_a, combined_with=ref_b, operation=SetOperation.INTERSECT\n",
+    ")\n",
+    "combined_intersect.set_block_name(\"intersect_ab\")\n",
+    "print(f\"Intersection: {combined_intersect.get_neuron_ids(circuit)}\")\n",
+    "print(f\"  Populations: {combined_intersect.get_populations(circuit)}\")\n",
+    "print(f\"  Neuron IDs: {combined_intersect.get_neuron_ids(circuit)}\")\n",
+    "print(f\"  Node set def: {combined_intersect.get_node_set_definition(circuit)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Difference (A - B)\n",
+    "combined_diff = BiophysicalCombinedNeuronSet(\n",
+    "    base_neuron_set=ref_a, combined_with=ref_b, operation=SetOperation.DIFF\n",
+    ")\n",
+    "combined_diff.set_block_name(\"diff_ab\")\n",
+    "print(f\"Difference (A - B): {combined_diff.get_neuron_ids(circuit)}\")\n",
+    "print(f\"  Populations: {combined_diff.get_populations(circuit)}\")\n",
+    "print(f\"  Neuron IDs: {combined_diff.get_neuron_ids(circuit)}\")\n",
+    "print(f\"  Node set def: {combined_diff.get_node_set_definition(circuit)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### (h) Recursive cycle detection in combined neuron sets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a recursive cycle: combined_x references combined_y, which references combined_x\n",
+    "combined_x = BiophysicalCombinedNeuronSet(\n",
+    "    base_neuron_set=ref_a, combined_with=ref_b, operation=SetOperation.UNION\n",
+    ")\n",
+    "combined_x.set_block_name(\"combined_x\")\n",
+    "\n",
+    "combined_y = BiophysicalCombinedNeuronSet(\n",
+    "    base_neuron_set=ref_a, combined_with=ref_b, operation=SetOperation.UNION\n",
+    ")\n",
+    "combined_y.set_block_name(\"combined_y\")\n",
+    "\n",
+    "# Now create the cycle: x references y, y references x\n",
+    "ref_x = BiophysicalNeuronSetReference(block_dict_name=\"neuron_sets\", block_name=\"combined_x\")\n",
+    "ref_x.block = combined_x\n",
+    "ref_y = BiophysicalNeuronSetReference(block_dict_name=\"neuron_sets\", block_name=\"combined_y\")\n",
+    "ref_y.block = combined_y\n",
+    "\n",
+    "# Rewire to create the cycle\n",
+    "combined_x.combined_with = ref_y  # x combines with y\n",
+    "combined_y.combined_with = ref_x  # y combines with x (CYCLE!)\n",
+    "\n",
+    "# This should raise a ValueError about recursive loop\n",
+    "try:\n",
+    "    combined_x.get_neuron_ids(circuit)\n",
+    "except ValueError as e:\n",
+    "    print(f\"Caught expected error: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### (i) Writing a node set to file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "nset = PredefinedNeuronSet(node_set=\"Layer6\")\n",
+    "nset.set_block_name(\"my_layer6_nset\")\n",
+    "\n",
+    "output_file = nset.to_node_set_file(\n",
+    "    circuit, output_path=\"./\", file_name=\"neuron_set_2_test.json\",\n",
+    "    overwrite_if_exists=True, init_empty=True\n",
+    ")\n",
+    "print(f\"Written to: {output_file}\")\n",
+    "\n",
+    "with open(output_file) as f:\n",
+    "    print(json.dumps(json.load(f), indent=2))\n",
+    "\n",
+    "# With force_resolve_ids=True\n",
+    "output_file_resolved = nset.to_node_set_file(\n",
+    "    circuit, output_path=\"./\", file_name=\"neuron_set_2_test_resolved.json\",\n",
+    "    overwrite_if_exists=True, init_empty=True, force_resolve_ids=True\n",
+    ")\n",
+    "print(f\"\\nWritten (resolved) to: {output_file_resolved}\")\n",
+    "with open(output_file_resolved) as f:\n",
+    "    print(json.dumps(json.load(f), indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### (h) Adding a node set definition to a SONATA circuit object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a neuron set and add it directly to the SONATA circuit object\n",
+    "nset = PropertyNeuronSet(\n",
+    "    population=\"S1nonbarrel_neurons\",\n",
+    "    property_filter=NeuronPropertyFilter(filter_dict={\"layer\": [\"6\"], \"synapse_class\": [\"EXC\"]}),\n",
+    ")\n",
+    "nset.set_block_name(\"L6_EXC_added\")\n",
+    "\n",
+    "nset_name, sonata_circuit = nset.add_node_set_definition_to_sonata_circuit(circuit)\n",
+    "print(f\"Added node set '{nset_name}' to SONATA circuit\")\n",
+    "print(f\"Node set content: {sonata_circuit.node_sets.content[nset_name]}\")\n",
+    "\n",
+    "# Verify it resolves correctly\n",
+    "resolved_ids = sonata_circuit.nodes['S1nonbarrel_neurons'].ids(nset_name)\n",
+    "print(f\"Resolved IDs via SONATA: {resolved_ids}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "obi-one",
+   "language": "python",
+   "name": "obi-one"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/B_blocks/neuron_set_2_example.ipynb
+++ b/examples/B_blocks/neuron_set_2_example.ipynb
@@ -72,6 +72,7 @@
     "from obi_one.scientific.blocks.neuron_sets_2.id import IDNeuronSet, BiophysicalIDNeuronSet\n",
     "from obi_one.scientific.blocks.neuron_sets_2.property import PropertyNeuronSet\n",
     "from obi_one.scientific.blocks.neuron_sets_2.property import NeuronPropertyFilter\n",
+    "from obi_one.scientific.blocks.neuron_sets_2.specific import AllNeurons, AllBiophysicalNeurons\n",
     "from obi_one.core.tuple import NamedTuple"
    ]
   },
@@ -367,7 +368,60 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### (i) Writing a node set to file"
+    "#### (i) AllNeurons — select all neurons (specific neuron sets)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# AllNeurons — all neurons from all populations\n",
+    "nset = AllNeurons()\n",
+    "nset.set_block_name(\"all_neurons\")\n",
+    "\n",
+    "ids = nset.get_neuron_ids(circuit)\n",
+    "print(f\"AllNeurons\")\n",
+    "print(f\"  Populations: {nset.get_populations(circuit)}\")\n",
+    "print(f\"  Neuron IDs: {ids}\")\n",
+    "\n",
+    "# Symbolic node set definition\n",
+    "nset_def, combined = nset.get_node_set_definition(circuit)\n",
+    "print(f\"  Node set definition (symbolic): {nset_def}\")\n",
+    "if combined:\n",
+    "    print(f\"  Combined definitions: {combined}\")\n",
+    "\n",
+    "# Force resolve IDs\n",
+    "nset_def_resolved, combined_resolved = nset.get_node_set_definition(circuit, force_resolve_ids=True)\n",
+    "print(f\"  Node set definition (resolved): {nset_def_resolved}\")\n",
+    "if combined_resolved:\n",
+    "    print(f\"  Combined definitions (resolved): {combined_resolved}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# AllBiophysicalNeurons — only biophysical populations\n",
+    "nset_bio = AllBiophysicalNeurons()\n",
+    "nset_bio.set_block_name(\"all_biophysical\")\n",
+    "\n",
+    "ids_bio = nset_bio.get_neuron_ids(circuit)\n",
+    "nset_def_bio, _ = nset_bio.get_node_set_definition(circuit)\n",
+    "print(f\"AllBiophysicalNeurons\")\n",
+    "print(f\"  Populations: {nset_bio.get_populations(circuit)}\")\n",
+    "print(f\"  Neuron IDs: {ids_bio}\")\n",
+    "print(f\"  Node set definition (symbolic): {nset_def_bio}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### (j) Writing a node set to file"
    ]
   },
   {
@@ -404,7 +458,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### (h) Adding a node set definition to a SONATA circuit object"
+    "#### (k) Adding a node set definition to a SONATA circuit object"
    ]
   },
   {

--- a/examples/B_blocks/neuron_set_2_example.ipynb
+++ b/examples/B_blocks/neuron_set_2_example.ipynb
@@ -68,9 +68,9 @@
    "outputs": [],
    "source": [
     "from obi_one.scientific.blocks.neuron_sets_2.combined import BiophysicalCombinedNeuronSet, SetOperation\n",
-    "from obi_one.scientific.blocks.neuron_sets_2.id import BiophysicalIDNeuronSet\n",
+    "from obi_one.scientific.blocks.neuron_sets_2.id import BiophysicalPopulationIDNeuronSet\n",
     "from obi_one.scientific.blocks.neuron_sets_2.population import PopulationNeuronSet, BiophysicalPopulationNeuronSet\n",
-    "from obi_one.scientific.blocks.neuron_sets_2.predefined import PredefinedNeuronSet, PredefinedPopulationNeuronSet, PredefinedVirtualPopulationNeuronSet\n",
+    "from obi_one.scientific.blocks.neuron_sets_2.predefined import PredefinedNeuronSet, PredefinedPopulationNeuronSet, VirtualPopulationPredefinedNeuronSet\n",
     "from obi_one.scientific.blocks.neuron_sets_2.property import PropertyNeuronSet\n",
     "from obi_one.scientific.blocks.neuron_sets_2.property import NeuronPropertyFilter\n",
     "from obi_one.scientific.blocks.neuron_sets_2.specific import AllNeurons, AllBiophysicalNeurons\n",
@@ -184,7 +184,7 @@
    "outputs": [],
    "source": [
     "# Wrong population type\n",
-    "nset = PredefinedVirtualPopulationNeuronSet(\n",
+    "nset = VirtualPopulationPredefinedNeuronSet(\n",
     "    node_set=\"Layer6\", population=\"S1nonbarrel_neurons\", sample_percentage=50, sample_seed=42\n",
     ")\n",
     "\n",
@@ -208,14 +208,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nset = BiophysicalIDNeuronSet(\n",
+    "nset = BiophysicalPopulationIDNeuronSet(\n",
     "    population=\"S1nonbarrel_neurons\",\n",
     "    neuron_ids=NamedTuple(name=\"my_ids\", elements=(0, 2, 5, 8)),\n",
     ")\n",
     "\n",
     "ids = nset.get_neuron_ids(circuit)\n",
     "nset_def, combined = nset.get_node_set_definition(circuit)\n",
-    "print(f\"BiophysicalIDNeuronSet\")\n",
+    "print(f\"BiophysicalPopulationIDNeuronSet\")\n",
     "print(f\"  Populations: {nset.get_populations(circuit)}\")\n",
     "print(f\"  Neuron IDs: {ids}\")\n",
     "print(f\"  Node set definition: {nset_def}\")"

--- a/examples/data/tiny_circuits/N_10__top_nodes_dim6/node_sets.json
+++ b/examples/data/tiny_circuits/N_10__top_nodes_dim6/node_sets.json
@@ -798,5 +798,16 @@
     "layer": [
       "6"
     ]
-  }
+  },
+  "AllBiophysical": {
+    "population": "S1nonbarrel_neurons"
+  },
+  "AllVirtual": [
+    "proj_Thalamocortical_VPM_Source",
+    "proj_Thalamocortical_POM_Source"
+  ],
+  "AllPopulations": [
+    "AllBiophysical",
+    "AllVirtual"
+  ]
 }

--- a/obi_one/scientific/blocks/neuron_sets_2/base.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/base.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import ClassVar
 
 import bluepysnap as snap
-import numpy as np
 
 from obi_one.core.block import Block
 from obi_one.scientific.library.circuit import Circuit
@@ -148,7 +147,7 @@ class NeuronSet(Block, abc.ABC):
         """Returns the SONATA node set expression."""
 
     @abc.abstractmethod
-    def get_neuron_ids(self, circuit: Circuit) -> dict[str, np.ndarray]:
+    def get_neuron_ids(self, circuit: Circuit) -> dict[str, list[int]]:
         """Returns list of neuron IDs per population."""
 
     def add_node_set_definition_to_sonata_circuit(

--- a/obi_one/scientific/blocks/neuron_sets_2/base.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/base.py
@@ -184,7 +184,7 @@ class NeuronSet(Block, abc.ABC):
         )
         nset_name = f"__{self.__class__.__name__}__{self.block_name}"
         nset_dict = compound_def | {nset_name: nset_def}
-        
+
         sonata_circuit = circuit.sonata_circuit
         add_node_set_to_circuit(sonata_circuit, nset_dict, overwrite_if_exists=False)
         return nset_name, sonata_circuit

--- a/obi_one/scientific/blocks/neuron_sets_2/base.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/base.py
@@ -143,12 +143,34 @@ class NeuronSet(Block, abc.ABC):
         """
 
     @abc.abstractmethod
-    def _get_expression(self, circuit: Circuit) -> dict | list:
-        """Returns the SONATA node set expression."""
-
-    @abc.abstractmethod
     def get_neuron_ids(self, circuit: Circuit) -> dict[str, list[int]]:
         """Returns list of neuron IDs per population."""
+
+    @staticmethod
+    def ids_to_node_set_definition(
+        ids_per_npop: dict[str, list[int]],
+        *,
+        prefix: str = "nset",
+        simplified: bool = True,
+    ) -> tuple[dict | list, dict]:
+        """Turns a dict of ID per population into a (compound) node set definition.
+
+        May be simplified to a single expression, if possible.
+        """
+        expression = []
+        combined = {}
+        for idx, (npop, ids) in enumerate(ids_per_npop.items()):
+            comb_key = f"{prefix}__{idx}__"
+            combined[comb_key] = {
+                "population": npop,
+                "node_id": ids,
+            }
+            expression.append(comb_key)
+        if simplified and len(expression) == 1:
+            # Simplify to single expression
+            expression = combined[expression[0]]
+            combined = {}
+        return expression, combined
 
     def add_node_set_definition_to_sonata_circuit(
         self, circuit: Circuit, *, force_resolve_ids: bool = False

--- a/obi_one/scientific/blocks/neuron_sets_2/base.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/base.py
@@ -2,9 +2,12 @@ import abc
 import json
 import logging
 import os
+from enum import StrEnum
 from pathlib import Path
+from typing import ClassVar
 
 import bluepysnap as snap
+import numpy as np
 
 from obi_one.core.block import Block
 from obi_one.scientific.library.circuit import Circuit
@@ -15,41 +18,157 @@ from obi_one.scientific.library.sonata_circuit_helpers import (
 L = logging.getLogger(__name__)
 
 
+class NeuronSetPopulationType(StrEnum):
+    BIOPHYSICAL = "biophysical"
+    POINT = "point"
+    VIRTUAL = "virtual"
+    NONVIRTUAL = "nonvirtual"
+    ANY = "any"
+
+
+class SonataPopulationType(StrEnum):
+    BIOPHYSICAL = "biophysical"
+    POINT = "point"
+    VIRTUAL = "virtual"
+
+
 class NeuronSet(Block, abc.ABC):
-    """NeuronSet  [NEW - redefined].
-
-    - New (abstract) base class for all neuron sets
-    - No sampling
-    - No node population (i.e., supports multi-population neuron sets!)
-    """
-
     """Base class representing a neuron set which can be turned into a SONATA node set by either
     adding it to an existing SONATA circuit object (add_node_set_to_circuit) or writing it to a
     SONATA node set .json file (write_circuit_node_set_file).
+
+    Has a well-defined population type (including mixtures) and may span multiple node populations
+    which are consistent with the defined type.
     """
 
-    @abc.abstractmethod
-    def _get_expression(self, circuit: Circuit) -> dict:
-        """Returns the SONATA node set expression (w/o subsampling)."""
+    _neuron_set_population_type: ClassVar[NeuronSetPopulationType]
 
-    def add_node_set_definition_to_sonata_circuit(
-        self, circuit: Circuit, sonata_circuit: snap.Circuit
-    ) -> dict:
-        nset_def = self.get_node_set_definition(circuit, force_resolve_ids=True)
+    def get_neuron_set_population_type(self) -> NeuronSetPopulationType:
+        return self._neuron_set_population_type
 
-        add_node_set_to_circuit(
-            sonata_circuit, {self.block_name: nset_def}, overwrite_if_exists=False
+    def check_populations_in_circuit(self, circuit: Circuit) -> None:
+        """Check if neuron set populations exist in circuit."""
+        # Get neuron set populations
+        nset_popul_names = self.get_populations()
+
+        # Get circuit populations of the given type
+        match self._neuron_set_population_type:
+            case NeuronSetPopulationType.BIOPHYSICAL:
+                incl_biophysical = True
+                incl_point = incl_virtual = False
+            case NeuronSetPopulationType.POINT:
+                incl_point = True
+                incl_biophysical = incl_virtual = False
+            case NeuronSetPopulationType.VIRTUAL:
+                incl_virtual = True
+                incl_biophysical = incl_point = False
+            case NeuronSetPopulationType.NONVIRTUAL:
+                incl_biophysical = incl_point = True
+                incl_virtual = False
+            case NeuronSetPopulationType.ANY:
+                incl_biophysical = incl_point = incl_virtual = True
+            case _:
+                msg = f"Unknown neuron set population type '{self._neuron_set_population_type}'!"
+                raise ValueError(msg)
+        circuit_popul_names = Circuit.get_node_population_names(
+            circuit.sonata_circuit,
+            incl_biophysical=incl_biophysical,
+            incl_point=incl_point,
+            incl_virtual=incl_virtual,
         )
 
-        return nset_def
+        # Check circuit populations
+        if not circuit_popul_names:
+            msg = (
+                f"Circuit '{circuit.name}' does not have any node populations"
+                f" of type '{self._neuron_set_population_type}'!"
+            )
+            raise ValueError(msg)
+
+        # Check neuron set populations
+        missing = [f"'{p}'" for p in nset_popul_names if p not in circuit_popul_names]
+        if missing:
+            msg = (
+                f"Node population(s) {', '.join(missing)}"
+                f" of type '{self._neuron_set_population_type}'"
+                f" not found in circuit '{circuit.name}'!"
+                f" Available node populations: {', '.join(circuit_popul_names)}"
+            )
+            raise ValueError(msg)
+
+    def get_population_types(self, circuit: Circuit) -> dict[str, SonataPopulationType]:
+        """Returns population names and types included in the neuron set."""
+        self.check_populations_in_circuit(circuit=circuit)
+
+        popul_types = {}
+        for pname in self.get_populations():
+            if circuit.sonata_circuit.nodes[pname].type == "biophysical":
+                ptype = SonataPopulationType.BIOPHYSICAL
+            elif circuit.sonata_circuit.nodes[pname].type == "virtual":
+                ptype = SonataPopulationType.VIRTUAL
+            elif circuit.sonata_circuit.nodes[pname].type.startswith("point_"):
+                ptype = SonataPopulationType.POINT
+            else:
+                msg = f"Unknown SONATA population type for population '{pname}'!"
+                raise ValueError(msg)
+            popul_types[pname] = ptype
+        return popul_types
+
+    def has_biophysical_neurons(self, circuit: Circuit) -> bool:
+        """Returns if the neuron set includes biophysical populations."""
+        popul_types = self.get_population_types(circuit=circuit)
+        return any(ptype == SonataPopulationType.BIOPHYSICAL for ptype in popul_types.values())
+
+    def has_virtual_neurons(self, circuit: Circuit) -> bool:
+        """Returns if the neuron set includes virtual populations."""
+        popul_types = self.get_population_types(circuit=circuit)
+        return any(ptype == SonataPopulationType.VIRTUAL for ptype in popul_types.values())
+
+    def has_point_neurons(self, circuit: Circuit) -> bool:
+        """Returns if the neuron set includes point populations."""
+        popul_types = self.get_population_types(circuit=circuit)
+        return any(ptype == SonataPopulationType.POINT for ptype in popul_types.values())
+
+    @abc.abstractmethod
+    def get_populations(self) -> list[str]:
+        """Returns population names included in the neuron set."""
+
+    @abc.abstractmethod
+    def get_node_set_definition(
+        self, circuit: Circuit, *, force_resolve_ids: bool = False
+    ) -> tuple[dict | list, dict]:
+        """Returns the SONATA node set definition, optionally forcing to resolve individual IDs.
+
+        In case of a compound expression (list expression), any new definitions
+        to be combined are returned as dict.
+        """
+
+    @abc.abstractmethod
+    def get_neuron_ids(self, circuit: Circuit) -> dict[str, np.ndarray]:
+        """Returns list of neuron IDs per population."""
+
+    def add_node_set_definition_to_sonata_circuit(
+        self, circuit: Circuit, *, force_resolve_ids: bool = False
+    ) -> tuple[str, snap.Circuit]:
+        """Adds the node set definition to the corresponding SONATA circuit object."""
+        if not self.has_block_name():
+            msg = "Block name undefined. NeuronSet must be set through a Task."
+            raise ValueError(msg)
+        nset_def, compound_def = self.get_node_set_definition(
+            circuit, force_resolve_ids=force_resolve_ids
+        )
+        nset_dict = compound_def | {self.block_name: nset_def}
+        sonata_circuit = circuit.sonata_circuit
+        add_node_set_to_circuit(sonata_circuit, nset_dict, overwrite_if_exists=False)
+        return self.block_name, sonata_circuit
 
     @staticmethod
-    def _get_output_file(circuit: Circuit, file_name: str | None, output_path: str) -> str:
+    def _get_output_file(circuit: Circuit, file_name: str | None, output_path: str) -> Path:
         if file_name is None:
             # Use circuit's node set file name by default
             file_name = os.path.split(circuit.sonata_circuit.config["node_sets_file"])[1]
         else:
-            if not isinstance(file_name, str) or len(file_name) == 0:
+            if len(file_name) == 0:
                 msg = (
                     "File name must be a non-empty string! Can be omitted to use default file name."
                 )
@@ -60,6 +179,14 @@ class NeuronSet(Block, abc.ABC):
                 raise ValueError(msg)
         output_file = Path(output_path) / file_name
         return output_file
+
+    @staticmethod
+    def _check_existing(new_node_sets: dict, existing_node_sets: dict) -> None:
+        """Checks if new names already exist."""
+        existing = [f"'{n}'" for n in new_node_sets if n in existing_node_sets]
+        if existing:
+            msg = f"Node set(s) {', '.join(existing)} already existing!"
+            raise ValueError(msg)
 
     def to_node_set_file(
         self,
@@ -72,50 +199,40 @@ class NeuronSet(Block, abc.ABC):
         force_resolve_ids: bool = False,
         init_empty: bool = False,
         optional_node_set_name: str | None = None,
-    ) -> str:
+    ) -> Path:
         """Resolves the node set for a given circuit and writes it to a .json node set file."""
         if optional_node_set_name is not None:
             node_set_name = optional_node_set_name
         elif self.has_block_name():
             node_set_name = self.block_name
         else:
-            msg = (
-                "NeuronSet name must be set through the Simulation"
-                " or optional_node_set_name parameter!"
-            )
+            msg = "NeuronSet name must be set through a Task or optional_node_set_name parameter!"
             raise ValueError(msg)
 
-        output_file = self._get_output_file(circuit, file_name, output_path)
+        output_file = NeuronSet._get_output_file(circuit, file_name, output_path)
 
         if overwrite_if_exists and append_if_exists:
             msg = "Append and overwrite options are mutually exclusive!"
             raise ValueError(msg)
-        expression = self.get_node_set_definition(circuit, force_resolve_ids=force_resolve_ids)
-        if expression is None:
-            msg = "Node set already exists in circuit, nothing to be done!"
-            raise ValueError(msg)
 
-        if not Path.exists(output_file) or overwrite_if_exists:
+        nset_def, compound_def = self.get_node_set_definition(
+            circuit, force_resolve_ids=force_resolve_ids
+        )
+        nset_dict = compound_def | {node_set_name: nset_def}
+
+        if not output_file.exists() or overwrite_if_exists:
             # Create new node sets file, overwrite if existing
-            if init_empty:
+            if init_empty:  # noqa: SIM108
                 # Initialize empty
                 node_sets = {}
             else:
                 # Initialize with circuit object's node sets
                 node_sets = circuit.sonata_circuit.node_sets.content
-                if node_set_name in node_sets:
-                    msg = f"Node set '{node_set_name}' already exists in circuit '{circuit}'!"
-                    raise ValueError(msg)
-            node_sets.update({node_set_name: expression})
 
-        elif Path.exists(output_file) and append_if_exists:
+        elif output_file.exists() and append_if_exists:
             # Append to existing node sets file
-            with Path(output_file).open("r", encoding="utf-8") as f:
+            with output_file.open("r", encoding="utf-8") as f:
                 node_sets = json.load(f)
-                if node_set_name in node_sets:
-                    msg = f"Appending not possible, node set '{node_set_name}' already exists!"
-                    raise ValueError(msg)
-                node_sets.update({node_set_name: expression})
 
         else:  # File existing but no option chosen
             msg = (
@@ -124,7 +241,10 @@ class NeuronSet(Block, abc.ABC):
             )
             raise ValueError(msg)
 
-        with Path(output_file).open("w", encoding="utf-8") as f:
+        NeuronSet._check_existing(nset_dict, node_sets)
+        node_sets.update(nset_dict)
+
+        with output_file.open("w", encoding="utf-8") as f:
             json.dump(node_sets, f, indent=2)
 
         return output_file

--- a/obi_one/scientific/blocks/neuron_sets_2/base.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/base.py
@@ -138,8 +138,27 @@ class NeuronSet(Block, abc.ABC):
     ) -> tuple[dict | list, dict]:
         """Returns the SONATA node set definition, optionally forcing to resolve individual IDs.
 
-        In case of a compound expression (list expression), any new definitions
-        to be combined are returned as dict.
+        Returns a tuple of (expression, combined) where:
+
+        - expression (dict): A single SONATA node set expression. Examples:
+            - Symbolic by population: {"population": "pop_name"}
+            - Symbolic by properties: {"layer": "6", "synapse_class": "EXC"}
+            - Resolved IDs: {"population": "pop_name", "node_id": [1, 2, 3]}
+
+        - expression (list): A compound expression referencing multiple named node sets.
+            Example: ["__ClassName__blockname__0__", "__ClassName__blockname__1__"]
+            Each name must exist as a key in the combined dict.
+            Also used for symbolic references to existing node sets: ["Layer6"]
+
+        - combined (dict): Additional node set definitions needed by a compound expression.
+            Example: {"__ClassName__blockname__0__": {"population": "A", "node_id": [...]},
+                      "__ClassName__blockname__1__": {"population": "B", "node_id": [...]}}
+            Empty ({}) when expression is a single dict.
+
+        Args:
+            circuit: The circuit to resolve the node set in.
+            force_resolve_ids: If True, always resolve to explicit neuron IDs
+                instead of preserving symbolic expressions.
         """
 
     @abc.abstractmethod

--- a/obi_one/scientific/blocks/neuron_sets_2/base.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/base.py
@@ -182,10 +182,12 @@ class NeuronSet(Block, abc.ABC):
         nset_def, compound_def = self.get_node_set_definition(
             circuit, force_resolve_ids=force_resolve_ids
         )
-        nset_dict = compound_def | {self.block_name: nset_def}
+        nset_name = f"__{self.__class__.__name__}__{self.block_name}"
+        nset_dict = compound_def | {nset_name: nset_def}
+        
         sonata_circuit = circuit.sonata_circuit
         add_node_set_to_circuit(sonata_circuit, nset_dict, overwrite_if_exists=False)
-        return self.block_name, sonata_circuit
+        return nset_name, sonata_circuit
 
     @staticmethod
     def _get_output_file(circuit: Circuit, file_name: str | None, output_path: str) -> Path:
@@ -229,7 +231,7 @@ class NeuronSet(Block, abc.ABC):
         if optional_node_set_name is not None:
             node_set_name = optional_node_set_name
         elif self.has_block_name():
-            node_set_name = self.block_name
+            node_set_name = f"__{self.__class__.__name__}__{self.block_name}"
         else:
             msg = "NeuronSet name must be set through a Task or optional_node_set_name parameter!"
             raise ValueError(msg)

--- a/obi_one/scientific/blocks/neuron_sets_2/base.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/base.py
@@ -246,7 +246,38 @@ class NeuronSet(Block, abc.ABC):
         init_empty: bool = False,
         optional_node_set_name: str | None = None,
     ) -> Path:
-        """Resolves the node set for a given circuit and writes it to a .json node set file."""
+        """Resolves the neuron set for a given circuit and writes it to a .json node set file.
+
+        The node set name in the output file defaults to
+        ``__{ClassName}__{block_name}`` unless overridden via ``optional_node_set_name``.
+
+        Args:
+            circuit: The circuit to resolve the neuron set in.
+            output_path: Directory where the output file will be written.
+            file_name: Output file name. If None, uses the circuit's node set file name.
+            overwrite_if_exists: If True, overwrite an existing file. Mutually exclusive
+                with append_if_exists.
+            append_if_exists: If True, append to an existing file. The node set name
+                must not already exist in the file.
+            force_resolve_ids: If True, resolve to explicit neuron IDs instead of
+                preserving symbolic expressions.
+            init_empty: If True, start with an empty file (ignore circuit's existing
+                node sets). Only applies when creating a new file or overwriting.
+            optional_node_set_name: Override the auto-generated node set name.
+
+        Returns:
+            Path to the written output file.
+
+        Note:
+            If the neuron set consists of a compound expression (list + combined dict),
+            all entries from the combined dict are written to the file alongside the main
+            node set entry. This ensures the compound expression references are resolvable.
+
+        Raises:
+            ValueError: If neither block_name nor optional_node_set_name is set,
+                if overwrite and append are both True, or if the file exists without
+                either option specified.
+        """
         if optional_node_set_name is not None:
             node_set_name = optional_node_set_name
         elif self.has_block_name():

--- a/obi_one/scientific/blocks/neuron_sets_2/base.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/base.py
@@ -49,7 +49,7 @@ class NeuronSet(Block, abc.ABC):
     def check_populations_in_circuit(self, circuit: Circuit) -> None:
         """Check if neuron set populations exist in circuit."""
         # Get neuron set populations
-        nset_popul_names = self.get_populations()
+        nset_popul_names = self.get_populations(circuit)
 
         # Get circuit populations of the given type
         match self._neuron_set_population_type:
@@ -101,7 +101,7 @@ class NeuronSet(Block, abc.ABC):
         self.check_populations_in_circuit(circuit=circuit)
 
         popul_types = {}
-        for pname in self.get_populations():
+        for pname in self.get_populations(circuit):
             if circuit.sonata_circuit.nodes[pname].type == "biophysical":
                 ptype = SonataPopulationType.BIOPHYSICAL
             elif circuit.sonata_circuit.nodes[pname].type == "virtual":
@@ -130,7 +130,7 @@ class NeuronSet(Block, abc.ABC):
         return any(ptype == SonataPopulationType.POINT for ptype in popul_types.values())
 
     @abc.abstractmethod
-    def get_populations(self) -> list[str]:
+    def get_populations(self, circuit: Circuit) -> list[str]:
         """Returns population names included in the neuron set."""
 
     @abc.abstractmethod
@@ -142,6 +142,10 @@ class NeuronSet(Block, abc.ABC):
         In case of a compound expression (list expression), any new definitions
         to be combined are returned as dict.
         """
+
+    @abc.abstractmethod
+    def _get_expression(self, circuit: Circuit) -> dict | list:
+        """Returns the SONATA node set expression."""
 
     @abc.abstractmethod
     def get_neuron_ids(self, circuit: Circuit) -> dict[str, np.ndarray]:

--- a/obi_one/scientific/blocks/neuron_sets_2/combined.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/combined.py
@@ -6,6 +6,7 @@ from typing import ClassVar, Literal
 import numpy as np
 from pydantic import Field
 
+from obi_one.core.block_reference import BlockReference
 from obi_one.core.schema import SchemaKey, UIElement
 from obi_one.scientific.blocks.neuron_sets_2.base import NeuronSet, NeuronSetPopulationType
 from obi_one.scientific.library.circuit import Circuit
@@ -13,20 +14,20 @@ from obi_one.scientific.library.entity_property_types import (
     CircuitUsability,
     MappedPropertiesGroup,
 )
-from obi_one.scientific.unions.unions_neuron_sets_2 import (
-    ALL_NEURON_SETS_REFERENCE_TYPES,
-    ALL_NEURON_SETS_REFERENCE_UNION,
-    BIOPHYSICAL_NEURON_SETS_REFERENCE_TYPES,
-    BIOPHYSICAL_NEURON_SETS_REFERENCE_UNION,
-    NON_VIRTUAL_NEURON_SETS_REFERENCE_TYPES,
-    NON_VIRTUAL_NEURON_SETS_REFERENCE_UNION,
-    POINT_NEURON_SETS_REFERENCE_TYPES,
-    POINT_NEURON_SETS_REFERENCE_UNION,
-    VIRTUAL_NEURON_SETS_REFERENCE_TYPES,
-    VIRTUAL_NEURON_SETS_REFERENCE_UNION,
-)
 
 L = logging.getLogger("obi-one")
+
+# Reference type names as strings to avoid circular imports with unions module.
+# These must match the class names defined in unions_neuron_sets_2.py.
+_BIOPHYSICAL_REF = "BiophysicalNeuronSetReference"
+_VIRTUAL_REF = "VirtualNeuronSetReference"
+_POINT_REF = "PointNeuronSetReference"
+
+_ALL_REFERENCE_TYPES = [_BIOPHYSICAL_REF, _VIRTUAL_REF, _POINT_REF]
+_NON_VIRTUAL_REFERENCE_TYPES = [_BIOPHYSICAL_REF, _POINT_REF]
+_BIOPHYSICAL_REFERENCE_TYPES = [_BIOPHYSICAL_REF]
+_VIRTUAL_REFERENCE_TYPES = [_VIRTUAL_REF]
+_POINT_REFERENCE_TYPES = [_POINT_REF]
 
 _MAX_COMBINED_DEPTH = 10
 
@@ -47,8 +48,8 @@ _OPERATION_MAP = {
 class CombinedBaseNeuronSet(NeuronSet, abc.ABC):
     """Abstract base class for combining neuron sets within and across node populations."""
 
-    base_neuron_set: NeuronSet
-    combined_with: NeuronSet
+    base_neuron_set: BlockReference | None
+    combined_with: BlockReference | None
     operation: Literal[SetOperation.UNION, SetOperation.INTERSECT, SetOperation.DIFF] = Field(
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.STRING_SELECTION,
@@ -182,23 +183,23 @@ class CombinedNeuronSet(CombinedBaseNeuronSet):
         },
     }
 
-    base_neuron_set: ALL_NEURON_SETS_REFERENCE_UNION | None = Field(
+    base_neuron_set: BlockReference | None = Field(
         default=None,
         title="First Neuron Set",
         description="Base neuron set to be combined.",
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
-            SchemaKey.REFERENCE_TYPES: ALL_NEURON_SETS_REFERENCE_TYPES,
+            SchemaKey.REFERENCE_TYPES: _ALL_REFERENCE_TYPES,
         },
     )
 
-    combined_with: ALL_NEURON_SETS_REFERENCE_UNION | None = Field(
+    combined_with: BlockReference | None = Field(
         default=None,
         title="Second Neuron Set",
         description="Neuron set to combine with.",
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
-            SchemaKey.REFERENCE_TYPES: ALL_NEURON_SETS_REFERENCE_TYPES,
+            SchemaKey.REFERENCE_TYPES: _ALL_REFERENCE_TYPES,
         },
     )
 
@@ -221,23 +222,23 @@ class BiophysicalCombinedNeuronSet(CombinedBaseNeuronSet):
         },
     }
 
-    base_neuron_set: BIOPHYSICAL_NEURON_SETS_REFERENCE_UNION | None = Field(
+    base_neuron_set: BlockReference | None = Field(
         default=None,
         title="First Neuron Set",
         description="Base neuron set to be combined.",
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
-            SchemaKey.REFERENCE_TYPES: BIOPHYSICAL_NEURON_SETS_REFERENCE_TYPES,
+            SchemaKey.REFERENCE_TYPES: _BIOPHYSICAL_REFERENCE_TYPES,
         },
     )
 
-    combined_with: BIOPHYSICAL_NEURON_SETS_REFERENCE_UNION | None = Field(
+    combined_with: BlockReference | None = Field(
         default=None,
         title="Second Neuron Set",
         description="Neuron set to combine with.",
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
-            SchemaKey.REFERENCE_TYPES: BIOPHYSICAL_NEURON_SETS_REFERENCE_TYPES,
+            SchemaKey.REFERENCE_TYPES: _BIOPHYSICAL_REFERENCE_TYPES,
         },
     )
 
@@ -258,23 +259,23 @@ class VirtualCombinedNeuronSet(CombinedBaseNeuronSet):
         },
     }
 
-    base_neuron_set: VIRTUAL_NEURON_SETS_REFERENCE_UNION | None = Field(
+    base_neuron_set: BlockReference | None = Field(
         default=None,
         title="First Neuron Set",
         description="Base neuron set to be combined.",
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
-            SchemaKey.REFERENCE_TYPES: VIRTUAL_NEURON_SETS_REFERENCE_TYPES,
+            SchemaKey.REFERENCE_TYPES: _VIRTUAL_REFERENCE_TYPES,
         },
     )
 
-    combined_with: VIRTUAL_NEURON_SETS_REFERENCE_UNION | None = Field(
+    combined_with: BlockReference | None = Field(
         default=None,
         title="Second Neuron Set",
         description="Neuron set to combine with.",
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
-            SchemaKey.REFERENCE_TYPES: VIRTUAL_NEURON_SETS_REFERENCE_TYPES,
+            SchemaKey.REFERENCE_TYPES: _VIRTUAL_REFERENCE_TYPES,
         },
     )
 
@@ -297,23 +298,23 @@ class NonVirtualCombinedNeuronSet(CombinedBaseNeuronSet):
         },
     }
 
-    base_neuron_set: NON_VIRTUAL_NEURON_SETS_REFERENCE_UNION | None = Field(
+    base_neuron_set: BlockReference | None = Field(
         default=None,
         title="First Neuron Set",
         description="Base neuron set to be combined.",
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
-            SchemaKey.REFERENCE_TYPES: NON_VIRTUAL_NEURON_SETS_REFERENCE_TYPES,
+            SchemaKey.REFERENCE_TYPES: _NON_VIRTUAL_REFERENCE_TYPES,
         },
     )
 
-    combined_with: NON_VIRTUAL_NEURON_SETS_REFERENCE_UNION | None = Field(
+    combined_with: BlockReference | None = Field(
         default=None,
         title="Second Neuron Set",
         description="Neuron set to combine with.",
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
-            SchemaKey.REFERENCE_TYPES: NON_VIRTUAL_NEURON_SETS_REFERENCE_TYPES,
+            SchemaKey.REFERENCE_TYPES: _NON_VIRTUAL_REFERENCE_TYPES,
         },
     )
 
@@ -334,22 +335,22 @@ class PointCombinedNeuronSet(CombinedBaseNeuronSet):
         },
     }
 
-    base_neuron_set: POINT_NEURON_SETS_REFERENCE_UNION | None = Field(
+    base_neuron_set: BlockReference | None = Field(
         default=None,
         title="First Neuron Set",
         description="Base neuron set to be combined.",
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
-            SchemaKey.REFERENCE_TYPES: POINT_NEURON_SETS_REFERENCE_TYPES,
+            SchemaKey.REFERENCE_TYPES: _POINT_REFERENCE_TYPES,
         },
     )
 
-    combined_with: POINT_NEURON_SETS_REFERENCE_UNION | None = Field(
+    combined_with: BlockReference | None = Field(
         default=None,
         title="Second Neuron Set",
         description="Neuron set to combine with.",
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
-            SchemaKey.REFERENCE_TYPES: POINT_NEURON_SETS_REFERENCE_TYPES,
+            SchemaKey.REFERENCE_TYPES: _POINT_REFERENCE_TYPES,
         },
     )

--- a/obi_one/scientific/blocks/neuron_sets_2/combined.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/combined.py
@@ -122,7 +122,9 @@ class CombinedBaseNeuronSet(NeuronSet, abc.ABC):
 
     @staticmethod
     def _make_union_expression(
-        circuit: Circuit, neuron_sets: list[NeuronSet], prefix: str = "",
+        circuit: Circuit,
+        neuron_sets: list[NeuronSet],
+        prefix: str = "",
     ) -> tuple[dict | list, dict]:
         """Make union expression preserving symbolic notation, if possible."""
         expression = []

--- a/obi_one/scientific/blocks/neuron_sets_2/combined.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/combined.py
@@ -138,6 +138,7 @@ class CombinedBaseNeuronSet(NeuronSet, abc.ABC):
     def get_neuron_ids(self, circuit: Circuit) -> dict[str, list[int]]:
         """Returns list of neuron IDs per population."""
         self.check_combined_depth()
+        self.check_populations_in_circuit(circuit=circuit)
         base_nset, with_nset = self._resolve_refs()
         base_ids = base_nset.get_neuron_ids(circuit)
         with_ids = with_nset.get_neuron_ids(circuit)
@@ -170,6 +171,7 @@ class CombinedBaseNeuronSet(NeuronSet, abc.ABC):
         else:
             # Symbolic expression may be preserved
             self.check_combined_depth()
+            self.check_populations_in_circuit(circuit=circuit)
             base_nset, with_nset = self._resolve_refs()
             prefix = f"__{self.__class__.__name__}__"
             expression, combined = CombinedBaseNeuronSet._make_union_expression(

--- a/obi_one/scientific/blocks/neuron_sets_2/combined.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/combined.py
@@ -14,9 +14,16 @@ from obi_one.scientific.library.entity_property_types import (
     MappedPropertiesGroup,
 )
 from obi_one.scientific.unions.unions_neuron_sets_2 import (
-    BiophysicalNeuronSetReference,
-    PointNeuronSetReference,
-    VirtualNeuronSetReference,
+    ALL_NEURON_SETS_REFERENCE_TYPES,
+    ALL_NEURON_SETS_REFERENCE_UNION,
+    BIOPHYSICAL_NEURON_SETS_REFERENCE_TYPES,
+    BIOPHYSICAL_NEURON_SETS_REFERENCE_UNION,
+    NON_VIRTUAL_NEURON_SETS_REFERENCE_TYPES,
+    NON_VIRTUAL_NEURON_SETS_REFERENCE_UNION,
+    POINT_NEURON_SETS_REFERENCE_TYPES,
+    POINT_NEURON_SETS_REFERENCE_UNION,
+    VIRTUAL_NEURON_SETS_REFERENCE_TYPES,
+    VIRTUAL_NEURON_SETS_REFERENCE_UNION,
 )
 
 L = logging.getLogger("obi-one")
@@ -64,7 +71,7 @@ class CombinedBaseNeuronSet(NeuronSet, abc.ABC):
         with_nset = (
             self.combined_with.block if hasattr(self.combined_with, "block") else self.combined_with
         )
-        return base_nset, with_nset
+        return base_nset, with_nset  # ty:ignore[invalid-return-type]
 
     def check_combined_depth(
         self, visited: set[str] | None = None, depth: int = _MAX_COMBINED_DEPTH

--- a/obi_one/scientific/blocks/neuron_sets_2/combined.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/combined.py
@@ -43,13 +43,13 @@ class CombinedBaseNeuronSet(NeuronSet, abc.ABC):
     base_neuron_set: NeuronSet
     combined_with: NeuronSet
     operation: Literal[SetOperation.UNION, SetOperation.INTERSECT, SetOperation.DIFF] = Field(
-            json_schema_extra={
-                SchemaKey.UI_ELEMENT: UIElement.STRING_SELECTION,
-            },
-            title="Operation",
-            description="Set option for combining the IDs in the neuron sets.",
-            default=SetOperation.UNION,
-        )
+        json_schema_extra={
+            SchemaKey.UI_ELEMENT: UIElement.STRING_SELECTION,
+        },
+        title="Operation",
+        description="Set option for combining the IDs in the neuron sets.",
+        default=SetOperation.UNION,
+    )
 
     def _resolve_refs(self) -> tuple[NeuronSet, NeuronSet]:
         """Resolve neuron set references to actual NeuronSet objects."""
@@ -62,9 +62,7 @@ class CombinedBaseNeuronSet(NeuronSet, abc.ABC):
             else self.base_neuron_set
         )
         with_nset = (
-            self.combined_with.block
-            if hasattr(self.combined_with, "block")
-            else self.combined_with
+            self.combined_with.block if hasattr(self.combined_with, "block") else self.combined_with
         )
         return base_nset, with_nset
 
@@ -161,50 +159,190 @@ class CombinedBaseNeuronSet(NeuronSet, abc.ABC):
         return (expression, combined)
 
 
-# class CombinedNeuronSet(PopulationNeuronSet, abc.ABC):
-#     """Neuron set definition by providing a list of neuron IDs."""
+class CombinedNeuronSet(CombinedBaseNeuronSet):
+    """Combine neuron sets of any type."""
+
+    title: ClassVar[str] = "Combined (Any)"
+    description: ClassVar[str] = "Use neuron sets of any type combined with set operations."
+
+    _neuron_set_population_type: ClassVar[NeuronSetPopulationType] = NeuronSetPopulationType.ANY
+
+    json_schema_extra_additions: ClassVar[dict] = {
+        SchemaKey.BLOCK_USABILITY_DICTIONARY: {
+            SchemaKey.PROPERTY_GROUP: MappedPropertiesGroup.CIRCUIT,
+            SchemaKey.PROPERTY: CircuitUsability.SHOW_NEURON_SETS,
+            SchemaKey.FALSE_MESSAGE: "This circuit has no populations.",
+        },
+    }
+
+    base_neuron_set: ALL_NEURON_SETS_REFERENCE_UNION | None = Field(
+        default=None,
+        title="First Neuron Set",
+        description="Base neuron set to be combined.",
+        json_schema_extra={
+            SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
+            SchemaKey.REFERENCE_TYPES: ALL_NEURON_SETS_REFERENCE_TYPES,
+        },
+    )
+
+    combined_with: ALL_NEURON_SETS_REFERENCE_UNION | None = Field(
+        default=None,
+        title="Second Neuron Set",
+        description="Neuron set to combine with.",
+        json_schema_extra={
+            SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
+            SchemaKey.REFERENCE_TYPES: ALL_NEURON_SETS_REFERENCE_TYPES,
+        },
+    )
 
 
-# class BiophysicalCombinedNeuronSet(CombinedNeuronSet, BiophysicalPopulationNeuronSet):
-#     """Only biophysical neuron node populations are selectable."""
+class BiophysicalCombinedNeuronSet(CombinedBaseNeuronSet):
+    """Combine biophysical neuron sets."""
 
-#     title: ClassVar[str] = "Combined (Biophysical)"
+    title: ClassVar[str] = "Combined (Biophysical)"
+    description: ClassVar[str] = "Use biophysical neuron sets combined with set operations."
 
-#     neuron_sets: BiophysicalCombinedNeuronSetNamedTuple = Field(
-#         title="Neuron Sets to Combine",
-#         description="List of neuron IDs to include in the neuron set.",
-#         json_schema_extra={
-#             SchemaKey.UI_ELEMENT: UIElement.NEURON_SET_COMBINATION,
-#             SchemaKey.REFERENCE_TYPES: [BiophysicalNeuronSetReference.__name__],
-#         },
-#     )
+    _neuron_set_population_type: ClassVar[NeuronSetPopulationType] = (
+        NeuronSetPopulationType.BIOPHYSICAL
+    )
+
+    json_schema_extra_additions: ClassVar[dict] = {
+        SchemaKey.BLOCK_USABILITY_DICTIONARY: {
+            SchemaKey.PROPERTY_GROUP: MappedPropertiesGroup.CIRCUIT,
+            SchemaKey.PROPERTY: CircuitUsability.SHOW_BIOPHYSICAL_NEURON_SETS,
+            SchemaKey.FALSE_MESSAGE: "This circuit has no biophysical populations.",
+        },
+    }
+
+    base_neuron_set: BIOPHYSICAL_NEURON_SETS_REFERENCE_UNION | None = Field(
+        default=None,
+        title="First Neuron Set",
+        description="Base neuron set to be combined.",
+        json_schema_extra={
+            SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
+            SchemaKey.REFERENCE_TYPES: BIOPHYSICAL_NEURON_SETS_REFERENCE_TYPES,
+        },
+    )
+
+    combined_with: BIOPHYSICAL_NEURON_SETS_REFERENCE_UNION | None = Field(
+        default=None,
+        title="Second Neuron Set",
+        description="Neuron set to combine with.",
+        json_schema_extra={
+            SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
+            SchemaKey.REFERENCE_TYPES: BIOPHYSICAL_NEURON_SETS_REFERENCE_TYPES,
+        },
+    )
 
 
-# class VirtualCombinedNeuronSet(CombinedNeuronSet, VirtualPopulationNeuronSet):
-#     """Only virtual neuron node populations are selectable."""
+class VirtualCombinedNeuronSet(CombinedBaseNeuronSet):
+    """Combine virtual neuron sets."""
 
-#     title: ClassVar[str] = "Combined (Virtual)"
+    title: ClassVar[str] = "Combined (Virtual)"
+    description: ClassVar[str] = "Use virtual neuron sets combined with set operations."
 
-#     neuron_sets: VirtualCombinedNeuronSetNamedTuple = Field(
-#         title="Neuron Sets to Combine",
-#         description="...",
-#         json_schema_extra={
-#             SchemaKey.UI_ELEMENT: UIElement.NEURON_SET_COMBINATION,
-#             SchemaKey.REFERENCE_TYPES: [VirtualNeuronSetReference.__name__],
-#         },
-#     )
+    _neuron_set_population_type: ClassVar[NeuronSetPopulationType] = NeuronSetPopulationType.VIRTUAL
+
+    json_schema_extra_additions: ClassVar[dict] = {
+        SchemaKey.BLOCK_USABILITY_DICTIONARY: {
+            SchemaKey.PROPERTY_GROUP: MappedPropertiesGroup.CIRCUIT,
+            SchemaKey.PROPERTY: CircuitUsability.SHOW_VIRTUAL_NEURON_SETS,
+            SchemaKey.FALSE_MESSAGE: "This circuit has no virtual populations.",
+        },
+    }
+
+    base_neuron_set: VIRTUAL_NEURON_SETS_REFERENCE_UNION | None = Field(
+        default=None,
+        title="First Neuron Set",
+        description="Base neuron set to be combined.",
+        json_schema_extra={
+            SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
+            SchemaKey.REFERENCE_TYPES: VIRTUAL_NEURON_SETS_REFERENCE_TYPES,
+        },
+    )
+
+    combined_with: VIRTUAL_NEURON_SETS_REFERENCE_UNION | None = Field(
+        default=None,
+        title="Second Neuron Set",
+        description="Neuron set to combine with.",
+        json_schema_extra={
+            SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
+            SchemaKey.REFERENCE_TYPES: VIRTUAL_NEURON_SETS_REFERENCE_TYPES,
+        },
+    )
 
 
-# class PointCombinedNeuronSet(CombinedNeuronSet, PointPopulationNeuronSet):
-#     """Only point neuron node populations are selectable."""
+class NonVirtualCombinedNeuronSet(CombinedBaseNeuronSet):
+    """Combine non-virtual neuron sets."""
 
-#     title: ClassVar[str] = "Combined (Point)"
+    title: ClassVar[str] = "Combined (Non-Virtual)"
+    description: ClassVar[str] = "Use non-virtual neuron sets combined with set operations."
 
-#     neuron_sets: PointCombinedNeuronSetNamedTuple = Field(
-#         title="Neuron Sets to Combine",
-#         description="...",
-#         json_schema_extra={
-#             SchemaKey.UI_ELEMENT: UIElement.NEURON_SET_COMBINATION,
-#             SchemaKey.REFERENCE_TYPES: [PointNeuronSetReference.__name__],
-#         },
-#     )
+    _neuron_set_population_type: ClassVar[NeuronSetPopulationType] = (
+        NeuronSetPopulationType.NONVIRTUAL
+    )
+
+    json_schema_extra_additions: ClassVar[dict] = {
+        SchemaKey.BLOCK_USABILITY_DICTIONARY: {
+            SchemaKey.PROPERTY_GROUP: MappedPropertiesGroup.CIRCUIT,
+            SchemaKey.PROPERTY: CircuitUsability.SHOW_NONVIRTUAL_NEURON_SETS,
+            SchemaKey.FALSE_MESSAGE: "This circuit has no non-virtual populations.",
+        },
+    }
+
+    base_neuron_set: NON_VIRTUAL_NEURON_SETS_REFERENCE_UNION | None = Field(
+        default=None,
+        title="First Neuron Set",
+        description="Base neuron set to be combined.",
+        json_schema_extra={
+            SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
+            SchemaKey.REFERENCE_TYPES: NON_VIRTUAL_NEURON_SETS_REFERENCE_TYPES,
+        },
+    )
+
+    combined_with: NON_VIRTUAL_NEURON_SETS_REFERENCE_UNION | None = Field(
+        default=None,
+        title="Second Neuron Set",
+        description="Neuron set to combine with.",
+        json_schema_extra={
+            SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
+            SchemaKey.REFERENCE_TYPES: NON_VIRTUAL_NEURON_SETS_REFERENCE_TYPES,
+        },
+    )
+
+
+class PointCombinedNeuronSet(CombinedBaseNeuronSet):
+    """Combine point neuron sets."""
+
+    title: ClassVar[str] = "Combined (Point)"
+    description: ClassVar[str] = "Use point neuron sets combined with set operations."
+
+    _neuron_set_population_type: ClassVar[NeuronSetPopulationType] = NeuronSetPopulationType.POINT
+
+    json_schema_extra_additions: ClassVar[dict] = {
+        SchemaKey.BLOCK_USABILITY_DICTIONARY: {
+            SchemaKey.PROPERTY_GROUP: MappedPropertiesGroup.CIRCUIT,
+            SchemaKey.PROPERTY: CircuitUsability.SHOW_POINT_NEURON_SETS,
+            SchemaKey.FALSE_MESSAGE: "This circuit has no point neuron populations.",
+        },
+    }
+
+    base_neuron_set: POINT_NEURON_SETS_REFERENCE_UNION | None = Field(
+        default=None,
+        title="First Neuron Set",
+        description="Base neuron set to be combined.",
+        json_schema_extra={
+            SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
+            SchemaKey.REFERENCE_TYPES: POINT_NEURON_SETS_REFERENCE_TYPES,
+        },
+    )
+
+    combined_with: POINT_NEURON_SETS_REFERENCE_UNION | None = Field(
+        default=None,
+        title="Second Neuron Set",
+        description="Neuron set to combine with.",
+        json_schema_extra={
+            SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
+            SchemaKey.REFERENCE_TYPES: POINT_NEURON_SETS_REFERENCE_TYPES,
+        },
+    )

--- a/obi_one/scientific/blocks/neuron_sets_2/combined.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/combined.py
@@ -1,5 +1,6 @@
 import abc
 import logging
+import numpy as np
 from typing import Annotated, ClassVar
 
 from pydantic import Field
@@ -20,6 +21,131 @@ from obi_one.scientific.unions.unions_neuron_sets_2 import (
 )
 
 L = logging.getLogger("obi-one")
+
+_MAX_COMBINED_DEPTH = 10
+
+class SetOperation(StrEnum):
+    UNION = "union"
+    INTERSECT = "intersect"
+    DIFF = "diff"
+
+_OPERATION_MAP = {
+    SetOperation.UNION: np.union1d,
+    SetOperation.INTERSECT: np.intersect1d,
+    SetOperation.DIFF: np.setdiff1d,
+}
+
+class CombinedBaseNeuronSet(NeuronSet, abc.ABC):
+    """Abstract base class for combining neuron sets within and across node populations."""
+
+    base_neuron_set: NeuronSet 
+    combined_with: list[tuple[NeuronSet, SetOperation]]
+
+    def check_combined_depth(
+        self, visited: set[str] | None = None, depth: int = _MAX_COMBINED_DEPTH
+    ) -> None:
+        if not self.has_block_name():
+            msg = "Block name must be set before checking combined depth."
+            raise ValueError(msg)
+        if visited is None:
+            visited = set()
+        if self.block_name in visited:
+            msg = f"Recursive loop in combined neuron set '{self.block_name}'!"
+            raise ValueError(msg)
+        if depth == 0:
+            msg = "Too many nested combined neuron sets!"
+            raise ValueError(msg)
+        visited.add(self.block_name)
+        all_nsets = [self.base_neuron_set] + [nset for nset, _ in self.combined_with]
+        for nset in all_nsets:
+            if isinstance(nset, CombinedBaseNeuronSet):
+                nset.check_combined_depth(visited, depth - 1)
+
+    def get_populations(self, circuit: Circuit) -> list[str]:
+        """Returns population names included in the neuron set."""
+        all_pops = []
+        all_nsets = [self.base_neuron_set] + [nset for nset, _ in self.combined_with]
+        for nset in all_nsets:
+            for pop in nset.get_populations(circuit):
+                if pop not in all_pops:
+                    all_pops.append(pop)
+        return all_pops
+
+    @staticmethod
+    def _combine_ids(neuron_ids1: dict[str, list[int]], neuron_ids2: dict[str, list[int]], operation: SetOperation) -> dict[str, list[int]]:
+        op_fct = _OPERATION_MAP[operation]
+        npop_names = set(list(neuron_ids1) + list(neuron_ids2))
+        combined = {}
+        for npop in npop_names:
+            comb_ids = op_fct(neuron_ids1.get(npop, []), neuron_ids2.get(npop, []))
+            combined[npop] = list(comb_ids)
+        return combined
+
+    @staticmethod
+    def _make_union_expression(circuit: Circuit, neuron_sets: list[NeuronSet]) -> tuple[dict | list, dict]:
+        """Make union expression preserving symbolic notation, if possible"""
+        expression = []
+        combined = {}
+        for nset in neuron_sets:
+            nset_name = nset.block_name
+            nset_def, nset_combined = nset.get_node_set_definition(circuit)
+            combined.update(nset_combined)
+            combined[nset_name] = nset_def
+            expression.append(nset_name)
+        return (expression, combined)
+
+    def get_neuron_ids(self, circuit: Circuit) -> dict[str, list[int]]:
+        """Returns list of neuron IDs per population."""
+        self.check_combined_depth()
+        comb_ids = self.base_neuron_set.get_neuron_ids(circuit)
+        for nset, op in self.combined_with:
+            with_ids = nset.get_neuron_ids(circuit)
+            comb_ids = CombinedBaseNeuronSet._combine_ids(comb_ids, with_ids, op)
+        return comb_ids
+
+    def get_node_set_definition(
+        self, circuit: Circuit, *, force_resolve_ids: bool = False
+    ) -> tuple[dict | list, dict]:
+        """Returns the SONATA node set definition, optionally forcing to resolve individual IDs.
+
+        In case of a compound expression (list expression), any new definitions
+        to be combined are returned as dict.
+        """
+        unions_only = all(op == SetOperation.UNION for _, op in self.combined_with)
+        if force_resolve_ids or not unions_only:
+            # Resolve and combine individual IDs per population and use in compound expression
+            ids_per_npop = self.get_neuron_ids(circuit)
+            expression, combined = NeuronSet.ids_to_node_set_definition(ids_per_npop, prefix=self.block_name, simplified=True)
+        else:
+            # Symbolic expression may be preserved
+            self.check_combined_depth()
+            all_nsets = [self.base_neuron_set] + [nset for nset, _ in self.combined_with]
+            expression, combined = CombinedBaseNeuronSet._make_union_expression(circuit, all_nsets)
+        return (expression, combined)
+
+
+    # def _get_combined(self) -> list[str]:
+
+
+    # def _get_expression(self, circuit: Circuit) -> dict | list:
+    #     """Returns the SONATA node set expression."""
+    #     self.check_combined_depth()
+    #     return self._get_combined()
+
+
+    # @staticmethod
+    # def get_node_set_populations(node_set: str, circuit: Circuit) -> list[str]:
+    #     """Returns a list of all node populations a node set resolves in."""
+    #     node_populations = []
+    #     for npop in circuit.sonata_circuit.nodes.population_names:
+    #         try:
+    #             node_ids = circuit.sonata_circuit.nodes[npop].ids(node_set)
+    #         except snap.BluepySnapError:
+    #             # In case of an error (e.g., "No such attribute"), return empty list
+    #             node_ids = []
+    #         if node_ids:
+    #             node_populations.append(npop)
+    #     return node_populations
 
 
 # class CombinedNeuronSet(PopulationNeuronSet, abc.ABC):

--- a/obi_one/scientific/blocks/neuron_sets_2/combined.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/combined.py
@@ -78,7 +78,7 @@ class CombinedBaseNeuronSet(NeuronSet, abc.ABC):
         self, visited: set[str] | None = None, depth: int = _MAX_COMBINED_DEPTH
     ) -> None:
         if not self.has_block_name():
-            msg = "Block name must be set before checking combined depth."
+            msg = "Block name must be set."
             raise ValueError(msg)
         if visited is None:
             visited = set()
@@ -122,13 +122,13 @@ class CombinedBaseNeuronSet(NeuronSet, abc.ABC):
 
     @staticmethod
     def _make_union_expression(
-        circuit: Circuit, neuron_sets: list[NeuronSet]
+        circuit: Circuit, neuron_sets: list[NeuronSet], prefix: str = "",
     ) -> tuple[dict | list, dict]:
         """Make union expression preserving symbolic notation, if possible."""
         expression = []
         combined = {}
         for nset in neuron_sets:
-            nset_name = nset.block_name
+            nset_name = prefix + nset.block_name
             nset_def, nset_combined = nset.get_node_set_definition(circuit)
             combined.update(nset_combined)
             combined[nset_name] = nset_def
@@ -156,19 +156,24 @@ class CombinedBaseNeuronSet(NeuronSet, abc.ABC):
         In case of a compound expression (list expression), any new definitions
         to be combined are returned as dict.
         """
+        if not self.has_block_name():
+            msg = "Block name must be set."
+            raise ValueError(msg)
         is_union = self.operation == SetOperation.UNION
         if force_resolve_ids or not is_union:
             # Resolve and combine individual IDs per population and use in compound expression
             ids_per_npop = self.get_neuron_ids(circuit)
+            prefix = f"__{self.__class__.__name__}__{self.block_name}"
             expression, combined = NeuronSet.ids_to_node_set_definition(
-                ids_per_npop, prefix=self.block_name, simplified=True
+                ids_per_npop, prefix=prefix, simplified=True
             )
         else:
             # Symbolic expression may be preserved
             self.check_combined_depth()
             base_nset, with_nset = self._resolve_refs()
+            prefix = f"__{self.__class__.__name__}__"
             expression, combined = CombinedBaseNeuronSet._make_union_expression(
-                circuit, [base_nset, with_nset]
+                circuit, [base_nset, with_nset], prefix
             )
         return (expression, combined)
 

--- a/obi_one/scientific/blocks/neuron_sets_2/combined.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/combined.py
@@ -9,6 +9,7 @@ from obi_one.core.schema import SchemaKey, UIElement
 from obi_one.core.tuple import NamedTuple
 from obi_one.scientific.blocks.neuron_sets_2.population import (
     BiophysicalPopulationNeuronSet,
+    NeuronSet,
     PointPopulationNeuronSet,
     PopulationNeuronSet,
     VirtualPopulationNeuronSet,
@@ -39,7 +40,8 @@ class CombinedBaseNeuronSet(NeuronSet, abc.ABC):
     """Abstract base class for combining neuron sets within and across node populations."""
 
     base_neuron_set: NeuronSet 
-    combined_with: list[tuple[NeuronSet, SetOperation]]
+    combined_with: NeuronSet
+    operation: ClassVar[SetOperation]
 
     def check_combined_depth(
         self, visited: set[str] | None = None, depth: int = _MAX_COMBINED_DEPTH
@@ -56,7 +58,7 @@ class CombinedBaseNeuronSet(NeuronSet, abc.ABC):
             msg = "Too many nested combined neuron sets!"
             raise ValueError(msg)
         visited.add(self.block_name)
-        all_nsets = [self.base_neuron_set] + [nset for nset, _ in self.combined_with]
+        all_nsets = [self.base_neuron_set, self.combined_with]
         for nset in all_nsets:
             if isinstance(nset, CombinedBaseNeuronSet):
                 nset.check_combined_depth(visited, depth - 1)
@@ -64,7 +66,7 @@ class CombinedBaseNeuronSet(NeuronSet, abc.ABC):
     def get_populations(self, circuit: Circuit) -> list[str]:
         """Returns population names included in the neuron set."""
         all_pops = []
-        all_nsets = [self.base_neuron_set] + [nset for nset, _ in self.combined_with]
+        all_nsets = [self.base_neuron_set, self.combined_with]
         for nset in all_nsets:
             for pop in nset.get_populations(circuit):
                 if pop not in all_pops:
@@ -97,10 +99,9 @@ class CombinedBaseNeuronSet(NeuronSet, abc.ABC):
     def get_neuron_ids(self, circuit: Circuit) -> dict[str, list[int]]:
         """Returns list of neuron IDs per population."""
         self.check_combined_depth()
-        comb_ids = self.base_neuron_set.get_neuron_ids(circuit)
-        for nset, op in self.combined_with:
-            with_ids = nset.get_neuron_ids(circuit)
-            comb_ids = CombinedBaseNeuronSet._combine_ids(comb_ids, with_ids, op)
+        base_ids = self.base_neuron_set.get_neuron_ids(circuit)
+        with_ids = self.combined_with.get_neuron_ids(circuit)
+        comb_ids = CombinedBaseNeuronSet._combine_ids(base_ids, with_ids, self.operation)
         return comb_ids
 
     def get_node_set_definition(
@@ -111,41 +112,17 @@ class CombinedBaseNeuronSet(NeuronSet, abc.ABC):
         In case of a compound expression (list expression), any new definitions
         to be combined are returned as dict.
         """
-        unions_only = all(op == SetOperation.UNION for _, op in self.combined_with)
-        if force_resolve_ids or not unions_only:
+        is_union = self.operation == SetOperation.UNION
+        if force_resolve_ids or not is_union:
             # Resolve and combine individual IDs per population and use in compound expression
             ids_per_npop = self.get_neuron_ids(circuit)
             expression, combined = NeuronSet.ids_to_node_set_definition(ids_per_npop, prefix=self.block_name, simplified=True)
         else:
             # Symbolic expression may be preserved
             self.check_combined_depth()
-            all_nsets = [self.base_neuron_set] + [nset for nset, _ in self.combined_with]
+            all_nsets = [self.base_neuron_set, self.combined_with]
             expression, combined = CombinedBaseNeuronSet._make_union_expression(circuit, all_nsets)
         return (expression, combined)
-
-
-    # def _get_combined(self) -> list[str]:
-
-
-    # def _get_expression(self, circuit: Circuit) -> dict | list:
-    #     """Returns the SONATA node set expression."""
-    #     self.check_combined_depth()
-    #     return self._get_combined()
-
-
-    # @staticmethod
-    # def get_node_set_populations(node_set: str, circuit: Circuit) -> list[str]:
-    #     """Returns a list of all node populations a node set resolves in."""
-    #     node_populations = []
-    #     for npop in circuit.sonata_circuit.nodes.population_names:
-    #         try:
-    #             node_ids = circuit.sonata_circuit.nodes[npop].ids(node_set)
-    #         except snap.BluepySnapError:
-    #             # In case of an error (e.g., "No such attribute"), return empty list
-    #             node_ids = []
-    #         if node_ids:
-    #             node_populations.append(npop)
-    #     return node_populations
 
 
 # class CombinedNeuronSet(PopulationNeuronSet, abc.ABC):

--- a/obi_one/scientific/blocks/neuron_sets_2/combined.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/combined.py
@@ -1,34 +1,34 @@
 import abc
 import logging
-import numpy as np
-from typing import Annotated, ClassVar
+from enum import StrEnum
+from typing import ClassVar, Literal
 
+import numpy as np
 from pydantic import Field
 
 from obi_one.core.schema import SchemaKey, UIElement
-from obi_one.core.tuple import NamedTuple
-from obi_one.scientific.blocks.neuron_sets_2.population import (
-    BiophysicalPopulationNeuronSet,
-    NeuronSet,
-    PointPopulationNeuronSet,
-    PopulationNeuronSet,
-    VirtualPopulationNeuronSet,
-)
+from obi_one.scientific.blocks.neuron_sets_2.base import NeuronSet, NeuronSetPopulationType
 from obi_one.scientific.library.circuit import Circuit
+from obi_one.scientific.library.entity_property_types import (
+    CircuitUsability,
+    MappedPropertiesGroup,
+)
 from obi_one.scientific.unions.unions_neuron_sets_2 import (
     BiophysicalNeuronSetReference,
-    VirtualNeuronSetReference,
     PointNeuronSetReference,
+    VirtualNeuronSetReference,
 )
 
 L = logging.getLogger("obi-one")
 
 _MAX_COMBINED_DEPTH = 10
 
+
 class SetOperation(StrEnum):
     UNION = "union"
     INTERSECT = "intersect"
     DIFF = "diff"
+
 
 _OPERATION_MAP = {
     SetOperation.UNION: np.union1d,
@@ -36,12 +36,37 @@ _OPERATION_MAP = {
     SetOperation.DIFF: np.setdiff1d,
 }
 
+
 class CombinedBaseNeuronSet(NeuronSet, abc.ABC):
     """Abstract base class for combining neuron sets within and across node populations."""
 
-    base_neuron_set: NeuronSet 
+    base_neuron_set: NeuronSet
     combined_with: NeuronSet
-    operation: ClassVar[SetOperation]
+    operation: Literal[SetOperation.UNION, SetOperation.INTERSECT, SetOperation.DIFF] = Field(
+            json_schema_extra={
+                SchemaKey.UI_ELEMENT: UIElement.STRING_SELECTION,
+            },
+            title="Operation",
+            description="Set option for combining the IDs in the neuron sets.",
+            default=SetOperation.UNION,
+        )
+
+    def _resolve_refs(self) -> tuple[NeuronSet, NeuronSet]:
+        """Resolve neuron set references to actual NeuronSet objects."""
+        if self.base_neuron_set is None or self.combined_with is None:
+            msg = "Both neuron set references must be set for combining."
+            raise ValueError(msg)
+        base_nset = (
+            self.base_neuron_set.block
+            if hasattr(self.base_neuron_set, "block")
+            else self.base_neuron_set
+        )
+        with_nset = (
+            self.combined_with.block
+            if hasattr(self.combined_with, "block")
+            else self.combined_with
+        )
+        return base_nset, with_nset
 
     def check_combined_depth(
         self, visited: set[str] | None = None, depth: int = _MAX_COMBINED_DEPTH
@@ -58,23 +83,27 @@ class CombinedBaseNeuronSet(NeuronSet, abc.ABC):
             msg = "Too many nested combined neuron sets!"
             raise ValueError(msg)
         visited.add(self.block_name)
-        all_nsets = [self.base_neuron_set, self.combined_with]
-        for nset in all_nsets:
+        base_nset, with_nset = self._resolve_refs()
+        for nset in [base_nset, with_nset]:
             if isinstance(nset, CombinedBaseNeuronSet):
                 nset.check_combined_depth(visited, depth - 1)
 
     def get_populations(self, circuit: Circuit) -> list[str]:
         """Returns population names included in the neuron set."""
+        base_nset, with_nset = self._resolve_refs()
         all_pops = []
-        all_nsets = [self.base_neuron_set, self.combined_with]
-        for nset in all_nsets:
+        for nset in [base_nset, with_nset]:
             for pop in nset.get_populations(circuit):
                 if pop not in all_pops:
                     all_pops.append(pop)
         return all_pops
 
     @staticmethod
-    def _combine_ids(neuron_ids1: dict[str, list[int]], neuron_ids2: dict[str, list[int]], operation: SetOperation) -> dict[str, list[int]]:
+    def _combine_ids(
+        neuron_ids1: dict[str, list[int]],
+        neuron_ids2: dict[str, list[int]],
+        operation: SetOperation,
+    ) -> dict[str, list[int]]:
         op_fct = _OPERATION_MAP[operation]
         npop_names = set(list(neuron_ids1) + list(neuron_ids2))
         combined = {}
@@ -84,8 +113,10 @@ class CombinedBaseNeuronSet(NeuronSet, abc.ABC):
         return combined
 
     @staticmethod
-    def _make_union_expression(circuit: Circuit, neuron_sets: list[NeuronSet]) -> tuple[dict | list, dict]:
-        """Make union expression preserving symbolic notation, if possible"""
+    def _make_union_expression(
+        circuit: Circuit, neuron_sets: list[NeuronSet]
+    ) -> tuple[dict | list, dict]:
+        """Make union expression preserving symbolic notation, if possible."""
         expression = []
         combined = {}
         for nset in neuron_sets:
@@ -99,8 +130,9 @@ class CombinedBaseNeuronSet(NeuronSet, abc.ABC):
     def get_neuron_ids(self, circuit: Circuit) -> dict[str, list[int]]:
         """Returns list of neuron IDs per population."""
         self.check_combined_depth()
-        base_ids = self.base_neuron_set.get_neuron_ids(circuit)
-        with_ids = self.combined_with.get_neuron_ids(circuit)
+        base_nset, with_nset = self._resolve_refs()
+        base_ids = base_nset.get_neuron_ids(circuit)
+        with_ids = with_nset.get_neuron_ids(circuit)
         comb_ids = CombinedBaseNeuronSet._combine_ids(base_ids, with_ids, self.operation)
         return comb_ids
 
@@ -116,18 +148,22 @@ class CombinedBaseNeuronSet(NeuronSet, abc.ABC):
         if force_resolve_ids or not is_union:
             # Resolve and combine individual IDs per population and use in compound expression
             ids_per_npop = self.get_neuron_ids(circuit)
-            expression, combined = NeuronSet.ids_to_node_set_definition(ids_per_npop, prefix=self.block_name, simplified=True)
+            expression, combined = NeuronSet.ids_to_node_set_definition(
+                ids_per_npop, prefix=self.block_name, simplified=True
+            )
         else:
             # Symbolic expression may be preserved
             self.check_combined_depth()
-            all_nsets = [self.base_neuron_set, self.combined_with]
-            expression, combined = CombinedBaseNeuronSet._make_union_expression(circuit, all_nsets)
+            base_nset, with_nset = self._resolve_refs()
+            expression, combined = CombinedBaseNeuronSet._make_union_expression(
+                circuit, [base_nset, with_nset]
+            )
         return (expression, combined)
 
 
 # class CombinedNeuronSet(PopulationNeuronSet, abc.ABC):
 #     """Neuron set definition by providing a list of neuron IDs."""
-    
+
 
 # class BiophysicalCombinedNeuronSet(CombinedNeuronSet, BiophysicalPopulationNeuronSet):
 #     """Only biophysical neuron node populations are selectable."""

--- a/obi_one/scientific/blocks/neuron_sets_2/combined.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/combined.py
@@ -154,8 +154,27 @@ class CombinedBaseNeuronSet(NeuronSet, abc.ABC):
     ) -> tuple[dict | list, dict]:
         """Returns the SONATA node set definition, optionally forcing to resolve individual IDs.
 
-        In case of a compound expression (list expression), any new definitions
-        to be combined are returned as dict.
+        Returns a tuple of (expression, combined) where:
+
+        - expression (dict): A single SONATA node set expression. Examples:
+            - Symbolic by population: {"population": "pop_name"}
+            - Symbolic by properties: {"layer": "6", "synapse_class": "EXC"}
+            - Resolved IDs: {"population": "pop_name", "node_id": [1, 2, 3]}
+
+        - expression (list): A compound expression referencing multiple named node sets.
+            Example: ["__ClassName__blockname__0__", "__ClassName__blockname__1__"]
+            Each name must exist as a key in the combined dict.
+            Also used for symbolic references to existing node sets: ["Layer6"]
+
+        - combined (dict): Additional node set definitions needed by a compound expression.
+            Example: {"__ClassName__blockname__0__": {"population": "A", "node_id": [...]},
+                      "__ClassName__blockname__1__": {"population": "B", "node_id": [...]}}
+            Empty ({}) when expression is a single dict.
+
+        Args:
+            circuit: The circuit to resolve the node set in.
+            force_resolve_ids: If True, always resolve to explicit neuron IDs
+                instead of preserving symbolic expressions.
         """
         if not self.has_block_name():
             msg = "Block name must be set."

--- a/obi_one/scientific/blocks/neuron_sets_2/combined.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/combined.py
@@ -115,9 +115,7 @@ class CombinedBaseNeuronSet(NeuronSet, abc.ABC):
         combined = {}
         for npop in npop_names:
             comb_ids = op_fct(neuron_ids1.get(npop, []), neuron_ids2.get(npop, []))
-            if len(comb_ids) > 0:
-                # Only keep non-empty populations
-                combined[npop] = comb_ids.tolist()
+            combined[npop] = comb_ids.tolist()
         return combined
 
     @staticmethod

--- a/obi_one/scientific/blocks/neuron_sets_2/combined.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/combined.py
@@ -115,7 +115,7 @@ class CombinedBaseNeuronSet(NeuronSet, abc.ABC):
         combined = {}
         for npop in npop_names:
             comb_ids = op_fct(neuron_ids1.get(npop, []), neuron_ids2.get(npop, []))
-            combined[npop] = list(comb_ids)
+            combined[npop] = comb_ids.tolist()
         return combined
 
     @staticmethod
@@ -140,6 +140,10 @@ class CombinedBaseNeuronSet(NeuronSet, abc.ABC):
         base_ids = base_nset.get_neuron_ids(circuit)
         with_ids = with_nset.get_neuron_ids(circuit)
         comb_ids = CombinedBaseNeuronSet._combine_ids(base_ids, with_ids, self.operation)
+
+        if all(len(ids) == 0 for ids in comb_ids.values()):
+            L.warning("Combined neuron set empty!")
+
         return comb_ids
 
     def get_node_set_definition(

--- a/obi_one/scientific/blocks/neuron_sets_2/combined.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/combined.py
@@ -115,7 +115,9 @@ class CombinedBaseNeuronSet(NeuronSet, abc.ABC):
         combined = {}
         for npop in npop_names:
             comb_ids = op_fct(neuron_ids1.get(npop, []), neuron_ids2.get(npop, []))
-            combined[npop] = comb_ids.tolist()
+            if len(comb_ids) > 0:
+                # Only keep non-empty populations
+                combined[npop] = comb_ids.tolist()
         return combined
 
     @staticmethod

--- a/obi_one/scientific/blocks/neuron_sets_2/id.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/id.py
@@ -8,10 +8,8 @@ from obi_one.core.schema import SchemaKey, UIElement
 from obi_one.core.tuple import NamedTuple
 from obi_one.scientific.blocks.neuron_sets_2.population import (
     BiophysicalPopulationNeuronSet,
-    NonVirtualPopulationNeuronSet,
     PointPopulationNeuronSet,
     PopulationBaseNeuronSet,
-    PopulationNeuronSet,
     VirtualPopulationNeuronSet,
 )
 from obi_one.scientific.library.circuit import Circuit
@@ -47,18 +45,6 @@ class IDBaseNeuronSet(PopulationBaseNeuronSet, abc.ABC):
         return {"population": self.population, "node_id": list(self.neuron_ids.elements)}  # ty:ignore[unresolved-attribute]
 
 
-class IDNeuronSet(IDBaseNeuronSet, PopulationNeuronSet):
-    """Neuron set definition by providing a list of neuron IDs.
-
-    Resolved in one selected node population of any type.
-    """
-
-    title: ClassVar[str] = "Sample IDs (Any)"
-    description: ClassVar[str] = (
-        "Use neurons by providing a list of IDs, resolved in a single population of any type."
-    )
-
-
 class BiophysicalIDNeuronSet(IDBaseNeuronSet, BiophysicalPopulationNeuronSet):
     """Neuron set definition by providing a list of neuron IDs.
 
@@ -80,18 +66,6 @@ class VirtualIDNeuronSet(IDBaseNeuronSet, VirtualPopulationNeuronSet):
     title: ClassVar[str] = "Sample IDs (Virtual)"
     description: ClassVar[str] = (
         "Use neurons by providing a list of IDs, resolved in a single virtual population."
-    )
-
-
-class NonVirtualIDNeuronSet(IDBaseNeuronSet, NonVirtualPopulationNeuronSet):
-    """Neuron set definition by providing a list of neuron IDs.
-
-    Resolved in one selected non-virtual node population.
-    """
-
-    title: ClassVar[str] = "Sample IDs (Non-Virtual)"
-    description: ClassVar[str] = (
-        "Use neurons by providing a list of IDs, resolved in a single non-virtual population."
     )
 
 

--- a/obi_one/scientific/blocks/neuron_sets_2/id.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/id.py
@@ -23,7 +23,7 @@ class IDBaseNeuronSet(PopulationBaseNeuronSet, abc.ABC):
     """Abstract base class for neuron sets provided by a list of neuron IDs."""
 
     neuron_ids: NamedTuple | Annotated[list[NamedTuple], Field(min_length=1)] = Field(
-        title="ID Neuronset",
+        title="Neuron IDs",
         description="List of neuron IDs to include in the neuron set.",
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.NEURON_IDS,

--- a/obi_one/scientific/blocks/neuron_sets_2/id.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/id.py
@@ -17,7 +17,7 @@ from obi_one.scientific.library.circuit import Circuit
 L = logging.getLogger("obi-one")
 
 
-class IDBaseNeuronSet(PopulationBaseNeuronSet, abc.ABC):
+class IDPopulationBaseNeuronSet(PopulationBaseNeuronSet, abc.ABC):
     """Abstract base class for neuron sets provided by a list of neuron IDs."""
 
     neuron_ids: NamedTuple | Annotated[list[NamedTuple], Field(min_length=1)] = Field(
@@ -45,7 +45,7 @@ class IDBaseNeuronSet(PopulationBaseNeuronSet, abc.ABC):
         return {"population": self.population, "node_id": list(self.neuron_ids.elements)}  # ty:ignore[unresolved-attribute]
 
 
-class BiophysicalIDNeuronSet(IDBaseNeuronSet, BiophysicalPopulationNeuronSet):
+class BiophysicalPopulationIDNeuronSet(IDPopulationBaseNeuronSet, BiophysicalPopulationNeuronSet):
     """Neuron set definition by providing a list of neuron IDs.
 
     Resolved in one selected biophysical node population.
@@ -57,7 +57,7 @@ class BiophysicalIDNeuronSet(IDBaseNeuronSet, BiophysicalPopulationNeuronSet):
     )
 
 
-class VirtualIDNeuronSet(IDBaseNeuronSet, VirtualPopulationNeuronSet):
+class VirtualPopulationIDNeuronSet(IDPopulationBaseNeuronSet, VirtualPopulationNeuronSet):
     """Neuron set definition by providing a list of neuron IDs.
 
     Resolved in one selected virtual node population.
@@ -69,7 +69,7 @@ class VirtualIDNeuronSet(IDBaseNeuronSet, VirtualPopulationNeuronSet):
     )
 
 
-class PointIDNeuronSet(IDBaseNeuronSet, PointPopulationNeuronSet):
+class PointPopulationIDNeuronSet(IDPopulationBaseNeuronSet, PointPopulationNeuronSet):
     """Neuron set definition by providing a list of neuron IDs.
 
     Resolved in one selected point neuron population.

--- a/obi_one/scientific/blocks/neuron_sets_2/id.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/id.py
@@ -1,8 +1,3 @@
-"""IDNeuronSet(PopulationNeuronSet).
-
-- As before, selected IDs within a given node population
-"""
-
 import abc
 import logging
 from typing import Annotated, ClassVar
@@ -13,7 +8,9 @@ from obi_one.core.schema import SchemaKey, UIElement
 from obi_one.core.tuple import NamedTuple
 from obi_one.scientific.blocks.neuron_sets_2.population import (
     BiophysicalPopulationNeuronSet,
+    NonVirtualPopulationNeuronSet,
     PointPopulationNeuronSet,
+    PopulationBaseNeuronSet,
     PopulationNeuronSet,
     VirtualPopulationNeuronSet,
 )
@@ -22,8 +19,8 @@ from obi_one.scientific.library.circuit import Circuit
 L = logging.getLogger("obi-one")
 
 
-class IDNeuronSet(PopulationNeuronSet, abc.ABC):
-    """Neuron set definition by providing a list of neuron IDs."""
+class IDBaseNeuronSet(PopulationBaseNeuronSet, abc.ABC):
+    """Abstract base class for neuron sets provided by a list of neuron IDs."""
 
     neuron_ids: NamedTuple | Annotated[list[NamedTuple], Field(min_length=1)] = Field(
         title="ID Neuronset",
@@ -34,8 +31,9 @@ class IDNeuronSet(PopulationNeuronSet, abc.ABC):
     )
 
     def check_neuron_ids(self, circuit: Circuit) -> None:
+        self.check_populations_in_circuit(circuit=circuit)
         popul_ids = circuit.sonata_circuit.nodes[self.population].ids()
-        if not all(_nid in popul_ids for _nid in self.neuron_ids.elements):
+        if not all(nid in popul_ids for nid in self.neuron_ids.elements):  # ty:ignore[unresolved-attribute]
             msg = (
                 f"Neuron ID(s) not found in population '{self.population}' "
                 f"of circuit '{circuit.name}'. "
@@ -46,22 +44,64 @@ class IDNeuronSet(PopulationNeuronSet, abc.ABC):
     def _get_expression(self, circuit: Circuit) -> dict:
         """Returns the SONATA node set expression (w/o subsampling)."""
         self.check_neuron_ids(circuit)
-        return {"population": self.population, "node_id": list(self.neuron_ids.elements)}
+        return {"population": self.population, "node_id": list(self.neuron_ids.elements)}  # ty:ignore[unresolved-attribute]
 
 
-class BiophysicalIDNeuronSet(IDNeuronSet, BiophysicalPopulationNeuronSet):
-    """Only biophysical neuron node populations are selectable."""
+class IDNeuronSet(IDBaseNeuronSet, PopulationNeuronSet):
+    """Neuron set definition by providing a list of neuron IDs.
+
+    Resolved in one selected node population of any type.
+    """
+
+    title: ClassVar[str] = "Sample IDs (Any)"
+    description: ClassVar[str] = (
+        "Use neurons by providing a list of IDs, resolved in a single population of any type."
+    )
+
+
+class BiophysicalIDNeuronSet(IDBaseNeuronSet, BiophysicalPopulationNeuronSet):
+    """Neuron set definition by providing a list of neuron IDs.
+
+    Resolved in one selected biophysical node population.
+    """
 
     title: ClassVar[str] = "Sample IDs (Biophysical)"
+    description: ClassVar[str] = (
+        "Use neurons by providing a list of IDs, resolved in a single biophysical population."
+    )
 
 
-class VirtualIDNeuronSet(IDNeuronSet, VirtualPopulationNeuronSet):
-    """Only virtual neuron node populations are selectable."""
+class VirtualIDNeuronSet(IDBaseNeuronSet, VirtualPopulationNeuronSet):
+    """Neuron set definition by providing a list of neuron IDs.
+
+    Resolved in one selected virtual node population.
+    """
 
     title: ClassVar[str] = "Sample IDs (Virtual)"
+    description: ClassVar[str] = (
+        "Use neurons by providing a list of IDs, resolved in a single virtual population."
+    )
 
 
-class PointIDNeuronSet(IDNeuronSet, PointPopulationNeuronSet):
-    """Only point neuron node populations are selectable."""
+class NonVirtualIDNeuronSet(IDBaseNeuronSet, NonVirtualPopulationNeuronSet):
+    """Neuron set definition by providing a list of neuron IDs.
+
+    Resolved in one selected non-virtual node population.
+    """
+
+    title: ClassVar[str] = "Sample IDs (Non-Virtual)"
+    description: ClassVar[str] = (
+        "Use neurons by providing a list of IDs, resolved in a single non-virtual population."
+    )
+
+
+class PointIDNeuronSet(IDBaseNeuronSet, PointPopulationNeuronSet):
+    """Neuron set definition by providing a list of neuron IDs.
+
+    Resolved in one selected point neuron population.
+    """
 
     title: ClassVar[str] = "Sample IDs (Point)"
+    description: ClassVar[str] = (
+        "Use neurons by providing a list of IDs, resolved in a single point neuron population."
+    )

--- a/obi_one/scientific/blocks/neuron_sets_2/notes_PR821.md
+++ b/obi_one/scientific/blocks/neuron_sets_2/notes_PR821.md
@@ -1,0 +1,46 @@
+# Notes and remaining issues from PR#821
+
+Link: https://github.com/openbraininstitute/obi-one/pull/821
+
+
+## Add other types of point neurons
+
+There are two other types of point neuron we now support
+
+See [here](https://github.com/openbraininstitute/obi-one/blob/7cab6f0f3cad3a7fdf9412300f59f555e3c782ec/obi_one/scientific/library/circuit_metrics.py#L33)
+
+```
+TYPES_OF_POINT_NODES = ["point_process", "point_neuron", "brian2_point", "inait_point_neuron_lif"]
+```
+
+I think we'll need to update this statement. Also Circuit.get_node_population_names will need to be updated with this also. Are there other places too? Perhaps we can use a single list of constants across these different places
+
+Will handle this in a separate PR, since we need to rebase to main to have TYPES_OF_POINT_NODES available.
+
+
+## Solve circular import problem in CombinedNeuronSets
+
+I see. Yes, let's find a solution later. Just to make a note for later, two other possible solutions might be to:
+
+- Create a union within this class, which includes the class itself. Not sure if that's possible
+- We can't use CombinedNeuronSets within a CombinedNeuronSet - Hopefully we can avoid this
+
+
+## Proper use of general PredefinedNeuronSet and CombinedNeuronSet
+
+Only allowing the PredefinedNeuronSet and CombinedNeuronSet to be used as the source of spike replay
+
+Yes, this makes sense. But I am not even sure we should support spike replay from multiple populations within one stimulus block? Currently, it uses ALL_NEURON_SETS_REFERENCE_UNION which does not include the general CombinedNeuronSet and PredefinedNeuronSet types, but we can add them later of course.
+
+
+## Add missing neuron sets to unions
+
+I noticed that there are two neuron sets which are defined and potentially useful but not in unions_neuron_set2.py, namely:
+
+- NonVirtualCombinedNeuronSet - Useful as the target of the simulation, and potentially as the target of non virtual supporting stimuli + recordings? Related to your comment below: "not even sure we should support spike replay support spike replay from multiple populations within one stimulus block", but I think we can deal with this when we integrate with the simulation generation task?
+- AllNonVirtualNeurons - Also seems useful as the default target of the simulation?
+
+
+## NonVirtualPredefinedNeuronSet
+
+I agree. I think we can come back to NonVirtualPredefinedNeuronSet in the future if we need it, and consider which neuron sets are supported by the different stimuli when we integrate with the generate_simulations task

--- a/obi_one/scientific/blocks/neuron_sets_2/population.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/population.py
@@ -70,13 +70,13 @@ class PopulationBaseNeuronSet(NeuronSet, abc.ABC):
         add_node_set_to_circuit(c, {name: expression})
 
         try:
-            node_ids = c.nodes[self.population].ids(name)
+            node_ids = c.nodes[self.population].ids(name).tolist()
         except snap.BluepySnapError as e:
             # In case of an error (e.g., "No such attribute"), return empty list
             L.warning(e)
             node_ids = []
 
-        return list(node_ids)
+        return node_ids
 
     def get_neuron_ids(self, circuit: Circuit) -> dict[str, list[int]]:
         """Returns list of neuron IDs per population (with subsampling, if specified)."""
@@ -90,7 +90,7 @@ class PopulationBaseNeuronSet(NeuronSet, abc.ABC):
         if len(ids) == 0:
             L.warning("Neuron set empty!")
 
-        return {self.population: list(ids)}
+        return {self.population: ids.tolist()}
 
     def get_node_set_definition(
         self, circuit: Circuit, *, force_resolve_ids: bool = False

--- a/obi_one/scientific/blocks/neuron_sets_2/population.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/population.py
@@ -128,34 +128,6 @@ class PopulationBaseNeuronSet(NeuronSet, abc.ABC):
         return (expression, {})
 
 
-class PopulationNeuronSet(PopulationBaseNeuronSet):
-    """Sample a percentage of neurons from any population."""
-
-    title: ClassVar[str] = "Population Sample % (Any)"
-    description: ClassVar[str] = "Sample a percentage of neurons from a population of any type."
-
-    _neuron_set_population_type: ClassVar[NeuronSetPopulationType] = NeuronSetPopulationType.ANY
-
-    json_schema_extra_additions: ClassVar[dict] = {
-        SchemaKey.BLOCK_USABILITY_DICTIONARY: {
-            SchemaKey.PROPERTY_GROUP: MappedPropertiesGroup.CIRCUIT,
-            SchemaKey.PROPERTY: CircuitUsability.SHOW_NEURON_SETS,
-            SchemaKey.FALSE_MESSAGE: "This circuit has no populations.",
-        },
-    }
-
-    population: str = Field(
-        min_length=1,
-        title="Population",
-        description="Name of the node population to select from.",
-        json_schema_extra={
-            SchemaKey.UI_ELEMENT: UIElement.ENTITY_PROPERTY_DROPDOWN,
-            SchemaKey.PROPERTY_GROUP: MappedPropertiesGroup.CIRCUIT,
-            SchemaKey.PROPERTY: CircuitMappedProperties.NEURONAL_POPULATION,
-        },
-    )
-
-
 class BiophysicalPopulationNeuronSet(PopulationBaseNeuronSet):
     """Sample a percentage of neurons from a biophysical population."""
 
@@ -238,35 +210,5 @@ class VirtualPopulationNeuronSet(PopulationBaseNeuronSet):
             SchemaKey.UI_ELEMENT: UIElement.ENTITY_PROPERTY_DROPDOWN,
             SchemaKey.PROPERTY_GROUP: MappedPropertiesGroup.CIRCUIT,
             SchemaKey.PROPERTY: CircuitMappedProperties.VIRTUAL_NEURONAL_POPULATION,
-        },
-    )
-
-
-class NonVirtualPopulationNeuronSet(PopulationBaseNeuronSet):
-    """Sample a percentage of neurons from a non-virtual population."""
-
-    title: ClassVar[str] = "Population Sample % (Non-Virtual)"
-    description: ClassVar[str] = "Sample a percentage of neurons from a non-virtual population."
-
-    _neuron_set_population_type: ClassVar[NeuronSetPopulationType] = (
-        NeuronSetPopulationType.NONVIRTUAL
-    )
-
-    json_schema_extra_additions: ClassVar[dict] = {
-        SchemaKey.BLOCK_USABILITY_DICTIONARY: {
-            SchemaKey.PROPERTY_GROUP: MappedPropertiesGroup.CIRCUIT,
-            SchemaKey.PROPERTY: CircuitUsability.SHOW_NONVIRTUAL_NEURON_SETS,
-            SchemaKey.FALSE_MESSAGE: "This circuit has no non-virtual populations.",
-        },
-    }
-
-    population: str = Field(
-        min_length=1,
-        title="Population",
-        description="Name of the non-virtual node population to select from.",
-        json_schema_extra={
-            SchemaKey.UI_ELEMENT: UIElement.ENTITY_PROPERTY_DROPDOWN,
-            SchemaKey.PROPERTY_GROUP: MappedPropertiesGroup.CIRCUIT,
-            SchemaKey.PROPERTY: CircuitMappedProperties.NONVIRTUAL_NEURONAL_POPULATION,
         },
     )

--- a/obi_one/scientific/blocks/neuron_sets_2/population.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/population.py
@@ -64,12 +64,13 @@ class PopulationBaseNeuronSet(NeuronSet, abc.ABC):
 
     def _resolve_ids(self, circuit: Circuit) -> list[int]:
         """Returns the full list of neuron IDs (w/o subsampling)."""
+        c = circuit.sonata_circuit
         expression = self._get_expression(circuit)
         name = "__TMP_NODE_SET__"
-        add_node_set_to_circuit(circuit.sonata_circuit, {name: expression})
+        add_node_set_to_circuit(c, {name: expression})
 
         try:
-            node_ids = circuit.sonata_circuit.nodes[self.population].ids(name)
+            node_ids = c.nodes[self.population].ids(name)
         except snap.BluepySnapError as e:
             # In case of an error (e.g., "No such attribute"), return empty list
             L.warning(e)

--- a/obi_one/scientific/blocks/neuron_sets_2/population.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/population.py
@@ -53,11 +53,11 @@ class PopulationBaseNeuronSet(NeuronSet, abc.ABC):
         },
     )
 
-    def get_populations(self) -> list[str]:
+    def get_populations(self, circuit: Circuit) -> list[str]:
         """Returns population names included in the neuron set."""
         return [self.population]
 
-    def _get_expression(self, circuit: Circuit) -> dict:
+    def _get_expression(self, circuit: Circuit) -> dict | list:
         """Returns the SONATA node set expression (w/o subsampling)."""
         self.check_populations_in_circuit(circuit=circuit)
         return {"population": self.population}
@@ -71,7 +71,7 @@ class PopulationBaseNeuronSet(NeuronSet, abc.ABC):
         try:
             node_ids = circuit.sonata_circuit.nodes[self.population].ids(name)
         except snap.BluepySnapError as e:
-            # In case of an error, return empty list
+            # In case of an error (e.g., "No such attribute"), return empty list
             L.warning(e)
             node_ids = []
 

--- a/obi_one/scientific/blocks/neuron_sets_2/population.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/population.py
@@ -1,15 +1,14 @@
 import abc
 import logging
-from enum import StrEnum
 from typing import Annotated, ClassVar
 
 import bluepysnap as snap
 import numpy as np
-from pydantic import Field, NonNegativeFloat, model_validator
+from pydantic import Field, NonNegativeFloat
 
 from obi_one.core.schema import SchemaKey, UIElement
 from obi_one.core.units import Units
-from obi_one.scientific.blocks.neuron_sets_2.base import NeuronSet
+from obi_one.scientific.blocks.neuron_sets_2.base import NeuronSet, NeuronSetPopulationType
 from obi_one.scientific.library.circuit import Circuit
 from obi_one.scientific.library.entity_property_types import (
     CircuitMappedProperties,
@@ -22,35 +21,15 @@ from obi_one.scientific.library.sonata_circuit_helpers import (
 
 L = logging.getLogger(__name__)
 
-
-"""PopulationNeuronSet(NeuronSet) [NEW]
-- node_population
-- sample_percentage
-- sample_seed
-- _population_type
-
-- Allows a user to select a whole node population, i.e., restricted to a single node population
-- Supports sub-sampling
-- Is aware of the population type (i.e., biophysical, point, virtual)
-- Can be used for either biophysical, point, or virtual populations
-- Replaces: AllNeurons, nbS1VPMInputs, nbS1POmInputs, rCA1CA3Inputs, etc.
-"""
-
-
-class SonataPopulationType(StrEnum):
-    BIOPHYSICAL = "biophysical"
-    POINT = "point"
-    VIRTUAL = "virtual"
-
-
 _MAX_PERCENT = 100.0
 
 
-class PopulationNeuronSet(NeuronSet, abc.ABC):
-    """Abstract base class for neuron sets defined by node population and optional sub-sampling."""
+class PopulationBaseNeuronSet(NeuronSet, abc.ABC):
+    """Abstract base class for neuron sets defined by a node population \
+        and optional sub-sampling.
+    """
 
-    population: None = None
-    _population_type: SonataPopulationType | None = None
+    population: str
 
     sample_percentage: (
         Annotated[NonNegativeFloat, Field(le=100)]
@@ -74,27 +53,13 @@ class PopulationNeuronSet(NeuronSet, abc.ABC):
         },
     )
 
-    @model_validator(mode="after")
-    def check_population_exists_in_circuit(self, circuit: Circuit) -> None:
-        """Check self.population exists in circuit."""
-        if self.population is None:
-            msg = "Sub-class of PopulationNeuronSet must specify a node population name!"
-            raise ValueError(msg)
-        if self.population not in (
-            populations := Circuit.get_node_population_names(circuit.sonata_circuit)
-        ):
-            msg = (
-                f"Node population '{self.population}' not found in circuit '{circuit.name}'. "
-                f"Available node populations: {', '.join(populations)}"
-            )
-            raise ValueError(msg)
+    def get_populations(self) -> list[str]:
+        """Returns population names included in the neuron set."""
+        return [self.population]
 
-    def population_type(self, circuit: Circuit) -> SonataPopulationType:
-        """Returns the population type (i.e. biophysical, point, virtual)."""
-        return circuit.sonata_circuit.nodes[self.population].type
-
-    def _get_expression(self, circuit: Circuit) -> dict:  # noqa: ARG002
+    def _get_expression(self, circuit: Circuit) -> dict:
         """Returns the SONATA node set expression (w/o subsampling)."""
+        self.check_populations_in_circuit(circuit=circuit)
         return {"population": self.population}
 
     def _resolve_ids(self, circuit: Circuit) -> list[int]:
@@ -112,8 +77,8 @@ class PopulationNeuronSet(NeuronSet, abc.ABC):
 
         return node_ids
 
-    def get_neuron_ids(self, circuit: Circuit) -> np.ndarray:
-        """Returns list of neuron IDs (with subsampling, if specified)."""
+    def get_neuron_ids(self, circuit: Circuit) -> dict[str, np.ndarray]:
+        """Returns list of neuron IDs per population (with subsampling, if specified)."""
         ids = np.array(self._resolve_ids(circuit))
 
         if len(ids) > 0 and self.sample_percentage < _MAX_PERCENT:
@@ -124,11 +89,15 @@ class PopulationNeuronSet(NeuronSet, abc.ABC):
         if len(ids) == 0:
             L.warning("Neuron set empty!")
 
-        return ids
+        return {self.population: ids}
 
-    def get_node_set_definition(self, circuit: Circuit, *, force_resolve_ids: bool = False) -> dict:
-        """Returns the SONATA node set definition, optionally forcing to resolve individual \
-            IDs.
+    def get_node_set_definition(
+        self, circuit: Circuit, *, force_resolve_ids: bool = False
+    ) -> tuple[dict | list, dict]:
+        """Returns the SONATA node set definition, optionally forcing to resolve individual IDs.
+
+        In case of a compound expression (list expression), any new definitions
+        to be combined are returned as dict.
         """
         if self.sample_percentage == _MAX_PERCENT and not force_resolve_ids:
             # Symbolic expression can be preserved
@@ -137,18 +106,49 @@ class PopulationNeuronSet(NeuronSet, abc.ABC):
             # Individual IDs need to be resolved
             expression = {
                 "population": self.population,
-                "node_id": self.get_neuron_ids(circuit).tolist(),
+                "node_id": self.get_neuron_ids(circuit)[self.population].tolist(),
             }
 
-        return expression
+        return (expression, {})
 
 
-class BiophysicalPopulationNeuronSet(PopulationNeuronSet):
-    """Sample a percentage of neurons in a biophysical population."""
+class PopulationNeuronSet(PopulationBaseNeuronSet):
+    """Sample a percentage of neurons from any population."""
 
-    title: ClassVar[str] = "Sample % (Biophysical)"
+    title: ClassVar[str] = "Population Sample % (Any)"
+    description: ClassVar[str] = "Sample a percentage of neurons from a population of any type."
 
-    _population_type: ClassVar[SonataPopulationType] = SonataPopulationType.BIOPHYSICAL
+    _neuron_set_population_type: ClassVar[NeuronSetPopulationType] = NeuronSetPopulationType.ANY
+
+    json_schema_extra_additions: ClassVar[dict] = {
+        SchemaKey.BLOCK_USABILITY_DICTIONARY: {
+            SchemaKey.PROPERTY_GROUP: MappedPropertiesGroup.CIRCUIT,
+            SchemaKey.PROPERTY: CircuitUsability.SHOW_NEURON_SETS,
+            SchemaKey.FALSE_MESSAGE: "This circuit has no populations.",
+        },
+    }
+
+    population: str = Field(
+        min_length=1,
+        title="Population",
+        description="Name of the node population to select from.",
+        json_schema_extra={
+            SchemaKey.UI_ELEMENT: UIElement.ENTITY_PROPERTY_DROPDOWN,
+            SchemaKey.PROPERTY_GROUP: MappedPropertiesGroup.CIRCUIT,
+            SchemaKey.PROPERTY: CircuitMappedProperties.NEURONAL_POPULATION,
+        },
+    )
+
+
+class BiophysicalPopulationNeuronSet(PopulationBaseNeuronSet):
+    """Sample a percentage of neurons from a biophysical population."""
+
+    title: ClassVar[str] = "Population Sample % (Biophysical)"
+    description: ClassVar[str] = "Sample a percentage of neurons from a biophysical population."
+
+    _neuron_set_population_type: ClassVar[NeuronSetPopulationType] = (
+        NeuronSetPopulationType.BIOPHYSICAL
+    )
 
     json_schema_extra_additions: ClassVar[dict] = {
         SchemaKey.BLOCK_USABILITY_DICTIONARY: {
@@ -170,13 +170,13 @@ class BiophysicalPopulationNeuronSet(PopulationNeuronSet):
     )
 
 
-class PointPopulationNeuronSet(PopulationNeuronSet):
-    """Sample a percentage of neurons in a point neuron population."""
+class PointPopulationNeuronSet(PopulationBaseNeuronSet):
+    """Sample a percentage of neurons from a point neuron population."""
 
-    title: ClassVar[str] = "Sample % (Point)"
-    description: ClassVar[str] = "..."
+    title: ClassVar[str] = "Population Sample % (Point)"
+    description: ClassVar[str] = "Sample a percentage of neurons from a point neuron population."
 
-    _population_type: ClassVar[SonataPopulationType] = SonataPopulationType.POINT
+    _neuron_set_population_type: ClassVar[NeuronSetPopulationType] = NeuronSetPopulationType.POINT
 
     json_schema_extra_additions: ClassVar[dict] = {
         SchemaKey.BLOCK_USABILITY_DICTIONARY: {
@@ -198,13 +198,13 @@ class PointPopulationNeuronSet(PopulationNeuronSet):
     )
 
 
-class VirtualPopulationNeuronSet(PopulationNeuronSet):
-    """Sample a percentage of neurons in a virtual population."""
+class VirtualPopulationNeuronSet(PopulationBaseNeuronSet):
+    """Sample a percentage of neurons from a virtual population."""
 
-    title: ClassVar[str] = "Sample % (Virtual)"
-    description: ClassVar[str] = "..."
+    title: ClassVar[str] = "Population Sample % (Virtual)"
+    description: ClassVar[str] = "Sample a percentage of neurons from a virtual population."
 
-    _population_type: ClassVar[SonataPopulationType] = SonataPopulationType.VIRTUAL
+    _neuron_set_population_type: ClassVar[NeuronSetPopulationType] = NeuronSetPopulationType.VIRTUAL
 
     json_schema_extra_additions: ClassVar[dict] = {
         SchemaKey.BLOCK_USABILITY_DICTIONARY: {
@@ -222,5 +222,35 @@ class VirtualPopulationNeuronSet(PopulationNeuronSet):
             SchemaKey.UI_ELEMENT: UIElement.ENTITY_PROPERTY_DROPDOWN,
             SchemaKey.PROPERTY_GROUP: MappedPropertiesGroup.CIRCUIT,
             SchemaKey.PROPERTY: CircuitMappedProperties.VIRTUAL_NEURONAL_POPULATION,
+        },
+    )
+
+
+class NonVirtualPopulationNeuronSet(PopulationBaseNeuronSet):
+    """Sample a percentage of neurons from a non-virtual population."""
+
+    title: ClassVar[str] = "Population Sample % (Non-Virtual)"
+    description: ClassVar[str] = "Sample a percentage of neurons from a non-virtual population."
+
+    _neuron_set_population_type: ClassVar[NeuronSetPopulationType] = (
+        NeuronSetPopulationType.NONVIRTUAL
+    )
+
+    json_schema_extra_additions: ClassVar[dict] = {
+        SchemaKey.BLOCK_USABILITY_DICTIONARY: {
+            SchemaKey.PROPERTY_GROUP: MappedPropertiesGroup.CIRCUIT,
+            SchemaKey.PROPERTY: CircuitUsability.SHOW_NONVIRTUAL_NEURON_SETS,
+            SchemaKey.FALSE_MESSAGE: "This circuit has no non-virtual populations.",
+        },
+    }
+
+    population: str = Field(
+        min_length=1,
+        title="Population",
+        description="Name of the non-virtual node population to select from.",
+        json_schema_extra={
+            SchemaKey.UI_ELEMENT: UIElement.ENTITY_PROPERTY_DROPDOWN,
+            SchemaKey.PROPERTY_GROUP: MappedPropertiesGroup.CIRCUIT,
+            SchemaKey.PROPERTY: CircuitMappedProperties.NONVIRTUAL_NEURONAL_POPULATION,
         },
     )

--- a/obi_one/scientific/blocks/neuron_sets_2/population.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/population.py
@@ -53,7 +53,7 @@ class PopulationBaseNeuronSet(NeuronSet, abc.ABC):
         },
     )
 
-    def get_populations(self, circuit: Circuit) -> list[str]:
+    def get_populations(self, circuit: Circuit) -> list[str]:  # noqa: ARG002
         """Returns population names included in the neuron set."""
         return [self.population]
 
@@ -75,21 +75,21 @@ class PopulationBaseNeuronSet(NeuronSet, abc.ABC):
             L.warning(e)
             node_ids = []
 
-        return node_ids
+        return list(node_ids)
 
-    def get_neuron_ids(self, circuit: Circuit) -> dict[str, np.ndarray]:
+    def get_neuron_ids(self, circuit: Circuit) -> dict[str, list[int]]:
         """Returns list of neuron IDs per population (with subsampling, if specified)."""
         ids = np.array(self._resolve_ids(circuit))
 
-        if len(ids) > 0 and self.sample_percentage < _MAX_PERCENT:
+        if len(ids) > 0 and self.sample_percentage < _MAX_PERCENT:  # ty:ignore[unsupported-operator]
             rng = np.random.default_rng(self.sample_seed)
-            num_sample = np.round((self.sample_percentage / 100.0) * len(ids)).astype(int)
+            num_sample = np.round((self.sample_percentage / 100.0) * len(ids)).astype(int)  # ty:ignore[unsupported-operator]
             ids = ids[rng.permutation([True] * num_sample + [False] * (len(ids) - num_sample))]
 
         if len(ids) == 0:
             L.warning("Neuron set empty!")
 
-        return {self.population: ids}
+        return {self.population: list(ids)}
 
     def get_node_set_definition(
         self, circuit: Circuit, *, force_resolve_ids: bool = False
@@ -106,7 +106,7 @@ class PopulationBaseNeuronSet(NeuronSet, abc.ABC):
             # Individual IDs need to be resolved
             expression = {
                 "population": self.population,
-                "node_id": self.get_neuron_ids(circuit)[self.population].tolist(),
+                "node_id": self.get_neuron_ids(circuit)[self.population],
             }
 
         return (expression, {})

--- a/obi_one/scientific/blocks/neuron_sets_2/population.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/population.py
@@ -97,8 +97,23 @@ class PopulationBaseNeuronSet(NeuronSet, abc.ABC):
     ) -> tuple[dict | list, dict]:
         """Returns the SONATA node set definition, optionally forcing to resolve individual IDs.
 
-        In case of a compound expression (list expression), any new definitions
-        to be combined are returned as dict.
+        Returns a tuple of (expression, combined) where:
+
+        - expression (dict): A single SONATA node set expression. Examples:
+            - Symbolic by population: {"population": "pop_name"}
+            - Symbolic by properties: {"layer": "6", "synapse_class": "EXC"}
+            - Resolved IDs: {"population": "pop_name", "node_id": [1, 2, 3]}
+
+        - expression (list): A compound expression referencing multiple named node sets.
+            This is not used for population neuron sets.
+
+        - combined (dict): Additional node set definitions needed by a compound expression.
+            Always empty ({}) for population neuron sets.
+
+        Args:
+            circuit: The circuit to resolve the node set in.
+            force_resolve_ids: If True, always resolve to explicit neuron IDs
+                instead of preserving symbolic expressions.
         """
         if self.sample_percentage == _MAX_PERCENT and not force_resolve_ids:
             # Symbolic expression can be preserved

--- a/obi_one/scientific/blocks/neuron_sets_2/predefined.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/predefined.py
@@ -116,10 +116,14 @@ class PredefinedNeuronSet(PredefinedBaseNeuronSet):
         """
         if force_resolve_ids:
             # Resolve individual IDs per population and use in compound expression
+            if not self.has_block_name():
+                msg = "Block name must be set."
+                raise ValueError(msg)
+            prefix = f"__{self.__class__.__name__}__{self.block_name}"
             ids_per_npop = self.get_neuron_ids(circuit)
             expression, combined = NeuronSet.ids_to_node_set_definition(
                 ids_per_npop,
-                prefix=self.node_set,  # ty:ignore[invalid-argument-type]
+                prefix=prefix,  # ty:ignore[invalid-argument-type]
                 simplified=True,
             )
         else:

--- a/obi_one/scientific/blocks/neuron_sets_2/predefined.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/predefined.py
@@ -205,7 +205,7 @@ class PredefinedPopulationBaseNeuronSet(PredefinedBaseNeuronSet, PopulationBaseN
         return {"population": self.population, "node_id": node_ids}
 
 
-class PredefinedBiophysicalPopulationNeuronSet(
+class BiophysicalPopulationPredefinedNeuronSet(
     PredefinedPopulationBaseNeuronSet, BiophysicalPopulationNeuronSet
 ):
     """Use an existing node set already defined in the circuit's node sets file.
@@ -220,7 +220,7 @@ class PredefinedBiophysicalPopulationNeuronSet(
     )
 
 
-class PredefinedVirtualPopulationNeuronSet(
+class VirtualPopulationPredefinedNeuronSet(
     PredefinedPopulationBaseNeuronSet, VirtualPopulationNeuronSet
 ):
     """Use an existing node set already defined in the circuit's node sets file.
@@ -235,7 +235,7 @@ class PredefinedVirtualPopulationNeuronSet(
     )
 
 
-class PredefinedPointPopulationNeuronSet(
+class PointPopulationPredefinedNeuronSet(
     PredefinedPopulationBaseNeuronSet, PointPopulationNeuronSet
 ):
     """Use an existing node set already defined in the circuit's node sets file.

--- a/obi_one/scientific/blocks/neuron_sets_2/predefined.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/predefined.py
@@ -60,7 +60,7 @@ class PredefinedBaseNeuronSet(NeuronSet, abc.ABC):
             except snap.BluepySnapError:
                 # In case of an error (e.g., "No such attribute"), return empty list
                 node_ids = []
-            if node_ids:
+            if len(node_ids) > 0:
                 node_populations.append(npop)
         return node_populations
 
@@ -134,7 +134,7 @@ class PredefinedNeuronSet(PredefinedBaseNeuronSet):
         node_populations = self.get_populations(circuit)
         ids_dict = {}
         for npop in node_populations:
-            ids_dict[npop] = list(circuit.sonata_circuit.nodes[npop].ids(self.node_set))
+            ids_dict[npop] = circuit.sonata_circuit.nodes[npop].ids(self.node_set).tolist()
         return ids_dict
 
 
@@ -148,7 +148,7 @@ class PredefinedPopulationBaseNeuronSet(PredefinedBaseNeuronSet, PopulationBaseN
         self.check_node_set(circuit)
         self.check_populations_in_circuit(circuit=circuit)
         node_ids = circuit.sonata_circuit.nodes[self.population].ids(self.node_set)
-        return list(node_ids)
+        return node_ids.tolist()
 
     def _get_expression(self, circuit: Circuit) -> dict | list:
         """Returns the SONATA node set resolved in one population (w/o subsampling).

--- a/obi_one/scientific/blocks/neuron_sets_2/predefined.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/predefined.py
@@ -1,0 +1,241 @@
+import abc
+import logging
+from typing import Annotated, ClassVar
+
+import bluepysnap as snap
+import numpy as np
+from pydantic import Field
+
+from obi_one.core.schema import SchemaKey, UIElement
+from obi_one.scientific.blocks.neuron_sets_2.base import NeuronSet, NeuronSetPopulationType
+from obi_one.scientific.blocks.neuron_sets_2.population import (
+    BiophysicalPopulationNeuronSet,
+    NonVirtualPopulationNeuronSet,
+    PointPopulationNeuronSet,
+    PopulationBaseNeuronSet,
+    PopulationNeuronSet,
+    VirtualPopulationNeuronSet,
+)
+from obi_one.scientific.library.circuit import Circuit
+from obi_one.scientific.library.entity_property_types import (
+    CircuitMappedProperties,
+    MappedPropertiesGroup,
+)
+
+L = logging.getLogger(__name__)
+
+CircuitNode = Annotated[str, Field(min_length=1)]
+NodeSetType = CircuitNode | list[CircuitNode]
+
+
+class PredefinedBaseNeuronSet(NeuronSet, abc.ABC):
+    """Abstract base class for using an existing node set already defined in the circuit's
+    node sets file.
+    """
+
+    node_set: NodeSetType = Field(
+        title="Node Set",
+        description="Name of the node set to use.",
+        json_schema_extra={
+            SchemaKey.UI_ELEMENT: UIElement.ENTITY_PROPERTY_DROPDOWN_SWEEP,
+            SchemaKey.PROPERTY_GROUP: MappedPropertiesGroup.CIRCUIT,
+            SchemaKey.PROPERTY: CircuitMappedProperties.NODE_SET,
+        },
+    )
+
+    def check_node_set(self, circuit: Circuit) -> None:
+        if self.node_set not in circuit.node_sets:
+            msg = (
+                f"Node set '{self.node_set}' not found in circuit '{circuit.name}'. "
+                f"Available node sets: {', '.join(circuit.node_sets)}"
+            )
+            raise ValueError(msg)
+
+    @staticmethod
+    def get_node_set_populations(node_set: str, circuit: Circuit) -> list[str]:
+        """Returns a list of all node populations a node set resolves in."""
+        node_populations = []
+        for npop in circuit.sonata_circuit.nodes.population_names:
+            try:
+                node_ids = circuit.sonata_circuit.nodes[npop].ids(node_set)
+            except snap.BluepySnapError:
+                # In case of an error (e.g., "No such attribute"), return empty list
+                node_ids = []
+            if node_ids:
+                node_populations.append(npop)
+        return node_populations
+
+
+class PredefinedNeuronSet(PredefinedBaseNeuronSet):
+    """Use an existing node set already defined in the circuit's node sets file.
+
+    The node set may span multiple populations, as defined in the circuit's
+    node set definition.
+    """
+
+    title: ClassVar[str] = "Predefined Neuron Set (multi-population)"
+    description: ClassVar[str] = (
+        "Use neurons from a predefined node set from the SONATA circuit."
+        " May span multiple node populations."
+    )
+
+    _neuron_set_population_type: ClassVar[NeuronSetPopulationType] = NeuronSetPopulationType.ANY
+
+    def _get_expression(self, circuit: Circuit) -> dict | list:
+        """Returns the raw SONATA node set expression."""
+        self.check_node_set(circuit)
+        return [self.node_set]
+
+    def get_populations(self, circuit: Circuit) -> list[str]:
+        """Returns population names included in the neuron set."""
+        self.check_node_set(circuit)
+        nset_def = circuit.sonata_circuit.node_sets.content[self.node_set]
+
+        if "population" in nset_def:
+            node_populations = [nset_def["population"]]
+        else:
+            # Return all populations this node set resolves in
+            node_populations = PredefinedBaseNeuronSet.get_node_set_populations(
+                self.node_set,  # ty:ignore[invalid-argument-type]
+                circuit,
+            )
+            if not node_populations:
+                msg = (
+                    f"Node set '{self.node_set}' does not resolve in any"
+                    f" populations in circuit '{circuit}'!"
+                )
+                raise ValueError(msg)
+        return node_populations
+
+    def get_node_set_definition(
+        self, circuit: Circuit, *, force_resolve_ids: bool = False
+    ) -> tuple[dict | list, dict]:
+        """Returns the SONATA node set definition, optionally forcing to resolve individual IDs.
+
+        In case of a compound expression (list expression), any new definitions
+        to be combined are returned as dict.
+        """
+        if force_resolve_ids:
+            # Resolve individual IDs per population and use in compound expression
+            expression = []
+            combined = {}
+            ids_per_npop = self.get_neuron_ids(circuit)
+            for idx, (npop, ids) in enumerate(ids_per_npop.items()):
+                comb_key = f"{self.node_set}__{idx}__"
+                combined[comb_key] = {
+                    "population": npop,
+                    "node_id": ids.tolist(),
+                }
+                expression.append(comb_key)
+            if len(expression) == 1:
+                # Simplify to single expression
+                expression = combined[expression[0]]
+                combined = {}
+        else:
+            # Symbolic expression can be preserved
+            expression = self._get_expression(circuit)
+            combined = {}
+
+        return (expression, combined)
+
+    def get_neuron_ids(self, circuit: Circuit) -> dict[str, np.ndarray]:
+        """Returns list of neuron IDs per population."""
+        node_populations = self.get_populations(circuit)
+        ids_dict = {}
+        for npop in node_populations:
+            ids_dict[npop] = circuit.sonata_circuit.nodes[npop].ids(self.node_set)
+        return ids_dict
+
+
+class PredefinedPopulationBaseNeuronSet(PredefinedBaseNeuronSet, PopulationBaseNeuronSet, abc.ABC):
+    """Abstract class for using an existing node set already defined in the circuit's
+    node sets file resolved to a single node population.
+    """
+
+    def _resolve_ids(self, circuit: Circuit) -> list[int]:
+        """Returns the full list of neuron IDs (w/o subsampling)."""
+        self.check_node_set(circuit)
+        self.check_populations_in_circuit(circuit=circuit)
+        return circuit.sonata_circuit.nodes[self.population].ids(self.node_set)
+
+    def _get_expression(self, circuit: Circuit) -> dict | list:
+        """Returns the SONATA node set resolved in one population (w/o subsampling).
+
+        Always resolves IDs since snap doesn't support compound
+        population + node_set expressions.
+        """
+        node_ids = self._resolve_ids(circuit)
+        return {"population": self.population, "node_id": list(node_ids)}
+
+
+class PredefinedPopulationNeuronSet(PredefinedPopulationBaseNeuronSet, PopulationNeuronSet):
+    """Use an existing node set already defined in the circuit's node sets file.
+
+    The node set is resolved in one selected node population of any type.
+    """
+
+    title: ClassVar[str] = "Predefined Neuron Set (Any Population)"
+    description: ClassVar[str] = (
+        "Use neurons from a predefined node set from the SONATA circuit,"
+        " resolved in a single population of any type."
+    )
+
+
+class PredefinedBiophysicalPopulationNeuronSet(
+    PredefinedPopulationBaseNeuronSet, BiophysicalPopulationNeuronSet
+):
+    """Use an existing node set already defined in the circuit's node sets file.
+
+    The node set is resolved in one selected biophysical node population.
+    """
+
+    title: ClassVar[str] = "Predefined Neuron Set (Biophysical Population)"
+    description: ClassVar[str] = (
+        "Use neurons from a predefined node set from the SONATA circuit,"
+        " resolved in a single biophysical population."
+    )
+
+
+class PredefinedVirtualPopulationNeuronSet(
+    PredefinedPopulationBaseNeuronSet, VirtualPopulationNeuronSet
+):
+    """Use an existing node set already defined in the circuit's node sets file.
+
+    The node set is resolved in one selected virtual node population.
+    """
+
+    title: ClassVar[str] = "Predefined Neuron Set (Virtual Population)"
+    description: ClassVar[str] = (
+        "Use neurons from a predefined node set from the SONATA circuit,"
+        " resolved in a single virtual population."
+    )
+
+
+class PredefinedNonVirtualPopulationNeuronSet(
+    PredefinedPopulationBaseNeuronSet, NonVirtualPopulationNeuronSet
+):
+    """Use an existing node set already defined in the circuit's node sets file.
+
+    The node set is resolved in one selected non-virtual node population.
+    """
+
+    title: ClassVar[str] = "Predefined Neuron Set (Non-Virtual Population)"
+    description: ClassVar[str] = (
+        "Use neurons from a predefined node set from the SONATA circuit,"
+        " resolved in a single non-virtual population."
+    )
+
+
+class PredefinedPointPopulationNeuronSet(
+    PredefinedPopulationBaseNeuronSet, PointPopulationNeuronSet
+):
+    """Use an existing node set already defined in the circuit's node sets file.
+
+    The node set is resolved in one selected point neuron population.
+    """
+
+    title: ClassVar[str] = "Predefined Neuron Set (Point Population)"
+    description: ClassVar[str] = (
+        "Use neurons from a predefined node set from the SONATA circuit,"
+        " resolved in a single point neuron population."
+    )

--- a/obi_one/scientific/blocks/neuron_sets_2/predefined.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/predefined.py
@@ -116,20 +116,12 @@ class PredefinedNeuronSet(PredefinedBaseNeuronSet):
         """
         if force_resolve_ids:
             # Resolve individual IDs per population and use in compound expression
-            expression = []
-            combined = {}
             ids_per_npop = self.get_neuron_ids(circuit)
-            for idx, (npop, ids) in enumerate(ids_per_npop.items()):
-                comb_key = f"{self.node_set}__{idx}__"
-                combined[comb_key] = {
-                    "population": npop,
-                    "node_id": ids,
-                }
-                expression.append(comb_key)
-            if len(expression) == 1:
-                # Simplify to single expression
-                expression = combined[expression[0]]
-                combined = {}
+            expression, combined = NeuronSet.ids_to_node_set_definition(
+                ids_per_npop,
+                prefix=self.node_set,  # ty:ignore[invalid-argument-type]
+                simplified=True,
+            )
         else:
             # Symbolic expression can be preserved
             expression = self._get_expression(circuit)

--- a/obi_one/scientific/blocks/neuron_sets_2/predefined.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/predefined.py
@@ -135,6 +135,10 @@ class PredefinedNeuronSet(PredefinedBaseNeuronSet):
         ids_dict = {}
         for npop in node_populations:
             ids_dict[npop] = circuit.sonata_circuit.nodes[npop].ids(self.node_set).tolist()
+
+        if all(len(ids) == 0 for ids in ids_dict.values()):
+            L.warning("Neuron set empty!")
+
         return ids_dict
 
 

--- a/obi_one/scientific/blocks/neuron_sets_2/predefined.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/predefined.py
@@ -9,10 +9,8 @@ from obi_one.core.schema import SchemaKey, UIElement
 from obi_one.scientific.blocks.neuron_sets_2.base import NeuronSet, NeuronSetPopulationType
 from obi_one.scientific.blocks.neuron_sets_2.population import (
     BiophysicalPopulationNeuronSet,
-    NonVirtualPopulationNeuronSet,
     PointPopulationNeuronSet,
     PopulationBaseNeuronSet,
-    PopulationNeuronSet,
     VirtualPopulationNeuronSet,
 )
 from obi_one.scientific.library.circuit import Circuit
@@ -207,19 +205,6 @@ class PredefinedPopulationBaseNeuronSet(PredefinedBaseNeuronSet, PopulationBaseN
         return {"population": self.population, "node_id": node_ids}
 
 
-class PredefinedPopulationNeuronSet(PredefinedPopulationBaseNeuronSet, PopulationNeuronSet):
-    """Use an existing node set already defined in the circuit's node sets file.
-
-    The node set is resolved in one selected node population of any type.
-    """
-
-    title: ClassVar[str] = "Predefined Neuron Set (Any Population)"
-    description: ClassVar[str] = (
-        "Use neurons from a predefined node set from the SONATA circuit,"
-        " resolved in a single population of any type."
-    )
-
-
 class PredefinedBiophysicalPopulationNeuronSet(
     PredefinedPopulationBaseNeuronSet, BiophysicalPopulationNeuronSet
 ):
@@ -247,21 +232,6 @@ class PredefinedVirtualPopulationNeuronSet(
     description: ClassVar[str] = (
         "Use neurons from a predefined node set from the SONATA circuit,"
         " resolved in a single virtual population."
-    )
-
-
-class PredefinedNonVirtualPopulationNeuronSet(
-    PredefinedPopulationBaseNeuronSet, NonVirtualPopulationNeuronSet
-):
-    """Use an existing node set already defined in the circuit's node sets file.
-
-    The node set is resolved in one selected non-virtual node population.
-    """
-
-    title: ClassVar[str] = "Predefined Neuron Set (Non-Virtual Population)"
-    description: ClassVar[str] = (
-        "Use neurons from a predefined node set from the SONATA circuit,"
-        " resolved in a single non-virtual population."
     )
 
 

--- a/obi_one/scientific/blocks/neuron_sets_2/predefined.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/predefined.py
@@ -111,8 +111,27 @@ class PredefinedNeuronSet(PredefinedBaseNeuronSet):
     ) -> tuple[dict | list, dict]:
         """Returns the SONATA node set definition, optionally forcing to resolve individual IDs.
 
-        In case of a compound expression (list expression), any new definitions
-        to be combined are returned as dict.
+        Returns a tuple of (expression, combined) where:
+
+        - expression (dict): A single SONATA node set expression. Examples:
+            - Symbolic by population: {"population": "pop_name"}
+            - Symbolic by properties: {"layer": "6", "synapse_class": "EXC"}
+            - Resolved IDs: {"population": "pop_name", "node_id": [1, 2, 3]}
+
+        - expression (list): A compound expression referencing multiple named node sets.
+            Example: ["__ClassName__blockname__0__", "__ClassName__blockname__1__"]
+            Each name must exist as a key in the combined dict.
+            Also used for symbolic references to existing node sets: ["Layer6"]
+
+        - combined (dict): Additional node set definitions needed by a compound expression.
+            Example: {"__ClassName__blockname__0__": {"population": "A", "node_id": [...]},
+                      "__ClassName__blockname__1__": {"population": "B", "node_id": [...]}}
+            Empty ({}) when expression is a single dict.
+
+        Args:
+            circuit: The circuit to resolve the node set in.
+            force_resolve_ids: If True, always resolve to explicit neuron IDs
+                instead of preserving symbolic expressions.
         """
         if force_resolve_ids:
             # Resolve individual IDs per population and use in compound expression

--- a/obi_one/scientific/blocks/neuron_sets_2/predefined.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/predefined.py
@@ -123,7 +123,7 @@ class PredefinedNeuronSet(PredefinedBaseNeuronSet):
             ids_per_npop = self.get_neuron_ids(circuit)
             expression, combined = NeuronSet.ids_to_node_set_definition(
                 ids_per_npop,
-                prefix=prefix,  # ty:ignore[invalid-argument-type]
+                prefix=prefix,
                 simplified=True,
             )
         else:
@@ -140,7 +140,7 @@ class PredefinedNeuronSet(PredefinedBaseNeuronSet):
         for npop in node_populations:
             try:
                 node_ids = circuit.sonata_circuit.nodes[npop].ids(self.node_set).tolist()
-            except snap.BluepySnapError as e:
+            except snap.BluepySnapError:
                 # In case of an error (e.g., "No such attribute"), return empty list
                 node_ids = []
             ids_dict[npop] = node_ids
@@ -162,12 +162,12 @@ class PredefinedPopulationBaseNeuronSet(PredefinedBaseNeuronSet, PopulationBaseN
         self.check_populations_in_circuit(circuit)
         try:
             node_ids = circuit.sonata_circuit.nodes[self.population].ids(self.node_set)
-        except snap.BluepySnapError as e:
+        except snap.BluepySnapError:
             # In case of an error (e.g., "No such attribute"), return empty list
             L.warning("Neuron set empty!")
             return []
         return node_ids.tolist()
-    
+
     def _get_expression(self, circuit: Circuit) -> dict | list:
         """Returns the SONATA node set resolved in one population (w/o subsampling).
 

--- a/obi_one/scientific/blocks/neuron_sets_2/predefined.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/predefined.py
@@ -3,7 +3,6 @@ import logging
 from typing import Annotated, ClassVar
 
 import bluepysnap as snap
-import numpy as np
 from pydantic import Field
 
 from obi_one.core.schema import SchemaKey, UIElement
@@ -124,7 +123,7 @@ class PredefinedNeuronSet(PredefinedBaseNeuronSet):
                 comb_key = f"{self.node_set}__{idx}__"
                 combined[comb_key] = {
                     "population": npop,
-                    "node_id": ids.tolist(),
+                    "node_id": ids,
                 }
                 expression.append(comb_key)
             if len(expression) == 1:
@@ -138,12 +137,12 @@ class PredefinedNeuronSet(PredefinedBaseNeuronSet):
 
         return (expression, combined)
 
-    def get_neuron_ids(self, circuit: Circuit) -> dict[str, np.ndarray]:
+    def get_neuron_ids(self, circuit: Circuit) -> dict[str, list[int]]:
         """Returns list of neuron IDs per population."""
         node_populations = self.get_populations(circuit)
         ids_dict = {}
         for npop in node_populations:
-            ids_dict[npop] = circuit.sonata_circuit.nodes[npop].ids(self.node_set)
+            ids_dict[npop] = list(circuit.sonata_circuit.nodes[npop].ids(self.node_set))
         return ids_dict
 
 
@@ -156,7 +155,8 @@ class PredefinedPopulationBaseNeuronSet(PredefinedBaseNeuronSet, PopulationBaseN
         """Returns the full list of neuron IDs (w/o subsampling)."""
         self.check_node_set(circuit)
         self.check_populations_in_circuit(circuit=circuit)
-        return circuit.sonata_circuit.nodes[self.population].ids(self.node_set)
+        node_ids = circuit.sonata_circuit.nodes[self.population].ids(self.node_set)
+        return list(node_ids)
 
     def _get_expression(self, circuit: Circuit) -> dict | list:
         """Returns the SONATA node set resolved in one population (w/o subsampling).
@@ -165,7 +165,7 @@ class PredefinedPopulationBaseNeuronSet(PredefinedBaseNeuronSet, PopulationBaseN
         population + node_set expressions.
         """
         node_ids = self._resolve_ids(circuit)
-        return {"population": self.population, "node_id": list(node_ids)}
+        return {"population": self.population, "node_id": node_ids}
 
 
 class PredefinedPopulationNeuronSet(PredefinedPopulationBaseNeuronSet, PopulationNeuronSet):

--- a/obi_one/scientific/blocks/neuron_sets_2/predefined.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/predefined.py
@@ -134,7 +134,12 @@ class PredefinedNeuronSet(PredefinedBaseNeuronSet):
         node_populations = self.get_populations(circuit)
         ids_dict = {}
         for npop in node_populations:
-            ids_dict[npop] = circuit.sonata_circuit.nodes[npop].ids(self.node_set).tolist()
+            try:
+                node_ids = circuit.sonata_circuit.nodes[npop].ids(self.node_set).tolist()
+            except snap.BluepySnapError as e:
+                # In case of an error (e.g., "No such attribute"), return empty list
+                node_ids = []
+            ids_dict[npop] = node_ids
 
         if all(len(ids) == 0 for ids in ids_dict.values()):
             L.warning("Neuron set empty!")
@@ -150,10 +155,15 @@ class PredefinedPopulationBaseNeuronSet(PredefinedBaseNeuronSet, PopulationBaseN
     def _resolve_ids(self, circuit: Circuit) -> list[int]:
         """Returns the full list of neuron IDs (w/o subsampling)."""
         self.check_node_set(circuit)
-        self.check_populations_in_circuit(circuit=circuit)
-        node_ids = circuit.sonata_circuit.nodes[self.population].ids(self.node_set)
+        self.check_populations_in_circuit(circuit)
+        try:
+            node_ids = circuit.sonata_circuit.nodes[self.population].ids(self.node_set)
+        except snap.BluepySnapError as e:
+            # In case of an error (e.g., "No such attribute"), return empty list
+            L.warning("Neuron set empty!")
+            return []
         return node_ids.tolist()
-
+    
     def _get_expression(self, circuit: Circuit) -> dict | list:
         """Returns the SONATA node set resolved in one population (w/o subsampling).
 
@@ -167,8 +177,9 @@ class PredefinedPopulationBaseNeuronSet(PredefinedBaseNeuronSet, PopulationBaseN
         )
         if nset_populations == [self.population]:
             # Node set only resolves in this population — keep symbolic
+            self.check_populations_in_circuit(circuit)
             return [self.node_set]
-        # Resolves in multiple populations — must resolve IDs for this population
+        # Resolves in multiple (or none) populations — must resolve IDs for this population
         node_ids = self._resolve_ids(circuit)
         return {"population": self.population, "node_id": node_ids}
 

--- a/obi_one/scientific/blocks/neuron_sets_2/predefined.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/predefined.py
@@ -157,9 +157,18 @@ class PredefinedPopulationBaseNeuronSet(PredefinedBaseNeuronSet, PopulationBaseN
     def _get_expression(self, circuit: Circuit) -> dict | list:
         """Returns the SONATA node set resolved in one population (w/o subsampling).
 
-        Always resolves IDs since snap doesn't support compound
+        If the node set only resolves in self.population, keeps it symbolic.
+        Otherwise resolves IDs since snap doesn't support compound
         population + node_set expressions.
         """
+        nset_populations = PredefinedBaseNeuronSet.get_node_set_populations(
+            self.node_set,  # ty:ignore[invalid-argument-type]
+            circuit,
+        )
+        if nset_populations == [self.population]:
+            # Node set only resolves in this population — keep symbolic
+            return [self.node_set]
+        # Resolves in multiple populations — must resolve IDs for this population
         node_ids = self._resolve_ids(circuit)
         return {"population": self.population, "node_id": node_ids}
 

--- a/obi_one/scientific/blocks/neuron_sets_2/property.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/property.py
@@ -99,25 +99,51 @@ class PropertyBaseNeuronSet(PopulationBaseNeuronSet, abc.ABC):
     def check_properties(self, circuit: Circuit) -> None:
         self.property_filter.test_validity(circuit, self.population)  # ty:ignore[unresolved-attribute]
 
+    def _resolve_in_population(self, circuit: Circuit, population: str) -> list[int]:
+        """Resolve property filter in a given population, returning matching neuron IDs."""
+        c = circuit.sonata_circuit
+        try:
+            df = (
+                c.nodes[population]
+                .get(
+                    properties=self.property_filter.filter_keys  # ty:ignore[unresolved-attribute]
+                )
+                .reset_index()
+            )
+            df = self.property_filter.filter(df)  # ty:ignore[unresolved-attribute]
+        except Exception:  # noqa: BLE001
+            return []
+        return df["node_ids"].to_numpy().tolist()
+
     def _resolve_ids(self, circuit: Circuit) -> list[int]:
         """Returns the full list of neuron IDs (w/o subsampling)."""
         self.check_populations_in_circuit(circuit=circuit)
         self.check_properties(circuit)
-
-        c = circuit.sonata_circuit
-        df = c.nodes[self.population].get(properties=self.property_filter.filter_keys).reset_index()  # ty:ignore[unresolved-attribute]
-        df = self.property_filter.filter(df)  # ty:ignore[unresolved-attribute]
-        node_ids = df["node_ids"].to_numpy()
-
-        return node_ids.tolist()
+        return self._resolve_in_population(circuit, self.population)
 
     def _get_expression(self, circuit: Circuit) -> dict:
-        """Returns the SONATA node set resolved in one population (w/o subsampling).
+        """Returns the SONATA node set expression (w/o subsampling).
 
-        Always resolves IDs since snap doesn't support compound population +
-        property expressions.
+        If the property filter only matches neurons in self.population, keeps
+        it symbolic (without population key). Otherwise resolves IDs.
         """
         node_ids = self._resolve_ids(circuit)
+
+        # Check if properties also resolve in other populations
+        resolves_elsewhere = any(
+            len(self._resolve_in_population(circuit, npop)) > 0
+            for npop in circuit.sonata_circuit.nodes.population_names
+            if npop != self.population
+        )
+
+        if not resolves_elsewhere:
+            # Only resolves in self.population — keep symbolic (no population key)
+            expression = {}
+            for key, values in self.property_filter.filter_dict.items():  # ty:ignore[unresolved-attribute]
+                expression[key] = values[0] if len(values) == 1 else list(values)
+            return expression
+
+        # Resolves in multiple populations — must use explicit IDs
         return {"population": self.population, "node_id": node_ids}
 
 

--- a/obi_one/scientific/blocks/neuron_sets_2/property.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/property.py
@@ -127,7 +127,8 @@ class PropertyBaseNeuronSet(PopulationBaseNeuronSet, abc.ABC):
         If the property filter only matches neurons in self.population, keeps
         it symbolic (without population key). Otherwise resolves IDs.
         """
-        node_ids = self._resolve_ids(circuit)
+        self.check_populations_in_circuit(circuit=circuit)
+        self.check_properties(circuit)
 
         # Check if properties also resolve in other populations
         resolves_elsewhere = any(
@@ -144,6 +145,7 @@ class PropertyBaseNeuronSet(PopulationBaseNeuronSet, abc.ABC):
             return expression
 
         # Resolves in multiple populations — must use explicit IDs
+        node_ids = self._resolve_in_population(circuit, self.population)
         return {"population": self.population, "node_id": node_ids}
 
 

--- a/obi_one/scientific/blocks/neuron_sets_2/property.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/property.py
@@ -77,7 +77,7 @@ class NeuronPropertyFilter(OBIBaseModel):
         return string_rep[:-1]  # Remove trailing comma and space
 
 
-class PropertyBaseNeuronSet(PopulationBaseNeuronSet, abc.ABC):
+class PropertyPopulationBaseNeuronSet(PopulationBaseNeuronSet, abc.ABC):
     """Abstract base class for a neuron set definition based on neuron properties
     in a given node population.
     """
@@ -147,7 +147,9 @@ class PropertyBaseNeuronSet(PopulationBaseNeuronSet, abc.ABC):
         return {"population": self.population, "node_id": node_ids}
 
 
-class BiophysicalPropertyNeuronSet(PropertyBaseNeuronSet, BiophysicalPopulationNeuronSet):
+class BiophysicalPopulationPropertyNeuronSet(
+    PropertyPopulationBaseNeuronSet, BiophysicalPopulationNeuronSet
+):
     """Neuron set definition based on neuron properties.
 
     Resolved in one selected biophysical node population.
@@ -159,7 +161,9 @@ class BiophysicalPropertyNeuronSet(PropertyBaseNeuronSet, BiophysicalPopulationN
     )
 
 
-class VirtualPropertyNeuronSet(PropertyBaseNeuronSet, VirtualPopulationNeuronSet):
+class VirtualPopulationPropertyNeuronSet(
+    PropertyPopulationBaseNeuronSet, VirtualPopulationNeuronSet
+):
     """Neuron set definition based on neuron properties.
 
     Resolved in one selected virtual node population.
@@ -171,7 +175,7 @@ class VirtualPropertyNeuronSet(PropertyBaseNeuronSet, VirtualPopulationNeuronSet
     )
 
 
-class PointPropertyNeuronSet(PropertyBaseNeuronSet, PointPopulationNeuronSet):
+class PointPopulationPropertyNeuronSet(PropertyPopulationBaseNeuronSet, PointPopulationNeuronSet):
     """Neuron set definition based on neuron properties.
 
     Resolved in one selected point neuron population.

--- a/obi_one/scientific/blocks/neuron_sets_2/property.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/property.py
@@ -1,31 +1,25 @@
-"""PropertyNeuronSet(PopulationNeuronSet).
-
-- property_filter (may be refined)
-- Has a filter by node properties only
-- Available node properties dependent on the node population
-- No node sets any more (can be combined separately, see below)
-"""
-
+import abc
 import logging
 from typing import Annotated, ClassVar, Self
 
-import numpy as np
 import pandas as pd
 from pydantic import Field, model_validator
 
 from obi_one.core.base import OBIBaseModel
-from obi_one.scientific.blocks.neuron_sets_2.base import NeuronSet
+from obi_one.core.schema import SchemaKey, UIElement
+from obi_one.scientific.blocks.neuron_sets_2.population import (
+    BiophysicalPopulationNeuronSet,
+    NonVirtualPopulationNeuronSet,
+    PointPopulationNeuronSet,
+    PopulationBaseNeuronSet,
+    PopulationNeuronSet,
+    VirtualPopulationNeuronSet,
+)
 from obi_one.scientific.library.circuit import Circuit
 from obi_one.scientific.library.entity_property_types import (
     CircuitMappedProperties,
     MappedPropertiesGroup,
 )
-from obi_one.scientific.blocks.neuron_sets_2.population import (
-    BiophysicalPopulationNeuronSet,
-    PointPopulationNeuronSet,
-    VirtualPopulationNeuronSet,
-)
-from obi_one.core.schema import SchemaKey, UIElement
 
 L = logging.getLogger("obi-one")
 
@@ -33,9 +27,12 @@ L = logging.getLogger("obi-one")
 class NeuronPropertyFilter(OBIBaseModel):
     filter_dict: dict[str, list[str] | list[int]] = Field(
         title="Filter",
-        description="Filter dictionary. Note as this is NOT a Block and the list here is \
-                    not to support multi-dimensional parameters but to support a key-value pair \
-                    with multiple values i.e. {'layer': ['2', '3']}}")
+        description=(
+            "Filter dictionary. Note: this is NOT a Block and the list here is not to"
+            " support multi-dimensional parameters but to support a key-value pair with"
+            " multiple values i.e. {'layer': ['2', '3']}"
+        ),
+    )
 
     @model_validator(mode="after")
     def check_filter_dict_values(self) -> Self:
@@ -55,9 +52,9 @@ class NeuronPropertyFilter(OBIBaseModel):
 
     def filter(self, df_in: pd.DataFrame, *, reindex: bool = True) -> pd.DataFrame:
         ret = df_in
-        for filter_key, _filter_value in self.filter_dict.items():
-            filter_value = [str(_entry) for _entry in _filter_value]
-            vld = ret[filter_key].astype(str).isin(filter_value)
+        for filter_key, filter_values in self.filter_dict.items():
+            str_values = [str(entry) for entry in filter_values]
+            vld = ret[filter_key].astype(str).isin(str_values)
             ret = ret.loc[vld]
             if reindex:
                 ret = ret.reset_index(drop=True)
@@ -66,7 +63,7 @@ class NeuronPropertyFilter(OBIBaseModel):
     def test_validity(self, circuit: Circuit, node_population: str) -> None:
         circuit_prop_names = circuit.sonata_circuit.nodes[node_population].property_names
 
-        if not all(_prop in circuit_prop_names for _prop in self.filter_keys):
+        if not all(prop in circuit_prop_names for prop in self.filter_keys):
             msg = f"Invalid neuron properties! Available properties: {circuit_prop_names}"
             raise ValueError(msg)
 
@@ -82,93 +79,103 @@ class NeuronPropertyFilter(OBIBaseModel):
         return string_rep[:-1]  # Remove trailing comma and space
 
 
-class PropertyNeuronSet(NeuronSet):
-    """Neuron set definition based on neuron properties, optionally combined with (named) node \
-        sets.
+class PropertyBaseNeuronSet(PopulationBaseNeuronSet, abc.ABC):
+    """Abstract base class for a neuron set definition based on neuron properties
+    in a given node population.
     """
 
-    population: str = Field(
-        min_length=1,
-        title="Population",
-        description="Name of the biophysical node population to select from.",
-        json_schema_extra={
-            SchemaKey.UI_ELEMENT: UIElement.ENTITY_PROPERTY_DROPDOWN,
-            SchemaKey.PROPERTY_GROUP: MappedPropertiesGroup.CIRCUIT,
-            SchemaKey.PROPERTY: CircuitMappedProperties.BIOPHYSICAL_NEURONAL_POPULATION,
-            "property_filter_key": "property_filter",
-        },
-    )
-
-    property_filter: NeuronPropertyFilter | Annotated[list[NeuronPropertyFilter], Field(min_length=1)] = Field(
-        title="Neuron property filter",
-        description="NeuronPropertyFilter object or list of NeuronPropertyFilter objects",
+    property_filter: (
+        NeuronPropertyFilter | Annotated[list[NeuronPropertyFilter], Field(min_length=1)]
+    ) = Field(
+        title="Neuron Property Filter",
+        description="Neuron property values to use for filtering neuron IDs.",
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.NEURON_PROPERTY_FILTER,
             SchemaKey.PROPERTY_GROUP: MappedPropertiesGroup.CIRCUIT,
             SchemaKey.PROPERTY: CircuitMappedProperties.NODE_PROPERTY_UNIQUE_VALUES_BY_POPULATION,
-            "population_source_dropdown_key": "population",
         },
     )
 
-    def check_properties(self, circuit: Circuit, population: str | None = None) -> None:
-        population = self._population(population)
-        self.property_filter.test_validity(circuit, population)
+    def check_properties(self, circuit: Circuit) -> None:
+        self.property_filter.test_validity(circuit, self.population)  # ty:ignore[unresolved-attribute]
 
-    def _get_resolved_expression(self, circuit: Circuit, population: str | None = None) -> dict:
-        """A helper function used to make subclasses work."""
+    def _resolve_ids(self, circuit: Circuit) -> list[int]:
+        """Returns the full list of neuron IDs (w/o subsampling)."""
+        self.check_populations_in_circuit(circuit=circuit)
+        self.check_properties(circuit)
+
         c = circuit.sonata_circuit
-        population = self._population(population)
-
-        df = c.nodes[population].get(properties=self.property_filter.filter_keys).reset_index()
-        df = self.property_filter.filter(df)
-
+        df = c.nodes[self.population].get(properties=self.property_filter.filter_keys).reset_index()  # ty:ignore[unresolved-attribute]
+        df = self.property_filter.filter(df)  # ty:ignore[unresolved-attribute]
         node_ids = df["node_ids"].to_numpy()
 
-        if len(self.node_sets) > 0:
-            node_ids_nset = np.array([]).astype(int)
-            for _nset in self.node_sets:
-                node_ids_nset = np.union1d(node_ids_nset, c.nodes[population].ids(_nset))
-            node_ids = np.intersect1d(node_ids, node_ids_nset)
+        return list(node_ids)
 
-        expression = {"population": population, "node_id": node_ids.tolist()}
-        return expression
+    def _get_expression(self, circuit: Circuit) -> dict:
+        """Returns the SONATA node set resolved in one population (w/o subsampling).
 
-    def _get_expression(self, circuit: Circuit, population: str) -> dict:
-        """Returns the SONATA node set expression (w/o subsampling)."""
-        population = self._population(population)
-        self.check_properties(circuit, population)
-        self.check_node_sets(circuit, population)
+        Always resolves IDs since snap doesn't support compound population +
+        property expressions.
+        """
+        node_ids = self._resolve_ids(circuit)
+        return {"population": self.population, "node_id": node_ids}
 
-        def __resolve_sngl(prop_vals: list) -> list:
-            if len(prop_vals) == 1:
-                return prop_vals[0]
-            return list(prop_vals)
 
-        if len(self.node_sets) == 0:
-            # Symbolic expression can be preserved
-            expression = {
-                property_key: __resolve_sngl(property_value)
-                for property_key, property_value in self.property_filter.filter_dict.items()
-            }
-        else:
-            # Individual IDs need to be resolved
-            return self._get_resolved_expression(circuit, population)
+class PropertyNeuronSet(PropertyBaseNeuronSet, PopulationNeuronSet):
+    """Neuron set definition based on neuron properties.
 
-        return expression
-    
-class BiophysicalPropertyNeuronSet(PropertyNeuronSet, BiophysicalPopulationNeuronSet):
-    """Only biophysical neuron node populations are selectable."""
+    Resolved in one selected node population of any type.
+    """
+
+    title: ClassVar[str] = "By Properties (Any)"
+    description: ClassVar[str] = (
+        "Use neurons based on properties, resolved in a single population of any type."
+    )
+
+
+class BiophysicalPropertyNeuronSet(PropertyBaseNeuronSet, BiophysicalPopulationNeuronSet):
+    """Neuron set definition based on neuron properties.
+
+    Resolved in one selected biophysical node population.
+    """
 
     title: ClassVar[str] = "By Properties (Biophysical)"
+    description: ClassVar[str] = (
+        "Use neurons based on properties, resolved in a single biophysical population."
+    )
 
 
-class VirtualPropertyNeuronSet(PropertyNeuronSet, VirtualPopulationNeuronSet):
-    """Only virtual neuron node populations are selectable."""
+class VirtualPropertyNeuronSet(PropertyBaseNeuronSet, VirtualPopulationNeuronSet):
+    """Neuron set definition based on neuron properties.
+
+    Resolved in one selected virtual node population.
+    """
 
     title: ClassVar[str] = "By Properties (Virtual)"
+    description: ClassVar[str] = (
+        "Use neurons based on properties, resolved in a single virtual population."
+    )
 
 
-class PointPropertyNeuronSet(PropertyNeuronSet, PointPopulationNeuronSet):
-    """Only point neuron node populations are selectable."""
+class NonVirtualPropertyNeuronSet(PropertyBaseNeuronSet, NonVirtualPopulationNeuronSet):
+    """Neuron set definition based on neuron properties.
+
+    Resolved in one selected non-virtual node population.
+    """
+
+    title: ClassVar[str] = "By Properties (Non-Virtual)"
+    description: ClassVar[str] = (
+        "Use neurons based on properties, resolved in a single non-virtual population."
+    )
+
+
+class PointPropertyNeuronSet(PropertyBaseNeuronSet, PointPopulationNeuronSet):
+    """Neuron set definition based on neuron properties.
+
+    Resolved in one selected point neuron population.
+    """
 
     title: ClassVar[str] = "By Properties (Point)"
+    description: ClassVar[str] = (
+        "Use neurons based on properties, resolved in a single point neuron population."
+    )

--- a/obi_one/scientific/blocks/neuron_sets_2/property.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/property.py
@@ -109,7 +109,7 @@ class PropertyBaseNeuronSet(PopulationBaseNeuronSet, abc.ABC):
         df = self.property_filter.filter(df)  # ty:ignore[unresolved-attribute]
         node_ids = df["node_ids"].to_numpy()
 
-        return list(node_ids)
+        return node_ids.tolist()
 
     def _get_expression(self, circuit: Circuit) -> dict:
         """Returns the SONATA node set resolved in one population (w/o subsampling).

--- a/obi_one/scientific/blocks/neuron_sets_2/property.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/property.py
@@ -9,10 +9,8 @@ from obi_one.core.base import OBIBaseModel
 from obi_one.core.schema import SchemaKey, UIElement
 from obi_one.scientific.blocks.neuron_sets_2.population import (
     BiophysicalPopulationNeuronSet,
-    NonVirtualPopulationNeuronSet,
     PointPopulationNeuronSet,
     PopulationBaseNeuronSet,
-    PopulationNeuronSet,
     VirtualPopulationNeuronSet,
 )
 from obi_one.scientific.library.circuit import Circuit
@@ -149,18 +147,6 @@ class PropertyBaseNeuronSet(PopulationBaseNeuronSet, abc.ABC):
         return {"population": self.population, "node_id": node_ids}
 
 
-class PropertyNeuronSet(PropertyBaseNeuronSet, PopulationNeuronSet):
-    """Neuron set definition based on neuron properties.
-
-    Resolved in one selected node population of any type.
-    """
-
-    title: ClassVar[str] = "By Properties (Any)"
-    description: ClassVar[str] = (
-        "Use neurons based on properties, resolved in a single population of any type."
-    )
-
-
 class BiophysicalPropertyNeuronSet(PropertyBaseNeuronSet, BiophysicalPopulationNeuronSet):
     """Neuron set definition based on neuron properties.
 
@@ -182,18 +168,6 @@ class VirtualPropertyNeuronSet(PropertyBaseNeuronSet, VirtualPopulationNeuronSet
     title: ClassVar[str] = "By Properties (Virtual)"
     description: ClassVar[str] = (
         "Use neurons based on properties, resolved in a single virtual population."
-    )
-
-
-class NonVirtualPropertyNeuronSet(PropertyBaseNeuronSet, NonVirtualPopulationNeuronSet):
-    """Neuron set definition based on neuron properties.
-
-    Resolved in one selected non-virtual node population.
-    """
-
-    title: ClassVar[str] = "By Properties (Non-Virtual)"
-    description: ClassVar[str] = (
-        "Use neurons based on properties, resolved in a single non-virtual population."
     )
 
 

--- a/obi_one/scientific/blocks/neuron_sets_2/specific.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/specific.py
@@ -21,7 +21,30 @@ class AllNeuronsBase(NeuronSet, abc.ABC):
     def get_node_set_definition(
         self, circuit: Circuit, *, force_resolve_ids: bool = False
     ) -> tuple[dict | list, dict]:
-        """Returns node set definition combining all matching populations."""
+        """Returns the SONATA node set definition, optionally forcing to resolve individual IDs.
+
+        Returns a tuple of (expression, combined) where:
+
+        - expression (dict): A single SONATA node set expression. Examples:
+            - Symbolic by population: {"population": "pop_name"}
+            - Symbolic by properties: {"layer": "6", "synapse_class": "EXC"}
+            - Resolved IDs: {"population": "pop_name", "node_id": [1, 2, 3]}
+
+        - expression (list): A compound expression referencing multiple named node sets.
+            Example: ["__ClassName__blockname__0__", "__ClassName__blockname__1__"]
+            Each name must exist as a key in the combined dict.
+            Also used for symbolic references to existing node sets: ["Layer6"]
+
+        - combined (dict): Additional node set definitions needed by a compound expression.
+            Example: {"__ClassName__blockname__0__": {"population": "A", "node_id": [...]},
+                      "__ClassName__blockname__1__": {"population": "B", "node_id": [...]}}
+            Empty ({}) when expression is a single dict.
+
+        Args:
+            circuit: The circuit to resolve the node set in.
+            force_resolve_ids: If True, always resolve to explicit neuron IDs
+                instead of preserving symbolic expressions.
+        """
         if not self.has_block_name():
             msg = "Block name must be set."
             raise ValueError(msg)

--- a/obi_one/scientific/blocks/neuron_sets_2/specific.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/specific.py
@@ -1,0 +1,134 @@
+import abc
+import logging
+from typing import ClassVar
+
+from obi_one.scientific.blocks.neuron_sets_2.base import NeuronSet, NeuronSetPopulationType
+from obi_one.scientific.library.circuit import Circuit
+
+L = logging.getLogger(__name__)
+
+
+class AllNeuronsBase(NeuronSet, abc.ABC):
+    """Abstract base class for neuron sets selecting all neurons of a given type."""
+
+    def get_neuron_ids(self, circuit: Circuit) -> dict[str, list[int]]:
+        """Returns all neuron IDs per population."""
+        ids_dict = {}
+        for npop in self.get_populations(circuit):
+            ids_dict[npop] = circuit.sonata_circuit.nodes[npop].ids().tolist()
+        return ids_dict
+
+    def get_node_set_definition(
+        self, circuit: Circuit, *, force_resolve_ids: bool = False
+    ) -> tuple[dict | list, dict]:
+        """Returns node set definition combining all matching populations."""
+        if force_resolve_ids:
+            ids_per_npop = self.get_neuron_ids(circuit)
+            return NeuronSet.ids_to_node_set_definition(
+                ids_per_npop, prefix=self.block_name, simplified=True
+            )
+        # Symbolic: list all population node sets
+        populations = self.get_populations(circuit)
+        if len(populations) == 1:
+            return {"population": populations[0]}, {}
+        expression = []
+        combined = {}
+        for idx, npop in enumerate(populations):
+            key = f"{self.block_name}__{idx}__"
+            combined[key] = {"population": npop}
+            expression.append(key)
+        return expression, combined
+
+
+class AllNeurons(AllNeuronsBase):
+    """All neurons across all populations."""
+
+    title: ClassVar[str] = "All Neurons"
+    description: ClassVar[str] = "All neurons from all node populations."
+
+    _neuron_set_population_type: ClassVar[NeuronSetPopulationType] = NeuronSetPopulationType.ANY
+
+    def get_populations(self, circuit: Circuit) -> list[str]:  # noqa: PLR6301
+        """Returns all population names in the circuit."""
+        return Circuit.get_node_population_names(
+            circuit.sonata_circuit,
+            incl_biophysical=True,
+            incl_point=True,
+            incl_virtual=True,
+        )
+
+
+class AllBiophysicalNeurons(AllNeuronsBase):
+    """All biophysical neurons across all biophysical populations."""
+
+    title: ClassVar[str] = "All Biophysical Neurons"
+    description: ClassVar[str] = "All neurons from all biophysical node populations."
+
+    _neuron_set_population_type: ClassVar[NeuronSetPopulationType] = (
+        NeuronSetPopulationType.BIOPHYSICAL
+    )
+
+    def get_populations(self, circuit: Circuit) -> list[str]:  # noqa: PLR6301
+        """Returns all biophysical population names."""
+        return Circuit.get_node_population_names(
+            circuit.sonata_circuit,
+            incl_biophysical=True,
+            incl_point=False,
+            incl_virtual=False,
+        )
+
+
+class AllPointNeurons(AllNeuronsBase):
+    """All point neurons across all point neuron populations."""
+
+    title: ClassVar[str] = "All Point Neurons"
+    description: ClassVar[str] = "All neurons from all point neuron populations."
+
+    _neuron_set_population_type: ClassVar[NeuronSetPopulationType] = NeuronSetPopulationType.POINT
+
+    def get_populations(self, circuit: Circuit) -> list[str]:  # noqa: PLR6301
+        """Returns all point neuron population names."""
+        return Circuit.get_node_population_names(
+            circuit.sonata_circuit,
+            incl_biophysical=False,
+            incl_point=True,
+            incl_virtual=False,
+        )
+
+
+class AllVirtualNeurons(AllNeuronsBase):
+    """All virtual neurons across all virtual populations."""
+
+    title: ClassVar[str] = "All Virtual Neurons"
+    description: ClassVar[str] = "All neurons from all virtual node populations."
+
+    _neuron_set_population_type: ClassVar[NeuronSetPopulationType] = NeuronSetPopulationType.VIRTUAL
+
+    def get_populations(self, circuit: Circuit) -> list[str]:  # noqa: PLR6301
+        """Returns all virtual population names."""
+        return Circuit.get_node_population_names(
+            circuit.sonata_circuit,
+            incl_biophysical=False,
+            incl_point=False,
+            incl_virtual=True,
+        )
+
+
+class AllNonVirtualNeurons(AllNeuronsBase):
+    """All non-virtual neurons (biophysical + point) across all populations."""
+
+    title: ClassVar[str] = "All Non-Virtual Neurons"
+    description: ClassVar[str] = "All neurons from all non-virtual node populations."
+
+    _neuron_set_population_type: ClassVar[NeuronSetPopulationType] = (
+        NeuronSetPopulationType.NONVIRTUAL
+    )
+
+    def get_populations(self, circuit: Circuit) -> list[str]:  # noqa: PLR6301
+        """Returns all non-virtual population names."""
+        return Circuit.get_node_population_names(
+            circuit.sonata_circuit,
+            incl_biophysical=True,
+            incl_point=True,
+            incl_virtual=False,
+        )

--- a/obi_one/scientific/blocks/neuron_sets_2/specific.py
+++ b/obi_one/scientific/blocks/neuron_sets_2/specific.py
@@ -22,10 +22,14 @@ class AllNeuronsBase(NeuronSet, abc.ABC):
         self, circuit: Circuit, *, force_resolve_ids: bool = False
     ) -> tuple[dict | list, dict]:
         """Returns node set definition combining all matching populations."""
+        if not self.has_block_name():
+            msg = "Block name must be set."
+            raise ValueError(msg)
         if force_resolve_ids:
             ids_per_npop = self.get_neuron_ids(circuit)
+            prefix = f"__{self.__class__.__name__}__{self.block_name}"
             return NeuronSet.ids_to_node_set_definition(
-                ids_per_npop, prefix=self.block_name, simplified=True
+                ids_per_npop, prefix=prefix, simplified=True
             )
         # Symbolic: list all population node sets
         populations = self.get_populations(circuit)
@@ -34,7 +38,7 @@ class AllNeuronsBase(NeuronSet, abc.ABC):
         expression = []
         combined = {}
         for idx, npop in enumerate(populations):
-            key = f"{self.block_name}__{idx}__"
+            key = f"__{self.__class__.__name__}__{self.block_name}__{idx}__"
             combined[key] = {"population": npop}
             expression.append(key)
         return expression, combined

--- a/obi_one/scientific/blocks/stimuli/stimulus.py
+++ b/obi_one/scientific/blocks/stimuli/stimulus.py
@@ -718,7 +718,7 @@ class MultiLevelSEClampSomaticStimulus(ContinuousStimulusWithoutTimestamps):
             "duration_levels": [0]
             + [combination.duration for combination in self.duration_voltage[:-1]],
             "voltage_levels": [combination.voltage for combination in self.duration_voltage],
-            "node_set": resolve_neuron_set_ref_to_node_set(self.neuron_set, self._default_node_set),
+            "node_set": resolve_neuron_set_2_ref_to_node_set(self.neuron_set, self._default_node_set),
             "module": self._module,
             "input_type": self._input_type,
             "represents_physical_electrode": self._represents_physical_electrode,

--- a/obi_one/scientific/library/circuit.py
+++ b/obi_one/scientific/library/circuit.py
@@ -67,7 +67,11 @@ class Circuit(OBIBaseModel):
 
     @staticmethod
     def get_node_population_names(
-        c: snap.Circuit, *, incl_virtual: bool = True, incl_point: bool = True
+        c: snap.Circuit,
+        *,
+        incl_virtual: bool = True,
+        incl_point: bool = True,
+        incl_biophysical: bool = True,
     ) -> list:
         """Returns node population names."""
         popul_names = c.nodes.population_names
@@ -76,6 +80,8 @@ class Circuit(OBIBaseModel):
         if not incl_point:
             # Exclude "point_neuron", "point_process", etc. types
             popul_names = [pop for pop in popul_names if "point_" not in c.nodes[pop].type]
+        if not incl_biophysical:
+            popul_names = [pop for pop in popul_names if c.nodes[pop].type != "biophysical"]
         return popul_names
 
     @staticmethod
@@ -99,7 +105,11 @@ class Circuit(OBIBaseModel):
 
     @staticmethod
     def get_edge_population_names(
-        c: snap.Circuit, *, incl_virtual: bool = True, incl_point: bool = True
+        c: snap.Circuit,
+        *,
+        incl_virtual: bool = True,
+        incl_point: bool = True,
+        incl_biophysical: bool = True,
     ) -> list:
         """Returns edge population names."""
         popul_names = c.edges.population_names
@@ -112,6 +122,14 @@ class Circuit(OBIBaseModel):
                 for pop in popul_names
                 if "point_" not in c.edges[pop].source.type
                 and "point_" not in c.edges[pop].target.type
+            ]
+        if not incl_biophysical:
+            # Exclude biophysical source/target types
+            popul_names = [
+                pop
+                for pop in popul_names
+                if c.edges[pop].source.type != "biophysical"
+                and c.edges[pop].target.type != "biophysical"
             ]
         return popul_names
 

--- a/obi_one/scientific/library/entity_property_types.py
+++ b/obi_one/scientific/library/entity_property_types.py
@@ -14,8 +14,10 @@ class MappedPropertiesGroup(StrEnum):
 class CircuitMappedProperties(StrEnum):
     NODE_SET = "NodeSet"
     BIOPHYSICAL_NEURONAL_POPULATION = "BiophysicalNeuronalPopulation"
-    VIRTUAL_NEURONAL_POPULATION = "VirtualNeuronalPopulation"
     POINT_NEURONAL_POPULATION = "PointNeuronalPopulation"
+    VIRTUAL_NEURONAL_POPULATION = "VirtualNeuronalPopulation"
+    NONVIRTUAL_NEURONAL_POPULATION = "NonVirtualNeuronalPopulation"
+    NEURONAL_POPULATION = "NeuronalPopulation"
     MECHANISM_VARIABLES_BY_ION_CHANNEL = "MechanismVariablesByIonChannel"
     NODE_PROPERTY_UNIQUE_VALUES_BY_POPULATION = "NodePropertyUniqueValuesByPopulation"
 

--- a/obi_one/scientific/library/entity_property_types.py
+++ b/obi_one/scientific/library/entity_property_types.py
@@ -26,6 +26,8 @@ class CircuitUsability(StrEnum):
     SHOW_BIOPHYSICAL_NEURON_SETS = "ShowBiophysicalNeuronSets"
     SHOW_POINT_NEURON_SETS = "ShowPointNeuronSets"
     SHOW_VIRTUAL_NEURON_SETS = "ShowVirtualNeuronSets"
+    SHOW_NONVIRTUAL_NEURON_SETS = "ShowNonVirtualNeuronSets"
+    SHOW_NEURON_SETS = "ShowNeuronSets"
 
 
 class IonChannelPropertyType(StrEnum):

--- a/obi_one/scientific/unions/unions_neuron_sets_2.py
+++ b/obi_one/scientific/unions/unions_neuron_sets_2.py
@@ -5,21 +5,69 @@ from pydantic import Discriminator
 from obi_one.core.block_reference import BlockReference
 from obi_one.scientific.blocks.neuron_sets_2.id import (
     BiophysicalIDNeuronSet,
+    IDNeuronSet,
+    NonVirtualIDNeuronSet,
     PointIDNeuronSet,
     VirtualIDNeuronSet,
 )
+from obi_one.scientific.blocks.neuron_sets_2.population import (
+    BiophysicalPopulationNeuronSet,
+    NonVirtualPopulationNeuronSet,
+    PointPopulationNeuronSet,
+    PopulationNeuronSet,
+    VirtualPopulationNeuronSet,
+)
+from obi_one.scientific.blocks.neuron_sets_2.predefined import (
+    PredefinedBiophysicalPopulationNeuronSet,
+    PredefinedNeuronSet,
+    PredefinedNonVirtualPopulationNeuronSet,
+    PredefinedPointPopulationNeuronSet,
+    PredefinedPopulationNeuronSet,
+    PredefinedVirtualPopulationNeuronSet,
+)
 from obi_one.scientific.blocks.neuron_sets_2.property import (
     BiophysicalPropertyNeuronSet,
-    VirtualPropertyNeuronSet,
+    NonVirtualPropertyNeuronSet,
     PointPropertyNeuronSet,
+    PropertyNeuronSet,
+    VirtualPropertyNeuronSet,
 )
-from obi_one.scientific.blocks.neuron_sets.predefined import PredefinedNeuronSet
 
-_BIOPHYSICAL_NEURON_SETS = BiophysicalIDNeuronSet | BiophysicalPropertyNeuronSet | PredefinedNeuronSet
-_VIRTUAL_NEURON_SETS = VirtualIDNeuronSet | VirtualPropertyNeuronSet
-_POINT_NEURON_SETS = PointIDNeuronSet | PointPropertyNeuronSet
-_ALL_NEURON_SETS = _BIOPHYSICAL_NEURON_SETS | _VIRTUAL_NEURON_SETS | _POINT_NEURON_SETS
-_BIOPHYSICAL_AND_POINT_NEURON_SETS = _BIOPHYSICAL_NEURON_SETS | _POINT_NEURON_SETS
+_BIOPHYSICAL_NEURON_SETS = (
+    BiophysicalPopulationNeuronSet
+    | BiophysicalIDNeuronSet
+    | BiophysicalPropertyNeuronSet
+    | PredefinedBiophysicalPopulationNeuronSet
+)
+_VIRTUAL_NEURON_SETS = (
+    VirtualPopulationNeuronSet
+    | VirtualIDNeuronSet
+    | VirtualPropertyNeuronSet
+    | PredefinedVirtualPopulationNeuronSet
+)
+_POINT_NEURON_SETS = (
+    PointPopulationNeuronSet
+    | PointIDNeuronSet
+    | PointPropertyNeuronSet
+    | PredefinedPointPopulationNeuronSet
+)
+_NONVIRTUAL_NEURON_SETS = (
+    NonVirtualPopulationNeuronSet
+    | NonVirtualIDNeuronSet
+    | NonVirtualPropertyNeuronSet
+    | PredefinedNonVirtualPopulationNeuronSet
+)
+_ALL_NEURON_SETS = (
+    _BIOPHYSICAL_NEURON_SETS
+    | _VIRTUAL_NEURON_SETS
+    | _POINT_NEURON_SETS
+    | _NONVIRTUAL_NEURON_SETS
+    | PopulationNeuronSet
+    | IDNeuronSet
+    | PropertyNeuronSet
+    | PredefinedNeuronSet
+    | PredefinedPopulationNeuronSet
+)
 
 
 BiophysicalNeuronSetUnion = Annotated[
@@ -43,7 +91,7 @@ AllNeuronSetUnion = Annotated[
 ]
 
 NonVirtualNeuronSetUnion = Annotated[
-    _BIOPHYSICAL_AND_POINT_NEURON_SETS,
+    _NONVIRTUAL_NEURON_SETS,
     Discriminator("type"),
 ]
 
@@ -82,6 +130,9 @@ ALL_NEURON_SETS_REFERENCE_UNION = (
     BiophysicalNeuronSetReference | VirtualNeuronSetReference | PointNeuronSetReference
 )
 NON_VIRTUAL_NEURON_SETS_REFERENCE_UNION = BiophysicalNeuronSetReference | PointNeuronSetReference
+BIOPHYSICAL_NEURON_SETS_REFERENCE_UNION = BiophysicalNeuronSetReference
+VIRTUAL_NEURON_SETS_REFERENCE_UNION = VirtualNeuronSetReference
+POINT_NEURON_SETS_REFERENCE_UNION = PointNeuronSetReference
 
 ALL_NEURON_SETS_REFERENCE_TYPES = [
     BiophysicalNeuronSetReference.__name__,
@@ -90,6 +141,15 @@ ALL_NEURON_SETS_REFERENCE_TYPES = [
 ]
 NON_VIRTUAL_NEURON_SETS_REFERENCE_TYPES = [
     BiophysicalNeuronSetReference.__name__,
+    PointNeuronSetReference.__name__,
+]
+BIOPHYSICAL_NEURON_SETS_REFERENCE_TYPES = [
+    BiophysicalNeuronSetReference.__name__,
+]
+VIRTUAL_NEURON_SETS_REFERENCE_TYPES = [
+    VirtualNeuronSetReference.__name__,
+]
+POINT_NEURON_SETS_REFERENCE_TYPES = [
     PointNeuronSetReference.__name__,
 ]
 
@@ -115,6 +175,6 @@ def resolve_neuron_set_2_ref_to_neuron_set(
             )
             raise ValueError(msg)
 
-        return default_neuron_set_reference.block
+        return default_neuron_set_reference.block  # ty:ignore[invalid-return-type]
 
-    return neuron_set_reference.block
+    return neuron_set_reference.block  # ty:ignore[invalid-return-type]

--- a/obi_one/scientific/unions/unions_neuron_sets_2.py
+++ b/obi_one/scientific/unions/unions_neuron_sets_2.py
@@ -6,43 +6,33 @@ from obi_one.core.block_reference import BlockReference
 from obi_one.scientific.blocks.neuron_sets_2.combined import (
     BiophysicalCombinedNeuronSet,
     CombinedNeuronSet,
-    NonVirtualCombinedNeuronSet,
     PointCombinedNeuronSet,
     VirtualCombinedNeuronSet,
 )
 from obi_one.scientific.blocks.neuron_sets_2.id import (
     BiophysicalIDNeuronSet,
-    IDNeuronSet,
-    NonVirtualIDNeuronSet,
     PointIDNeuronSet,
     VirtualIDNeuronSet,
 )
 from obi_one.scientific.blocks.neuron_sets_2.population import (
     BiophysicalPopulationNeuronSet,
-    NonVirtualPopulationNeuronSet,
     PointPopulationNeuronSet,
-    PopulationNeuronSet,
     VirtualPopulationNeuronSet,
 )
 from obi_one.scientific.blocks.neuron_sets_2.predefined import (
     PredefinedBiophysicalPopulationNeuronSet,
     PredefinedNeuronSet,
-    PredefinedNonVirtualPopulationNeuronSet,
     PredefinedPointPopulationNeuronSet,
-    PredefinedPopulationNeuronSet,
     PredefinedVirtualPopulationNeuronSet,
 )
 from obi_one.scientific.blocks.neuron_sets_2.property import (
     BiophysicalPropertyNeuronSet,
-    NonVirtualPropertyNeuronSet,
     PointPropertyNeuronSet,
-    PropertyNeuronSet,
     VirtualPropertyNeuronSet,
 )
 from obi_one.scientific.blocks.neuron_sets_2.specific import (
     AllBiophysicalNeurons,
     AllNeurons,
-    AllNonVirtualNeurons,
     AllPointNeurons,
     AllVirtualNeurons,
 )
@@ -71,24 +61,13 @@ _POINT_NEURON_SETS = (
     | PointCombinedNeuronSet
     | AllPointNeurons
 )
-_NONVIRTUAL_NEURON_SETS = (
-    NonVirtualPopulationNeuronSet
-    | NonVirtualIDNeuronSet
-    | NonVirtualPropertyNeuronSet
-    | PredefinedNonVirtualPopulationNeuronSet
-    | NonVirtualCombinedNeuronSet
-    | AllNonVirtualNeurons
-)
+_NONVIRTUAL_NEURON_SETS = _BIOPHYSICAL_NEURON_SETS | _POINT_NEURON_SETS
 _ALL_NEURON_SETS = (
     _BIOPHYSICAL_NEURON_SETS
     | _VIRTUAL_NEURON_SETS
     | _POINT_NEURON_SETS
     | _NONVIRTUAL_NEURON_SETS
-    | PopulationNeuronSet
-    | IDNeuronSet
-    | PropertyNeuronSet
     | PredefinedNeuronSet
-    | PredefinedPopulationNeuronSet
     | CombinedNeuronSet
     | AllNeurons
 )

--- a/obi_one/scientific/unions/unions_neuron_sets_2.py
+++ b/obi_one/scientific/unions/unions_neuron_sets_2.py
@@ -3,6 +3,13 @@ from typing import Annotated, Any, ClassVar
 from pydantic import Discriminator
 
 from obi_one.core.block_reference import BlockReference
+from obi_one.scientific.blocks.neuron_sets_2.combined import (
+    BiophysicalCombinedNeuronSet,
+    CombinedNeuronSet,
+    NonVirtualCombinedNeuronSet,
+    PointCombinedNeuronSet,
+    VirtualCombinedNeuronSet,
+)
 from obi_one.scientific.blocks.neuron_sets_2.id import (
     BiophysicalIDNeuronSet,
     IDNeuronSet,
@@ -38,24 +45,28 @@ _BIOPHYSICAL_NEURON_SETS = (
     | BiophysicalIDNeuronSet
     | BiophysicalPropertyNeuronSet
     | PredefinedBiophysicalPopulationNeuronSet
+    | BiophysicalCombinedNeuronSet
 )
 _VIRTUAL_NEURON_SETS = (
     VirtualPopulationNeuronSet
     | VirtualIDNeuronSet
     | VirtualPropertyNeuronSet
     | PredefinedVirtualPopulationNeuronSet
+    | VirtualCombinedNeuronSet
 )
 _POINT_NEURON_SETS = (
     PointPopulationNeuronSet
     | PointIDNeuronSet
     | PointPropertyNeuronSet
     | PredefinedPointPopulationNeuronSet
+    | PointCombinedNeuronSet
 )
 _NONVIRTUAL_NEURON_SETS = (
     NonVirtualPopulationNeuronSet
     | NonVirtualIDNeuronSet
     | NonVirtualPropertyNeuronSet
     | PredefinedNonVirtualPopulationNeuronSet
+    | NonVirtualCombinedNeuronSet
 )
 _ALL_NEURON_SETS = (
     _BIOPHYSICAL_NEURON_SETS
@@ -67,6 +78,7 @@ _ALL_NEURON_SETS = (
     | PropertyNeuronSet
     | PredefinedNeuronSet
     | PredefinedPopulationNeuronSet
+    | CombinedNeuronSet
 )
 
 

--- a/obi_one/scientific/unions/unions_neuron_sets_2.py
+++ b/obi_one/scientific/unions/unions_neuron_sets_2.py
@@ -10,9 +10,9 @@ from obi_one.scientific.blocks.neuron_sets_2.combined import (
     VirtualCombinedNeuronSet,
 )
 from obi_one.scientific.blocks.neuron_sets_2.id import (
-    BiophysicalIDNeuronSet,
-    PointIDNeuronSet,
-    VirtualIDNeuronSet,
+    BiophysicalPopulationIDNeuronSet,
+    PointPopulationIDNeuronSet,
+    VirtualPopulationIDNeuronSet,
 )
 from obi_one.scientific.blocks.neuron_sets_2.population import (
     BiophysicalPopulationNeuronSet,
@@ -20,15 +20,15 @@ from obi_one.scientific.blocks.neuron_sets_2.population import (
     VirtualPopulationNeuronSet,
 )
 from obi_one.scientific.blocks.neuron_sets_2.predefined import (
-    PredefinedBiophysicalPopulationNeuronSet,
+    BiophysicalPopulationPredefinedNeuronSet,
+    PointPopulationPredefinedNeuronSet,
     PredefinedNeuronSet,
-    PredefinedPointPopulationNeuronSet,
-    PredefinedVirtualPopulationNeuronSet,
+    VirtualPopulationPredefinedNeuronSet,
 )
 from obi_one.scientific.blocks.neuron_sets_2.property import (
-    BiophysicalPropertyNeuronSet,
-    PointPropertyNeuronSet,
-    VirtualPropertyNeuronSet,
+    BiophysicalPopulationPropertyNeuronSet,
+    PointPopulationPropertyNeuronSet,
+    VirtualPopulationPropertyNeuronSet,
 )
 from obi_one.scientific.blocks.neuron_sets_2.specific import (
     AllBiophysicalNeurons,
@@ -39,25 +39,25 @@ from obi_one.scientific.blocks.neuron_sets_2.specific import (
 
 _BIOPHYSICAL_NEURON_SETS = (
     BiophysicalPopulationNeuronSet
-    | BiophysicalIDNeuronSet
-    | BiophysicalPropertyNeuronSet
-    | PredefinedBiophysicalPopulationNeuronSet
+    | BiophysicalPopulationIDNeuronSet
+    | BiophysicalPopulationPropertyNeuronSet
+    | BiophysicalPopulationPredefinedNeuronSet
     | BiophysicalCombinedNeuronSet
     | AllBiophysicalNeurons
 )
 _VIRTUAL_NEURON_SETS = (
     VirtualPopulationNeuronSet
-    | VirtualIDNeuronSet
-    | VirtualPropertyNeuronSet
-    | PredefinedVirtualPopulationNeuronSet
+    | VirtualPopulationIDNeuronSet
+    | VirtualPopulationPropertyNeuronSet
+    | VirtualPopulationPredefinedNeuronSet
     | VirtualCombinedNeuronSet
     | AllVirtualNeurons
 )
 _POINT_NEURON_SETS = (
     PointPopulationNeuronSet
-    | PointIDNeuronSet
-    | PointPropertyNeuronSet
-    | PredefinedPointPopulationNeuronSet
+    | PointPopulationIDNeuronSet
+    | PointPopulationPropertyNeuronSet
+    | PointPopulationPredefinedNeuronSet
     | PointCombinedNeuronSet
     | AllPointNeurons
 )

--- a/obi_one/scientific/unions/unions_neuron_sets_2.py
+++ b/obi_one/scientific/unions/unions_neuron_sets_2.py
@@ -39,6 +39,13 @@ from obi_one.scientific.blocks.neuron_sets_2.property import (
     PropertyNeuronSet,
     VirtualPropertyNeuronSet,
 )
+from obi_one.scientific.blocks.neuron_sets_2.specific import (
+    AllBiophysicalNeurons,
+    AllNeurons,
+    AllNonVirtualNeurons,
+    AllPointNeurons,
+    AllVirtualNeurons,
+)
 
 _BIOPHYSICAL_NEURON_SETS = (
     BiophysicalPopulationNeuronSet
@@ -46,6 +53,7 @@ _BIOPHYSICAL_NEURON_SETS = (
     | BiophysicalPropertyNeuronSet
     | PredefinedBiophysicalPopulationNeuronSet
     | BiophysicalCombinedNeuronSet
+    | AllBiophysicalNeurons
 )
 _VIRTUAL_NEURON_SETS = (
     VirtualPopulationNeuronSet
@@ -53,6 +61,7 @@ _VIRTUAL_NEURON_SETS = (
     | VirtualPropertyNeuronSet
     | PredefinedVirtualPopulationNeuronSet
     | VirtualCombinedNeuronSet
+    | AllVirtualNeurons
 )
 _POINT_NEURON_SETS = (
     PointPopulationNeuronSet
@@ -60,6 +69,7 @@ _POINT_NEURON_SETS = (
     | PointPropertyNeuronSet
     | PredefinedPointPopulationNeuronSet
     | PointCombinedNeuronSet
+    | AllPointNeurons
 )
 _NONVIRTUAL_NEURON_SETS = (
     NonVirtualPopulationNeuronSet
@@ -67,6 +77,7 @@ _NONVIRTUAL_NEURON_SETS = (
     | NonVirtualPropertyNeuronSet
     | PredefinedNonVirtualPopulationNeuronSet
     | NonVirtualCombinedNeuronSet
+    | AllNonVirtualNeurons
 )
 _ALL_NEURON_SETS = (
     _BIOPHYSICAL_NEURON_SETS
@@ -79,6 +90,7 @@ _ALL_NEURON_SETS = (
     | PredefinedNeuronSet
     | PredefinedPopulationNeuronSet
     | CombinedNeuronSet
+    | AllNeurons
 )
 
 

--- a/tests/obi_one/scientific/blocks/neuron_sets_2/test_base.py
+++ b/tests/obi_one/scientific/blocks/neuron_sets_2/test_base.py
@@ -7,10 +7,10 @@ import pytest
 import obi_one as obi
 from obi_one.scientific.blocks.neuron_sets_2.base import NeuronSet
 from obi_one.scientific.blocks.neuron_sets_2.predefined import (
-    PredefinedBiophysicalPopulationNeuronSet,
+    BiophysicalPopulationPredefinedNeuronSet,
 )
 from obi_one.scientific.blocks.neuron_sets_2.property import (
-    BiophysicalPropertyNeuronSet,
+    BiophysicalPopulationPropertyNeuronSet,
     NeuronPropertyFilter,
 )
 
@@ -72,7 +72,7 @@ def test_ids_to_node_set_definition_no_simplification():
 
 def test_add_node_set_to_sonata_circuit(circuit):
     """Test that a node set is added and queryable via bluepysnap."""
-    nset = BiophysicalPropertyNeuronSet(
+    nset = BiophysicalPopulationPropertyNeuronSet(
         population="S1nonbarrel_neurons",
         property_filter=NeuronPropertyFilter(
             filter_dict={"layer": ["6"], "synapse_class": ["EXC"]}
@@ -96,7 +96,7 @@ def test_add_node_set_to_sonata_circuit(circuit):
 
 def test_to_node_set_file(circuit, tmp_path):
     """Test writing a node set to a JSON file."""
-    nset = PredefinedBiophysicalPopulationNeuronSet(
+    nset = BiophysicalPopulationPredefinedNeuronSet(
         node_set="Layer6", population="S1nonbarrel_neurons"
     )
     nset.set_block_name("file_nset")
@@ -123,7 +123,7 @@ def test_to_node_set_file(circuit, tmp_path):
 
 def test_to_node_set_file_force_resolve(circuit, tmp_path):
     """Test writing with force_resolve_ids produces node_id in output."""
-    nset = PredefinedBiophysicalPopulationNeuronSet(
+    nset = BiophysicalPopulationPredefinedNeuronSet(
         node_set="Layer6", population="S1nonbarrel_neurons"
     )
     nset.set_block_name("file_resolved")
@@ -147,12 +147,12 @@ def test_to_node_set_file_force_resolve(circuit, tmp_path):
 
 def test_to_node_set_file_append(circuit, tmp_path):
     """Test appending a node set to an existing file."""
-    nset1 = PredefinedBiophysicalPopulationNeuronSet(
+    nset1 = BiophysicalPopulationPredefinedNeuronSet(
         node_set="Layer6", population="S1nonbarrel_neurons"
     )
     nset1.set_block_name("nset1")
 
-    nset2 = PredefinedBiophysicalPopulationNeuronSet(
+    nset2 = BiophysicalPopulationPredefinedNeuronSet(
         node_set="L6_BPC", population="S1nonbarrel_neurons"
     )
     nset2.set_block_name("nset2")

--- a/tests/obi_one/scientific/blocks/neuron_sets_2/test_base.py
+++ b/tests/obi_one/scientific/blocks/neuron_sets_2/test_base.py
@@ -1,0 +1,175 @@
+"""Tests for neuron_sets_2 base class utilities."""
+
+import json
+
+import pytest
+
+import obi_one as obi
+from obi_one.scientific.blocks.neuron_sets_2.base import NeuronSet
+from obi_one.scientific.blocks.neuron_sets_2.predefined import (
+    PredefinedPopulationNeuronSet,
+)
+from obi_one.scientific.blocks.neuron_sets_2.property import (
+    NeuronPropertyFilter,
+    PropertyNeuronSet,
+)
+
+from tests.utils import CIRCUIT_DIR, MATRIX_DIR
+
+CIRCUIT_NAME = "N_10__top_nodes_dim6"
+
+
+@pytest.fixture
+def circuit():
+    return obi.Circuit(
+        name=CIRCUIT_NAME,
+        path=str(CIRCUIT_DIR / CIRCUIT_NAME / "circuit_config.json"),
+        matrix_path=str(MATRIX_DIR / CIRCUIT_NAME / "connectivity_matrix.h5"),
+    )
+
+
+# --- ids_to_node_set_definition ---
+
+
+def test_ids_to_node_set_definition_single_population():
+    """Test simplification for single population."""
+    ids = {"S1nonbarrel_neurons": [1, 2, 3]}
+    nset_def, combined = NeuronSet.ids_to_node_set_definition(ids, prefix="__test", simplified=True)
+    # Single population -> simplified to dict
+    assert isinstance(nset_def, dict)
+    assert nset_def["population"] == "S1nonbarrel_neurons"
+    assert nset_def["node_id"] == [1, 2, 3]
+    assert combined == {}
+
+
+def test_ids_to_node_set_definition_multi_population():
+    """Test compound expression for multiple populations."""
+    ids = {"pop_a": [1, 2], "pop_b": [3, 4, 5]}
+    nset_def, combined = NeuronSet.ids_to_node_set_definition(ids, prefix="__test", simplified=True)
+    # Multiple populations -> compound expression
+    assert isinstance(nset_def, list)
+    assert len(nset_def) == 2
+    assert set(nset_def) == set(combined.keys())
+    for key in nset_def:
+        assert "population" in combined[key]
+        assert "node_id" in combined[key]
+
+
+def test_ids_to_node_set_definition_no_simplification():
+    """Test that simplified=False always returns a list."""
+    ids = {"S1nonbarrel_neurons": [1, 2, 3]}
+    nset_def, combined = NeuronSet.ids_to_node_set_definition(
+        ids, prefix="__test", simplified=False
+    )
+    # No simplification -> always list
+    assert isinstance(nset_def, list)
+    assert len(nset_def) == 1
+    assert len(combined) == 1
+
+
+# --- add_node_set_definition_to_sonata_circuit ---
+
+
+def test_add_node_set_to_sonata_circuit(circuit):
+    """Test that a node set is added and queryable via bluepysnap."""
+    nset = PropertyNeuronSet(
+        population="S1nonbarrel_neurons",
+        property_filter=NeuronPropertyFilter(
+            filter_dict={"layer": ["6"], "synapse_class": ["EXC"]}
+        ),
+    )
+    nset.set_block_name("added_nset")
+
+    nset_name, sonata_circuit = nset.add_node_set_definition_to_sonata_circuit(circuit)
+
+    # Verify it's in the node sets
+    assert nset_name in sonata_circuit.node_sets.content
+
+    # Verify it resolves correctly via bluepysnap
+    resolved_ids = sonata_circuit.nodes["S1nonbarrel_neurons"].ids(nset_name)
+    expected_ids = nset.get_neuron_ids(circuit)["S1nonbarrel_neurons"]
+    assert sorted(resolved_ids) == sorted(expected_ids)
+
+
+# --- to_node_set_file ---
+
+
+def test_to_node_set_file(circuit, tmp_path):
+    """Test writing a node set to a JSON file."""
+    nset = PredefinedPopulationNeuronSet(node_set="Layer6", population="S1nonbarrel_neurons")
+    nset.set_block_name("file_nset")
+
+    output_file = nset.to_node_set_file(
+        circuit,
+        output_path=str(tmp_path),
+        file_name="test_output.json",
+        overwrite_if_exists=True,
+        init_empty=True,
+    )
+
+    # File exists
+    assert output_file.exists()
+
+    # Valid JSON
+    with output_file.open() as f:
+        content = json.load(f)
+
+    # Contains the node set name
+    nset_name = f"__{nset.__class__.__name__}__{nset.block_name}"
+    assert nset_name in content
+
+
+def test_to_node_set_file_force_resolve(circuit, tmp_path):
+    """Test writing with force_resolve_ids produces node_id in output."""
+    nset = PredefinedPopulationNeuronSet(node_set="Layer6", population="S1nonbarrel_neurons")
+    nset.set_block_name("file_resolved")
+
+    output_file = nset.to_node_set_file(
+        circuit,
+        output_path=str(tmp_path),
+        file_name="test_resolved.json",
+        overwrite_if_exists=True,
+        init_empty=True,
+        force_resolve_ids=True,
+    )
+
+    with output_file.open() as f:
+        content = json.load(f)
+
+    nset_name = f"__{nset.__class__.__name__}__{nset.block_name}"
+    assert nset_name in content
+    assert "node_id" in content[nset_name]
+
+
+def test_to_node_set_file_append(circuit, tmp_path):
+    """Test appending a node set to an existing file."""
+    nset1 = PredefinedPopulationNeuronSet(node_set="Layer6", population="S1nonbarrel_neurons")
+    nset1.set_block_name("nset1")
+
+    nset2 = PredefinedPopulationNeuronSet(node_set="L6_BPC", population="S1nonbarrel_neurons")
+    nset2.set_block_name("nset2")
+
+    # Write first
+    output_file = nset1.to_node_set_file(
+        circuit,
+        output_path=str(tmp_path),
+        file_name="append_test.json",
+        overwrite_if_exists=True,
+        init_empty=True,
+    )
+
+    # Append second
+    nset2.to_node_set_file(
+        circuit,
+        output_path=str(tmp_path),
+        file_name="append_test.json",
+        append_if_exists=True,
+    )
+
+    with output_file.open() as f:
+        content = json.load(f)
+
+    name1 = f"__{nset1.__class__.__name__}__{nset1.block_name}"
+    name2 = f"__{nset2.__class__.__name__}__{nset2.block_name}"
+    assert name1 in content
+    assert name2 in content

--- a/tests/obi_one/scientific/blocks/neuron_sets_2/test_base.py
+++ b/tests/obi_one/scientific/blocks/neuron_sets_2/test_base.py
@@ -7,11 +7,11 @@ import pytest
 import obi_one as obi
 from obi_one.scientific.blocks.neuron_sets_2.base import NeuronSet
 from obi_one.scientific.blocks.neuron_sets_2.predefined import (
-    PredefinedPopulationNeuronSet,
+    PredefinedBiophysicalPopulationNeuronSet,
 )
 from obi_one.scientific.blocks.neuron_sets_2.property import (
+    BiophysicalPropertyNeuronSet,
     NeuronPropertyFilter,
-    PropertyNeuronSet,
 )
 
 from tests.utils import CIRCUIT_DIR, MATRIX_DIR
@@ -72,7 +72,7 @@ def test_ids_to_node_set_definition_no_simplification():
 
 def test_add_node_set_to_sonata_circuit(circuit):
     """Test that a node set is added and queryable via bluepysnap."""
-    nset = PropertyNeuronSet(
+    nset = BiophysicalPropertyNeuronSet(
         population="S1nonbarrel_neurons",
         property_filter=NeuronPropertyFilter(
             filter_dict={"layer": ["6"], "synapse_class": ["EXC"]}
@@ -96,7 +96,9 @@ def test_add_node_set_to_sonata_circuit(circuit):
 
 def test_to_node_set_file(circuit, tmp_path):
     """Test writing a node set to a JSON file."""
-    nset = PredefinedPopulationNeuronSet(node_set="Layer6", population="S1nonbarrel_neurons")
+    nset = PredefinedBiophysicalPopulationNeuronSet(
+        node_set="Layer6", population="S1nonbarrel_neurons"
+    )
     nset.set_block_name("file_nset")
 
     output_file = nset.to_node_set_file(
@@ -121,7 +123,9 @@ def test_to_node_set_file(circuit, tmp_path):
 
 def test_to_node_set_file_force_resolve(circuit, tmp_path):
     """Test writing with force_resolve_ids produces node_id in output."""
-    nset = PredefinedPopulationNeuronSet(node_set="Layer6", population="S1nonbarrel_neurons")
+    nset = PredefinedBiophysicalPopulationNeuronSet(
+        node_set="Layer6", population="S1nonbarrel_neurons"
+    )
     nset.set_block_name("file_resolved")
 
     output_file = nset.to_node_set_file(
@@ -143,10 +147,14 @@ def test_to_node_set_file_force_resolve(circuit, tmp_path):
 
 def test_to_node_set_file_append(circuit, tmp_path):
     """Test appending a node set to an existing file."""
-    nset1 = PredefinedPopulationNeuronSet(node_set="Layer6", population="S1nonbarrel_neurons")
+    nset1 = PredefinedBiophysicalPopulationNeuronSet(
+        node_set="Layer6", population="S1nonbarrel_neurons"
+    )
     nset1.set_block_name("nset1")
 
-    nset2 = PredefinedPopulationNeuronSet(node_set="L6_BPC", population="S1nonbarrel_neurons")
+    nset2 = PredefinedBiophysicalPopulationNeuronSet(
+        node_set="L6_BPC", population="S1nonbarrel_neurons"
+    )
     nset2.set_block_name("nset2")
 
     # Write first

--- a/tests/obi_one/scientific/blocks/neuron_sets_2/test_combined.py
+++ b/tests/obi_one/scientific/blocks/neuron_sets_2/test_combined.py
@@ -12,7 +12,7 @@ from obi_one.scientific.blocks.neuron_sets_2.population import (
     VirtualPopulationNeuronSet,
 )
 from obi_one.scientific.blocks.neuron_sets_2.predefined import (
-    PredefinedBiophysicalPopulationNeuronSet,
+    BiophysicalPopulationPredefinedNeuronSet,
 )
 from obi_one.scientific.unions.unions_neuron_sets_2 import (
     BiophysicalNeuronSetReference,
@@ -36,7 +36,7 @@ def circuit():
 @pytest.fixture
 def nset_a():
     """L6_BPC node set."""
-    nset = PredefinedBiophysicalPopulationNeuronSet(
+    nset = BiophysicalPopulationPredefinedNeuronSet(
         node_set="L6_BPC", population="S1nonbarrel_neurons"
     )
     nset.set_block_name("nset_a")
@@ -46,7 +46,7 @@ def nset_a():
 @pytest.fixture
 def nset_b():
     """L6_TPC:A node set."""
-    nset = PredefinedBiophysicalPopulationNeuronSet(
+    nset = BiophysicalPopulationPredefinedNeuronSet(
         node_set="L6_TPC:A", population="S1nonbarrel_neurons"
     )
     nset.set_block_name("nset_b")
@@ -220,7 +220,7 @@ def test_combined_biophysical_type_mismatch_symbolic(circuit):
     ref_virt.block = virt_nset
 
     # Create a biophysical neuron set
-    bio_nset = PredefinedBiophysicalPopulationNeuronSet(
+    bio_nset = BiophysicalPopulationPredefinedNeuronSet(
         node_set="L6_BPC", population="S1nonbarrel_neurons"
     )
     bio_nset.set_block_name("bio_pop")
@@ -247,7 +247,7 @@ def test_combined_biophysical_type_mismatch_resolved(circuit):
     ref_virt.block = virt_nset
 
     # Create a biophysical neuron set
-    bio_nset = PredefinedBiophysicalPopulationNeuronSet(
+    bio_nset = BiophysicalPopulationPredefinedNeuronSet(
         node_set="L6_BPC", population="S1nonbarrel_neurons"
     )
     bio_nset.set_block_name("bio_pop2")
@@ -271,17 +271,17 @@ def test_combined_biophysical_type_mismatch_resolved(circuit):
 def test_nested_combined(circuit):
     """Test combining a combined set with another set (depth > 1)."""
     # Create base sets
-    nset_a = PredefinedBiophysicalPopulationNeuronSet(
+    nset_a = BiophysicalPopulationPredefinedNeuronSet(
         node_set="L6_BPC", population="S1nonbarrel_neurons"
     )
     nset_a.set_block_name("nested_a")
 
-    nset_b = PredefinedBiophysicalPopulationNeuronSet(
+    nset_b = BiophysicalPopulationPredefinedNeuronSet(
         node_set="L6_TPC:A", population="S1nonbarrel_neurons"
     )
     nset_b.set_block_name("nested_b")
 
-    nset_c = PredefinedBiophysicalPopulationNeuronSet(
+    nset_c = BiophysicalPopulationPredefinedNeuronSet(
         node_set="Layer6", population="S1nonbarrel_neurons"
     )
     nset_c.set_block_name("nested_c")

--- a/tests/obi_one/scientific/blocks/neuron_sets_2/test_combined.py
+++ b/tests/obi_one/scientific/blocks/neuron_sets_2/test_combined.py
@@ -12,7 +12,7 @@ from obi_one.scientific.blocks.neuron_sets_2.population import (
     VirtualPopulationNeuronSet,
 )
 from obi_one.scientific.blocks.neuron_sets_2.predefined import (
-    PredefinedPopulationNeuronSet,
+    PredefinedBiophysicalPopulationNeuronSet,
 )
 from obi_one.scientific.unions.unions_neuron_sets_2 import (
     BiophysicalNeuronSetReference,
@@ -36,7 +36,9 @@ def circuit():
 @pytest.fixture
 def nset_a():
     """L6_BPC node set."""
-    nset = PredefinedPopulationNeuronSet(node_set="L6_BPC", population="S1nonbarrel_neurons")
+    nset = PredefinedBiophysicalPopulationNeuronSet(
+        node_set="L6_BPC", population="S1nonbarrel_neurons"
+    )
     nset.set_block_name("nset_a")
     return nset
 
@@ -44,7 +46,9 @@ def nset_a():
 @pytest.fixture
 def nset_b():
     """L6_TPC:A node set."""
-    nset = PredefinedPopulationNeuronSet(node_set="L6_TPC:A", population="S1nonbarrel_neurons")
+    nset = PredefinedBiophysicalPopulationNeuronSet(
+        node_set="L6_TPC:A", population="S1nonbarrel_neurons"
+    )
     nset.set_block_name("nset_b")
     return nset
 
@@ -216,7 +220,9 @@ def test_combined_biophysical_type_mismatch_symbolic(circuit):
     ref_virt.block = virt_nset
 
     # Create a biophysical neuron set
-    bio_nset = PredefinedPopulationNeuronSet(node_set="L6_BPC", population="S1nonbarrel_neurons")
+    bio_nset = PredefinedBiophysicalPopulationNeuronSet(
+        node_set="L6_BPC", population="S1nonbarrel_neurons"
+    )
     bio_nset.set_block_name("bio_pop")
     ref_bio = BiophysicalNeuronSetReference(block_dict_name="neuron_sets", block_name="bio_pop")
     ref_bio.block = bio_nset
@@ -241,7 +247,9 @@ def test_combined_biophysical_type_mismatch_resolved(circuit):
     ref_virt.block = virt_nset
 
     # Create a biophysical neuron set
-    bio_nset = PredefinedPopulationNeuronSet(node_set="L6_BPC", population="S1nonbarrel_neurons")
+    bio_nset = PredefinedBiophysicalPopulationNeuronSet(
+        node_set="L6_BPC", population="S1nonbarrel_neurons"
+    )
     bio_nset.set_block_name("bio_pop2")
     ref_bio = BiophysicalNeuronSetReference(block_dict_name="neuron_sets", block_name="bio_pop2")
     ref_bio.block = bio_nset
@@ -263,13 +271,19 @@ def test_combined_biophysical_type_mismatch_resolved(circuit):
 def test_nested_combined(circuit):
     """Test combining a combined set with another set (depth > 1)."""
     # Create base sets
-    nset_a = PredefinedPopulationNeuronSet(node_set="L6_BPC", population="S1nonbarrel_neurons")
+    nset_a = PredefinedBiophysicalPopulationNeuronSet(
+        node_set="L6_BPC", population="S1nonbarrel_neurons"
+    )
     nset_a.set_block_name("nested_a")
 
-    nset_b = PredefinedPopulationNeuronSet(node_set="L6_TPC:A", population="S1nonbarrel_neurons")
+    nset_b = PredefinedBiophysicalPopulationNeuronSet(
+        node_set="L6_TPC:A", population="S1nonbarrel_neurons"
+    )
     nset_b.set_block_name("nested_b")
 
-    nset_c = PredefinedPopulationNeuronSet(node_set="Layer6", population="S1nonbarrel_neurons")
+    nset_c = PredefinedBiophysicalPopulationNeuronSet(
+        node_set="Layer6", population="S1nonbarrel_neurons"
+    )
     nset_c.set_block_name("nested_c")
 
     # Create references

--- a/tests/obi_one/scientific/blocks/neuron_sets_2/test_combined.py
+++ b/tests/obi_one/scientific/blocks/neuron_sets_2/test_combined.py
@@ -255,3 +255,54 @@ def test_combined_biophysical_type_mismatch_resolved(circuit):
     # Should fail in resolved path — virtual population not valid for biophysical type
     with pytest.raises(ValueError, match="not found in circuit"):
         combined.get_node_set_definition(circuit)
+
+
+# --- Nested combined ---
+
+
+def test_nested_combined(circuit):
+    """Test combining a combined set with another set (depth > 1)."""
+    # Create base sets
+    nset_a = PredefinedPopulationNeuronSet(node_set="L6_BPC", population="S1nonbarrel_neurons")
+    nset_a.set_block_name("nested_a")
+
+    nset_b = PredefinedPopulationNeuronSet(node_set="L6_TPC:A", population="S1nonbarrel_neurons")
+    nset_b.set_block_name("nested_b")
+
+    nset_c = PredefinedPopulationNeuronSet(node_set="Layer6", population="S1nonbarrel_neurons")
+    nset_c.set_block_name("nested_c")
+
+    # Create references
+    ref_a = BiophysicalNeuronSetReference(block_dict_name="neuron_sets", block_name="nested_a")
+    ref_a.block = nset_a
+    ref_b = BiophysicalNeuronSetReference(block_dict_name="neuron_sets", block_name="nested_b")
+    ref_b.block = nset_b
+    ref_c = BiophysicalNeuronSetReference(block_dict_name="neuron_sets", block_name="nested_c")
+    ref_c.block = nset_c
+
+    # Create inner combined (A union B)
+    inner = BiophysicalCombinedNeuronSet(
+        base_neuron_set=ref_a, combined_with=ref_b, operation=SetOperation.UNION
+    )
+    inner.set_block_name("inner_combined")
+
+    # Create reference to inner
+    ref_inner = BiophysicalNeuronSetReference(
+        block_dict_name="neuron_sets", block_name="inner_combined"
+    )
+    ref_inner.block = inner
+
+    # Create outer combined (inner intersect C)
+    outer = BiophysicalCombinedNeuronSet(
+        base_neuron_set=ref_inner, combined_with=ref_c, operation=SetOperation.INTERSECT
+    )
+    outer.set_block_name("outer_combined")
+
+    # (A union B) intersect C = [1, 2, 6, 7, 8, 9]
+    ids_a = set(nset_a.get_neuron_ids(circuit)["S1nonbarrel_neurons"])
+    ids_b = set(nset_b.get_neuron_ids(circuit)["S1nonbarrel_neurons"])
+    ids_c = set(nset_c.get_neuron_ids(circuit)["S1nonbarrel_neurons"])
+    expected = sorted((ids_a | ids_b) & ids_c)
+
+    result = outer.get_neuron_ids(circuit)
+    assert sorted(result["S1nonbarrel_neurons"]) == expected

--- a/tests/obi_one/scientific/blocks/neuron_sets_2/test_combined.py
+++ b/tests/obi_one/scientific/blocks/neuron_sets_2/test_combined.py
@@ -1,0 +1,257 @@
+"""Tests for neuron_sets_2 combined neuron sets."""
+
+import numpy as np
+import pytest
+
+import obi_one as obi
+from obi_one.scientific.blocks.neuron_sets_2.combined import (
+    BiophysicalCombinedNeuronSet,
+    SetOperation,
+)
+from obi_one.scientific.blocks.neuron_sets_2.population import (
+    VirtualPopulationNeuronSet,
+)
+from obi_one.scientific.blocks.neuron_sets_2.predefined import (
+    PredefinedPopulationNeuronSet,
+)
+from obi_one.scientific.unions.unions_neuron_sets_2 import (
+    BiophysicalNeuronSetReference,
+    VirtualNeuronSetReference,
+)
+
+from tests.utils import CIRCUIT_DIR, MATRIX_DIR
+
+CIRCUIT_NAME = "N_10__top_nodes_dim6"
+
+
+@pytest.fixture
+def circuit():
+    return obi.Circuit(
+        name=CIRCUIT_NAME,
+        path=str(CIRCUIT_DIR / CIRCUIT_NAME / "circuit_config.json"),
+        matrix_path=str(MATRIX_DIR / CIRCUIT_NAME / "connectivity_matrix.h5"),
+    )
+
+
+@pytest.fixture
+def nset_a():
+    """L6_BPC node set."""
+    nset = PredefinedPopulationNeuronSet(node_set="L6_BPC", population="S1nonbarrel_neurons")
+    nset.set_block_name("nset_a")
+    return nset
+
+
+@pytest.fixture
+def nset_b():
+    """L6_TPC:A node set."""
+    nset = PredefinedPopulationNeuronSet(node_set="L6_TPC:A", population="S1nonbarrel_neurons")
+    nset.set_block_name("nset_b")
+    return nset
+
+
+@pytest.fixture
+def ref_a(nset_a):
+    """BlockReference wrapping nset_a."""
+    ref = BiophysicalNeuronSetReference(block_dict_name="neuron_sets", block_name="nset_a")
+    ref.block = nset_a
+    return ref
+
+
+@pytest.fixture
+def ref_b(nset_b):
+    """BlockReference wrapping nset_b."""
+    ref = BiophysicalNeuronSetReference(block_dict_name="neuron_sets", block_name="nset_b")
+    ref.block = nset_b
+    return ref
+
+
+def test_combined_union(circuit, ref_a, ref_b, nset_a, nset_b):
+    """Test union operation combines IDs from both sets."""
+    combined = BiophysicalCombinedNeuronSet(
+        base_neuron_set=ref_a, combined_with=ref_b, operation=SetOperation.UNION
+    )
+    combined.set_block_name("union_ab")
+
+    ids_a = nset_a.get_neuron_ids(circuit)["S1nonbarrel_neurons"]
+    ids_b = nset_b.get_neuron_ids(circuit)["S1nonbarrel_neurons"]
+    expected = sorted(set(ids_a) | set(ids_b))
+
+    result = combined.get_neuron_ids(circuit)
+    assert "S1nonbarrel_neurons" in result
+    np.testing.assert_array_equal(sorted(result["S1nonbarrel_neurons"]), expected)
+
+
+def test_combined_intersection(circuit, ref_a, ref_b, nset_a, nset_b):
+    """Test intersection operation returns common IDs."""
+    combined = BiophysicalCombinedNeuronSet(
+        base_neuron_set=ref_a, combined_with=ref_b, operation=SetOperation.INTERSECT
+    )
+    combined.set_block_name("intersect_ab")
+
+    ids_a = nset_a.get_neuron_ids(circuit)["S1nonbarrel_neurons"]
+    ids_b = nset_b.get_neuron_ids(circuit)["S1nonbarrel_neurons"]
+    expected = sorted(set(ids_a) & set(ids_b))
+
+    result = combined.get_neuron_ids(circuit)
+    assert "S1nonbarrel_neurons" in result
+    np.testing.assert_array_equal(sorted(result["S1nonbarrel_neurons"]), expected)
+
+
+def test_combined_difference(circuit, ref_a, ref_b, nset_a, nset_b):
+    """Test difference operation returns A - B."""
+    combined = BiophysicalCombinedNeuronSet(
+        base_neuron_set=ref_a, combined_with=ref_b, operation=SetOperation.DIFF
+    )
+    combined.set_block_name("diff_ab")
+
+    ids_a = nset_a.get_neuron_ids(circuit)["S1nonbarrel_neurons"]
+    ids_b = nset_b.get_neuron_ids(circuit)["S1nonbarrel_neurons"]
+    expected = sorted(set(ids_a) - set(ids_b))
+
+    result = combined.get_neuron_ids(circuit)
+    np.testing.assert_array_equal(sorted(result["S1nonbarrel_neurons"]), expected)
+
+
+def test_combined_union_symbolic(circuit, ref_a, ref_b):
+    """Test union produces symbolic expression (not resolved IDs)."""
+    combined = BiophysicalCombinedNeuronSet(
+        base_neuron_set=ref_a, combined_with=ref_b, operation=SetOperation.UNION
+    )
+    combined.set_block_name("union_sym")
+
+    nset_def, combined_defs = combined.get_node_set_definition(circuit)
+    # Union -> symbolic compound expression
+    assert isinstance(nset_def, list)
+    assert len(nset_def) == 2
+    # Every key in the expression list must exist in combined_defs
+    assert set(nset_def) == set(combined_defs.keys())
+
+
+def test_combined_intersect_resolves_ids(circuit, ref_a, ref_b):
+    """Test intersection always resolves IDs (non-union operation)."""
+    combined = BiophysicalCombinedNeuronSet(
+        base_neuron_set=ref_a, combined_with=ref_b, operation=SetOperation.INTERSECT
+    )
+    combined.set_block_name("intersect_resolve")
+
+    nset_def, _ = combined.get_node_set_definition(circuit)
+    # Non-union -> resolved IDs (simplified to dict for single population)
+    assert isinstance(nset_def, dict)
+    assert "node_id" in nset_def
+
+
+def test_combined_missing_ref(circuit, ref_a):
+    """Test that None reference raises."""
+    combined = BiophysicalCombinedNeuronSet(
+        base_neuron_set=ref_a, combined_with=None, operation=SetOperation.UNION
+    )
+    combined.set_block_name("missing_ref")
+
+    with pytest.raises(ValueError, match="Both neuron set references must be set"):
+        combined.get_neuron_ids(circuit)
+
+
+def test_combined_recursive_cycle(circuit, ref_a, ref_b):
+    """Test that a recursive cycle is detected."""
+    combined_x = BiophysicalCombinedNeuronSet(
+        base_neuron_set=ref_a, combined_with=ref_b, operation=SetOperation.UNION
+    )
+    combined_x.set_block_name("combined_x")
+
+    combined_y = BiophysicalCombinedNeuronSet(
+        base_neuron_set=ref_a, combined_with=ref_b, operation=SetOperation.UNION
+    )
+    combined_y.set_block_name("combined_y")
+
+    # Create cycle: x -> y -> x
+    ref_x = BiophysicalNeuronSetReference(block_dict_name="neuron_sets", block_name="combined_x")
+    ref_x.block = combined_x
+    ref_y = BiophysicalNeuronSetReference(block_dict_name="neuron_sets", block_name="combined_y")
+    ref_y.block = combined_y
+
+    combined_x.combined_with = ref_y
+    combined_y.combined_with = ref_x
+
+    with pytest.raises(ValueError, match="Recursive loop"):
+        combined_x.get_neuron_ids(circuit)
+
+
+def test_combined_no_block_name(circuit, ref_a, ref_b):
+    """Test that missing block name raises."""
+    combined = BiophysicalCombinedNeuronSet(
+        base_neuron_set=ref_a, combined_with=ref_b, operation=SetOperation.UNION
+    )
+    # Don't set block name
+
+    with pytest.raises(ValueError, match="Block name must be set"):
+        combined.get_neuron_ids(circuit)
+
+
+# --- Population type matching ---
+
+
+def test_combined_biophysical_type_matching(circuit, ref_a, ref_b):
+    """Test BiophysicalCombinedNeuronSet works when both inputs are biophysical."""
+    combined = BiophysicalCombinedNeuronSet(
+        base_neuron_set=ref_a, combined_with=ref_b, operation=SetOperation.UNION
+    )
+    combined.set_block_name("bio_type_match")
+
+    # Symbolic path (union) — should succeed
+    nset_def, combined_defs = combined.get_node_set_definition(circuit)
+    assert isinstance(nset_def, list)
+    assert set(nset_def) == set(combined_defs.keys())
+
+    # Resolved path — should also succeed
+    nset_def_resolved, _ = combined.get_node_set_definition(circuit, force_resolve_ids=True)
+    assert "node_id" in nset_def_resolved
+
+
+def test_combined_biophysical_type_mismatch_symbolic(circuit):
+    """Test BiophysicalCombinedNeuronSet fails in symbolic path with a virtual input."""
+    # Create a virtual neuron set
+    virt_nset = VirtualPopulationNeuronSet(population="POm")
+    virt_nset.set_block_name("virt_pop")
+    ref_virt = VirtualNeuronSetReference(block_dict_name="neuron_sets", block_name="virt_pop")
+    ref_virt.block = virt_nset
+
+    # Create a biophysical neuron set
+    bio_nset = PredefinedPopulationNeuronSet(node_set="L6_BPC", population="S1nonbarrel_neurons")
+    bio_nset.set_block_name("bio_pop")
+    ref_bio = BiophysicalNeuronSetReference(block_dict_name="neuron_sets", block_name="bio_pop")
+    ref_bio.block = bio_nset
+
+    # Combine with union (symbolic path)
+    combined = BiophysicalCombinedNeuronSet(
+        base_neuron_set=ref_bio, combined_with=ref_virt, operation=SetOperation.UNION
+    )
+    combined.set_block_name("bio_mismatch_sym")
+
+    # Should fail in symbolic path — virtual population not valid for biophysical type
+    with pytest.raises(ValueError, match="not found in circuit"):
+        combined.get_node_set_definition(circuit)
+
+
+def test_combined_biophysical_type_mismatch_resolved(circuit):
+    """Test BiophysicalCombinedNeuronSet fails in resolved path with a virtual input."""
+    # Create a virtual neuron set
+    virt_nset = VirtualPopulationNeuronSet(population="POm")
+    virt_nset.set_block_name("virt_pop2")
+    ref_virt = VirtualNeuronSetReference(block_dict_name="neuron_sets", block_name="virt_pop2")
+    ref_virt.block = virt_nset
+
+    # Create a biophysical neuron set
+    bio_nset = PredefinedPopulationNeuronSet(node_set="L6_BPC", population="S1nonbarrel_neurons")
+    bio_nset.set_block_name("bio_pop2")
+    ref_bio = BiophysicalNeuronSetReference(block_dict_name="neuron_sets", block_name="bio_pop2")
+    ref_bio.block = bio_nset
+
+    # Combine with intersect (non-union = resolved path)
+    combined = BiophysicalCombinedNeuronSet(
+        base_neuron_set=ref_bio, combined_with=ref_virt, operation=SetOperation.INTERSECT
+    )
+    combined.set_block_name("bio_mismatch_resolve")
+
+    # Should fail in resolved path — virtual population not valid for biophysical type
+    with pytest.raises(ValueError, match="not found in circuit"):
+        combined.get_node_set_definition(circuit)

--- a/tests/obi_one/scientific/blocks/neuron_sets_2/test_id.py
+++ b/tests/obi_one/scientific/blocks/neuron_sets_2/test_id.py
@@ -6,8 +6,8 @@ import pytest
 import obi_one as obi
 from obi_one.core.tuple import NamedTuple
 from obi_one.scientific.blocks.neuron_sets_2.id import (
-    BiophysicalIDNeuronSet,
-    VirtualIDNeuronSet,
+    BiophysicalPopulationIDNeuronSet,
+    VirtualPopulationIDNeuronSet,
 )
 
 from tests.utils import CIRCUIT_DIR, MATRIX_DIR
@@ -25,8 +25,8 @@ def circuit():
 
 
 def test_id_neuron_set_basic(circuit):
-    """Test BiophysicalIDNeuronSet returns the specified IDs."""
-    nset = BiophysicalIDNeuronSet(
+    """Test BiophysicalPopulationIDNeuronSet returns the specified IDs."""
+    nset = BiophysicalPopulationIDNeuronSet(
         population="S1nonbarrel_neurons",
         neuron_ids=NamedTuple(name="test_ids", elements=(0, 2, 5, 8)),
     )
@@ -38,8 +38,8 @@ def test_id_neuron_set_basic(circuit):
 
 
 def test_id_neuron_set_expression(circuit):
-    """Test BiophysicalIDNeuronSet node set definition contains population and node_id."""
-    nset = BiophysicalIDNeuronSet(
+    """Test BiophysicalPopulationIDNeuronSet node set definition contains population and node_id."""
+    nset = BiophysicalPopulationIDNeuronSet(
         population="S1nonbarrel_neurons",
         neuron_ids=NamedTuple(name="test_ids", elements=(1, 3, 7)),
     )
@@ -52,8 +52,8 @@ def test_id_neuron_set_expression(circuit):
 
 
 def test_id_neuron_set_with_sampling(circuit):
-    """Test BiophysicalIDNeuronSet with sub-sampling."""
-    nset = BiophysicalIDNeuronSet(
+    """Test BiophysicalPopulationIDNeuronSet with sub-sampling."""
+    nset = BiophysicalPopulationIDNeuronSet(
         population="S1nonbarrel_neurons",
         neuron_ids=NamedTuple(name="test_ids", elements=list(range(10))),
         sample_percentage=50,
@@ -67,7 +67,7 @@ def test_id_neuron_set_with_sampling(circuit):
 
 def test_id_neuron_set_invalid_ids(circuit):
     """Test that neuron IDs not in the population raise an error."""
-    nset = BiophysicalIDNeuronSet(
+    nset = BiophysicalPopulationIDNeuronSet(
         population="S1nonbarrel_neurons",
         neuron_ids=NamedTuple(name="bad_ids", elements=(0, 999)),
     )
@@ -78,8 +78,8 @@ def test_id_neuron_set_invalid_ids(circuit):
 
 
 def test_id_neuron_set_biophysical_matching(circuit):
-    """Test BiophysicalIDNeuronSet works with biophysical population."""
-    nset = BiophysicalIDNeuronSet(
+    """Test BiophysicalPopulationIDNeuronSet works with biophysical population."""
+    nset = BiophysicalPopulationIDNeuronSet(
         population="S1nonbarrel_neurons",
         neuron_ids=NamedTuple(name="bio_ids", elements=(0, 1, 2)),
     )
@@ -90,8 +90,8 @@ def test_id_neuron_set_biophysical_matching(circuit):
 
 
 def test_id_neuron_set_virtual_mismatch(circuit):
-    """Test VirtualIDNeuronSet fails with a biophysical population."""
-    nset = VirtualIDNeuronSet(
+    """Test VirtualPopulationIDNeuronSet fails with a biophysical population."""
+    nset = VirtualPopulationIDNeuronSet(
         population="S1nonbarrel_neurons",
         neuron_ids=NamedTuple(name="virt_ids", elements=(0, 1)),
     )

--- a/tests/obi_one/scientific/blocks/neuron_sets_2/test_id.py
+++ b/tests/obi_one/scientific/blocks/neuron_sets_2/test_id.py
@@ -1,0 +1,102 @@
+"""Tests for neuron_sets_2 ID neuron sets."""
+
+import numpy as np
+import pytest
+
+import obi_one as obi
+from obi_one.core.tuple import NamedTuple
+from obi_one.scientific.blocks.neuron_sets_2.id import (
+    BiophysicalIDNeuronSet,
+    IDNeuronSet,
+    VirtualIDNeuronSet,
+)
+
+from tests.utils import CIRCUIT_DIR, MATRIX_DIR
+
+CIRCUIT_NAME = "N_10__top_nodes_dim6"
+
+
+@pytest.fixture
+def circuit():
+    return obi.Circuit(
+        name=CIRCUIT_NAME,
+        path=str(CIRCUIT_DIR / CIRCUIT_NAME / "circuit_config.json"),
+        matrix_path=str(MATRIX_DIR / CIRCUIT_NAME / "connectivity_matrix.h5"),
+    )
+
+
+def test_id_neuron_set_basic(circuit):
+    """Test IDNeuronSet returns the specified IDs."""
+    nset = IDNeuronSet(
+        population="S1nonbarrel_neurons",
+        neuron_ids=NamedTuple(name="test_ids", elements=(0, 2, 5, 8)),
+    )
+    nset.set_block_name("id_basic")
+
+    ids = nset.get_neuron_ids(circuit)
+    assert "S1nonbarrel_neurons" in ids
+    np.testing.assert_array_equal(sorted(ids["S1nonbarrel_neurons"]), [0, 2, 5, 8])
+
+
+def test_id_neuron_set_expression(circuit):
+    """Test IDNeuronSet node set definition contains population and node_id."""
+    nset = IDNeuronSet(
+        population="S1nonbarrel_neurons",
+        neuron_ids=NamedTuple(name="test_ids", elements=(1, 3, 7)),
+    )
+    nset.set_block_name("id_expr")
+
+    nset_def, combined = nset.get_node_set_definition(circuit)
+    assert nset_def["population"] == "S1nonbarrel_neurons"
+    assert nset_def["node_id"] == [1, 3, 7]
+    assert combined == {}
+
+
+def test_id_neuron_set_with_sampling(circuit):
+    """Test IDNeuronSet with sub-sampling."""
+    nset = IDNeuronSet(
+        population="S1nonbarrel_neurons",
+        neuron_ids=NamedTuple(name="test_ids", elements=list(range(10))),
+        sample_percentage=50,
+        sample_seed=1,
+    )
+    nset.set_block_name("id_sampled")
+
+    ids = nset.get_neuron_ids(circuit)
+    assert len(ids["S1nonbarrel_neurons"]) == 5
+
+
+def test_id_neuron_set_invalid_ids(circuit):
+    """Test that neuron IDs not in the population raise an error."""
+    nset = IDNeuronSet(
+        population="S1nonbarrel_neurons",
+        neuron_ids=NamedTuple(name="bad_ids", elements=(0, 999)),
+    )
+    nset.set_block_name("id_invalid")
+
+    with pytest.raises(ValueError, match="Neuron ID"):
+        nset.get_neuron_ids(circuit)
+
+
+def test_id_neuron_set_biophysical_matching(circuit):
+    """Test BiophysicalIDNeuronSet works with biophysical population."""
+    nset = BiophysicalIDNeuronSet(
+        population="S1nonbarrel_neurons",
+        neuron_ids=NamedTuple(name="bio_ids", elements=(0, 1, 2)),
+    )
+    nset.set_block_name("id_bio")
+
+    ids = nset.get_neuron_ids(circuit)
+    np.testing.assert_array_equal(sorted(ids["S1nonbarrel_neurons"]), [0, 1, 2])
+
+
+def test_id_neuron_set_virtual_mismatch(circuit):
+    """Test VirtualIDNeuronSet fails with a biophysical population."""
+    nset = VirtualIDNeuronSet(
+        population="S1nonbarrel_neurons",
+        neuron_ids=NamedTuple(name="virt_ids", elements=(0, 1)),
+    )
+    nset.set_block_name("id_virt_mismatch")
+
+    with pytest.raises(ValueError, match="not found in circuit"):
+        nset.get_neuron_ids(circuit)

--- a/tests/obi_one/scientific/blocks/neuron_sets_2/test_id.py
+++ b/tests/obi_one/scientific/blocks/neuron_sets_2/test_id.py
@@ -7,7 +7,6 @@ import obi_one as obi
 from obi_one.core.tuple import NamedTuple
 from obi_one.scientific.blocks.neuron_sets_2.id import (
     BiophysicalIDNeuronSet,
-    IDNeuronSet,
     VirtualIDNeuronSet,
 )
 
@@ -26,8 +25,8 @@ def circuit():
 
 
 def test_id_neuron_set_basic(circuit):
-    """Test IDNeuronSet returns the specified IDs."""
-    nset = IDNeuronSet(
+    """Test BiophysicalIDNeuronSet returns the specified IDs."""
+    nset = BiophysicalIDNeuronSet(
         population="S1nonbarrel_neurons",
         neuron_ids=NamedTuple(name="test_ids", elements=(0, 2, 5, 8)),
     )
@@ -39,8 +38,8 @@ def test_id_neuron_set_basic(circuit):
 
 
 def test_id_neuron_set_expression(circuit):
-    """Test IDNeuronSet node set definition contains population and node_id."""
-    nset = IDNeuronSet(
+    """Test BiophysicalIDNeuronSet node set definition contains population and node_id."""
+    nset = BiophysicalIDNeuronSet(
         population="S1nonbarrel_neurons",
         neuron_ids=NamedTuple(name="test_ids", elements=(1, 3, 7)),
     )
@@ -53,8 +52,8 @@ def test_id_neuron_set_expression(circuit):
 
 
 def test_id_neuron_set_with_sampling(circuit):
-    """Test IDNeuronSet with sub-sampling."""
-    nset = IDNeuronSet(
+    """Test BiophysicalIDNeuronSet with sub-sampling."""
+    nset = BiophysicalIDNeuronSet(
         population="S1nonbarrel_neurons",
         neuron_ids=NamedTuple(name="test_ids", elements=list(range(10))),
         sample_percentage=50,
@@ -68,7 +67,7 @@ def test_id_neuron_set_with_sampling(circuit):
 
 def test_id_neuron_set_invalid_ids(circuit):
     """Test that neuron IDs not in the population raise an error."""
-    nset = IDNeuronSet(
+    nset = BiophysicalIDNeuronSet(
         population="S1nonbarrel_neurons",
         neuron_ids=NamedTuple(name="bad_ids", elements=(0, 999)),
     )

--- a/tests/obi_one/scientific/blocks/neuron_sets_2/test_population.py
+++ b/tests/obi_one/scientific/blocks/neuron_sets_2/test_population.py
@@ -6,7 +6,6 @@ import pytest
 import obi_one as obi
 from obi_one.scientific.blocks.neuron_sets_2.population import (
     BiophysicalPopulationNeuronSet,
-    PopulationNeuronSet,
     VirtualPopulationNeuronSet,
 )
 
@@ -25,8 +24,8 @@ def circuit():
 
 
 def test_population_neuron_set_full(circuit):
-    """Test PopulationNeuronSet returns all neurons without sampling."""
-    nset = PopulationNeuronSet(population="S1nonbarrel_neurons")
+    """Test BiophysicalPopulationNeuronSet returns all neurons without sampling."""
+    nset = BiophysicalPopulationNeuronSet(population="S1nonbarrel_neurons")
     nset.set_block_name("pop_full")
 
     ids = nset.get_neuron_ids(circuit)
@@ -40,8 +39,8 @@ def test_population_neuron_set_full(circuit):
 
 
 def test_population_neuron_set_sampling(circuit):
-    """Test PopulationNeuronSet with 50% sampling."""
-    nset = PopulationNeuronSet(
+    """Test BiophysicalPopulationNeuronSet with 50% sampling."""
+    nset = BiophysicalPopulationNeuronSet(
         population="S1nonbarrel_neurons", sample_percentage=50, sample_seed=1
     )
     nset.set_block_name("pop_50")
@@ -58,7 +57,7 @@ def test_population_neuron_set_sampling(circuit):
 
 def test_population_neuron_set_force_resolve(circuit):
     """Test force_resolve_ids returns explicit IDs even without sampling."""
-    nset = PopulationNeuronSet(population="S1nonbarrel_neurons")
+    nset = BiophysicalPopulationNeuronSet(population="S1nonbarrel_neurons")
     nset.set_block_name("pop_resolve")
 
     nset_def, _ = nset.get_node_set_definition(circuit, force_resolve_ids=True)
@@ -78,7 +77,7 @@ def test_population_neuron_set_invalid_population(circuit):
 
 def test_population_neuron_set_get_populations(circuit):
     """Test get_populations returns the single population."""
-    nset = PopulationNeuronSet(population="S1nonbarrel_neurons")
+    nset = BiophysicalPopulationNeuronSet(population="S1nonbarrel_neurons")
     nset.set_block_name("pop_test")
 
     pops = nset.get_populations(circuit)
@@ -87,11 +86,11 @@ def test_population_neuron_set_get_populations(circuit):
 
 def test_population_neuron_set_deterministic_sampling(circuit):
     """Test that same seed produces same results."""
-    nset1 = PopulationNeuronSet(
+    nset1 = BiophysicalPopulationNeuronSet(
         population="S1nonbarrel_neurons", sample_percentage=50, sample_seed=42
     )
     nset1.set_block_name("pop_det1")
-    nset2 = PopulationNeuronSet(
+    nset2 = BiophysicalPopulationNeuronSet(
         population="S1nonbarrel_neurons", sample_percentage=50, sample_seed=42
     )
     nset2.set_block_name("pop_det2")
@@ -103,11 +102,11 @@ def test_population_neuron_set_deterministic_sampling(circuit):
 
 def test_population_neuron_set_different_seeds(circuit):
     """Test that different seeds produce different results."""
-    nset1 = PopulationNeuronSet(
+    nset1 = BiophysicalPopulationNeuronSet(
         population="S1nonbarrel_neurons", sample_percentage=50, sample_seed=1
     )
     nset1.set_block_name("pop_s1")
-    nset2 = PopulationNeuronSet(
+    nset2 = BiophysicalPopulationNeuronSet(
         population="S1nonbarrel_neurons", sample_percentage=50, sample_seed=2
     )
     nset2.set_block_name("pop_s2")

--- a/tests/obi_one/scientific/blocks/neuron_sets_2/test_population.py
+++ b/tests/obi_one/scientific/blocks/neuron_sets_2/test_population.py
@@ -7,6 +7,7 @@ import obi_one as obi
 from obi_one.scientific.blocks.neuron_sets_2.population import (
     BiophysicalPopulationNeuronSet,
     PopulationNeuronSet,
+    VirtualPopulationNeuronSet,
 )
 
 from tests.utils import CIRCUIT_DIR, MATRIX_DIR
@@ -115,3 +116,25 @@ def test_population_neuron_set_different_seeds(circuit):
     ids2 = nset2.get_neuron_ids(circuit)
     # With 10 neurons and 50% sampling, different seeds should (very likely) give different results
     assert ids1["S1nonbarrel_neurons"] != ids2["S1nonbarrel_neurons"]
+
+
+# --- Population type matching ---
+
+
+def test_biophysical_population_matching(circuit):
+    """Test that a biophysical population neuron set works with a biophysical population."""
+    nset = BiophysicalPopulationNeuronSet(population="S1nonbarrel_neurons")
+    nset.set_block_name("bio_match")
+
+    ids = nset.get_neuron_ids(circuit)
+    assert len(ids["S1nonbarrel_neurons"]) == 10
+
+
+def test_virtual_population_mismatch(circuit):
+    """Test that a virtual population neuron set fails with a biophysical population."""
+    # S1nonbarrel_neurons is biophysical, not virtual -> should raise
+    nset = VirtualPopulationNeuronSet(population="S1nonbarrel_neurons")
+    nset.set_block_name("virt_mismatch")
+
+    with pytest.raises(ValueError, match="not found in circuit"):
+        nset.get_neuron_ids(circuit)

--- a/tests/obi_one/scientific/blocks/neuron_sets_2/test_population.py
+++ b/tests/obi_one/scientific/blocks/neuron_sets_2/test_population.py
@@ -1,0 +1,117 @@
+"""Tests for neuron_sets_2 population neuron sets."""
+
+import numpy as np
+import pytest
+
+import obi_one as obi
+from obi_one.scientific.blocks.neuron_sets_2.population import (
+    BiophysicalPopulationNeuronSet,
+    PopulationNeuronSet,
+)
+
+from tests.utils import CIRCUIT_DIR, MATRIX_DIR
+
+CIRCUIT_NAME = "N_10__top_nodes_dim6"
+
+
+@pytest.fixture
+def circuit():
+    return obi.Circuit(
+        name=CIRCUIT_NAME,
+        path=str(CIRCUIT_DIR / CIRCUIT_NAME / "circuit_config.json"),
+        matrix_path=str(MATRIX_DIR / CIRCUIT_NAME / "connectivity_matrix.h5"),
+    )
+
+
+def test_population_neuron_set_full(circuit):
+    """Test PopulationNeuronSet returns all neurons without sampling."""
+    nset = PopulationNeuronSet(population="S1nonbarrel_neurons")
+    nset.set_block_name("pop_full")
+
+    ids = nset.get_neuron_ids(circuit)
+    assert "S1nonbarrel_neurons" in ids
+    assert len(ids["S1nonbarrel_neurons"]) == 10
+
+    # Symbolic expression (no sampling)
+    nset_def, combined = nset.get_node_set_definition(circuit)
+    assert nset_def == {"population": "S1nonbarrel_neurons"}
+    assert combined == {}
+
+
+def test_population_neuron_set_sampling(circuit):
+    """Test PopulationNeuronSet with 50% sampling."""
+    nset = PopulationNeuronSet(
+        population="S1nonbarrel_neurons", sample_percentage=50, sample_seed=1
+    )
+    nset.set_block_name("pop_50")
+
+    ids = nset.get_neuron_ids(circuit)
+    assert len(ids["S1nonbarrel_neurons"]) == 5
+
+    # Resolved expression (sampling active)
+    nset_def, _ = nset.get_node_set_definition(circuit)
+    assert nset_def["population"] == "S1nonbarrel_neurons"
+    assert "node_id" in nset_def
+    assert len(nset_def["node_id"]) == 5
+
+
+def test_population_neuron_set_force_resolve(circuit):
+    """Test force_resolve_ids returns explicit IDs even without sampling."""
+    nset = PopulationNeuronSet(population="S1nonbarrel_neurons")
+    nset.set_block_name("pop_resolve")
+
+    nset_def, _ = nset.get_node_set_definition(circuit, force_resolve_ids=True)
+    assert nset_def["population"] == "S1nonbarrel_neurons"
+    assert "node_id" in nset_def
+    assert len(nset_def["node_id"]) == 10
+
+
+def test_population_neuron_set_invalid_population(circuit):
+    """Test that an invalid population raises."""
+    nset = BiophysicalPopulationNeuronSet(population="NONEXISTENT")
+    nset.set_block_name("invalid_pop")
+
+    with pytest.raises(ValueError, match="not found in circuit"):
+        nset.get_neuron_ids(circuit)
+
+
+def test_population_neuron_set_get_populations(circuit):
+    """Test get_populations returns the single population."""
+    nset = PopulationNeuronSet(population="S1nonbarrel_neurons")
+    nset.set_block_name("pop_test")
+
+    pops = nset.get_populations(circuit)
+    assert pops == ["S1nonbarrel_neurons"]
+
+
+def test_population_neuron_set_deterministic_sampling(circuit):
+    """Test that same seed produces same results."""
+    nset1 = PopulationNeuronSet(
+        population="S1nonbarrel_neurons", sample_percentage=50, sample_seed=42
+    )
+    nset1.set_block_name("pop_det1")
+    nset2 = PopulationNeuronSet(
+        population="S1nonbarrel_neurons", sample_percentage=50, sample_seed=42
+    )
+    nset2.set_block_name("pop_det2")
+
+    ids1 = nset1.get_neuron_ids(circuit)
+    ids2 = nset2.get_neuron_ids(circuit)
+    np.testing.assert_array_equal(ids1["S1nonbarrel_neurons"], ids2["S1nonbarrel_neurons"])
+
+
+def test_population_neuron_set_different_seeds(circuit):
+    """Test that different seeds produce different results."""
+    nset1 = PopulationNeuronSet(
+        population="S1nonbarrel_neurons", sample_percentage=50, sample_seed=1
+    )
+    nset1.set_block_name("pop_s1")
+    nset2 = PopulationNeuronSet(
+        population="S1nonbarrel_neurons", sample_percentage=50, sample_seed=2
+    )
+    nset2.set_block_name("pop_s2")
+
+    ids1 = nset1.get_neuron_ids(circuit)
+    ids2 = nset2.get_neuron_ids(circuit)
+    # With 10 neurons and 50% sampling, different seeds should (very likely) give different results
+    assert ids1["S1nonbarrel_neurons"] != ids2["S1nonbarrel_neurons"]

--- a/tests/obi_one/scientific/blocks/neuron_sets_2/test_predefined.py
+++ b/tests/obi_one/scientific/blocks/neuron_sets_2/test_predefined.py
@@ -7,7 +7,6 @@ import obi_one as obi
 from obi_one.scientific.blocks.neuron_sets_2.predefined import (
     PredefinedBiophysicalPopulationNeuronSet,
     PredefinedNeuronSet,
-    PredefinedPopulationNeuronSet,
     PredefinedVirtualPopulationNeuronSet,
 )
 
@@ -78,12 +77,14 @@ def test_predefined_neuron_set_invalid_node_set(circuit):
         nset.get_neuron_ids(circuit)
 
 
-# --- PredefinedPopulationNeuronSet (single population) ---
+# --- PredefinedBiophysicalPopulationNeuronSet (single population) ---
 
 
 def test_predefined_population_full(circuit):
-    """Test PredefinedPopulationNeuronSet without sampling."""
-    nset = PredefinedPopulationNeuronSet(node_set="Layer6", population="S1nonbarrel_neurons")
+    """Test PredefinedBiophysicalPopulationNeuronSet without sampling."""
+    nset = PredefinedBiophysicalPopulationNeuronSet(
+        node_set="Layer6", population="S1nonbarrel_neurons"
+    )
     nset.set_block_name("predef_pop_full")
 
     ids = nset.get_neuron_ids(circuit)
@@ -92,8 +93,8 @@ def test_predefined_population_full(circuit):
 
 
 def test_predefined_population_sampling(circuit):
-    """Test PredefinedPopulationNeuronSet with sampling."""
-    nset = PredefinedPopulationNeuronSet(
+    """Test PredefinedBiophysicalPopulationNeuronSet with sampling."""
+    nset = PredefinedBiophysicalPopulationNeuronSet(
         node_set="Layer6",
         population="S1nonbarrel_neurons",
         sample_percentage=50,
@@ -108,7 +109,9 @@ def test_predefined_population_sampling(circuit):
 
 def test_predefined_population_symbolic_single_pop(circuit):
     """Test symbolic expression when node set resolves in only one population."""
-    nset = PredefinedPopulationNeuronSet(node_set="Layer6", population="S1nonbarrel_neurons")
+    nset = PredefinedBiophysicalPopulationNeuronSet(
+        node_set="Layer6", population="S1nonbarrel_neurons"
+    )
     nset.set_block_name("predef_pop_sym")
 
     # No sampling -> symbolic path
@@ -119,8 +122,10 @@ def test_predefined_population_symbolic_single_pop(circuit):
 
 
 def test_predefined_population_force_resolve(circuit):
-    """Test force_resolve_ids on PredefinedPopulationNeuronSet."""
-    nset = PredefinedPopulationNeuronSet(node_set="Layer6", population="S1nonbarrel_neurons")
+    """Test force_resolve_ids on PredefinedBiophysicalPopulationNeuronSet."""
+    nset = PredefinedBiophysicalPopulationNeuronSet(
+        node_set="Layer6", population="S1nonbarrel_neurons"
+    )
     nset.set_block_name("predef_pop_resolve")
 
     nset_def, _ = nset.get_node_set_definition(circuit, force_resolve_ids=True)
@@ -131,7 +136,9 @@ def test_predefined_population_force_resolve(circuit):
 
 def test_predefined_population_invalid_node_set(circuit):
     """Test that a non-existent node set raises for population variant."""
-    nset = PredefinedPopulationNeuronSet(node_set="NONEXISTENT", population="S1nonbarrel_neurons")
+    nset = PredefinedBiophysicalPopulationNeuronSet(
+        node_set="NONEXISTENT", population="S1nonbarrel_neurons"
+    )
     nset.set_block_name("predef_pop_invalid")
 
     with pytest.raises(ValueError, match="not found in circuit"):

--- a/tests/obi_one/scientific/blocks/neuron_sets_2/test_predefined.py
+++ b/tests/obi_one/scientific/blocks/neuron_sets_2/test_predefined.py
@@ -5,9 +5,9 @@ import pytest
 
 import obi_one as obi
 from obi_one.scientific.blocks.neuron_sets_2.predefined import (
-    PredefinedBiophysicalPopulationNeuronSet,
+    BiophysicalPopulationPredefinedNeuronSet,
     PredefinedNeuronSet,
-    PredefinedVirtualPopulationNeuronSet,
+    VirtualPopulationPredefinedNeuronSet,
 )
 
 from tests.utils import CIRCUIT_DIR, MATRIX_DIR
@@ -77,12 +77,12 @@ def test_predefined_neuron_set_invalid_node_set(circuit):
         nset.get_neuron_ids(circuit)
 
 
-# --- PredefinedBiophysicalPopulationNeuronSet (single population) ---
+# --- BiophysicalPopulationPredefinedNeuronSet (single population) ---
 
 
 def test_predefined_population_full(circuit):
-    """Test PredefinedBiophysicalPopulationNeuronSet without sampling."""
-    nset = PredefinedBiophysicalPopulationNeuronSet(
+    """Test BiophysicalPopulationPredefinedNeuronSet without sampling."""
+    nset = BiophysicalPopulationPredefinedNeuronSet(
         node_set="Layer6", population="S1nonbarrel_neurons"
     )
     nset.set_block_name("predef_pop_full")
@@ -93,8 +93,8 @@ def test_predefined_population_full(circuit):
 
 
 def test_predefined_population_sampling(circuit):
-    """Test PredefinedBiophysicalPopulationNeuronSet with sampling."""
-    nset = PredefinedBiophysicalPopulationNeuronSet(
+    """Test BiophysicalPopulationPredefinedNeuronSet with sampling."""
+    nset = BiophysicalPopulationPredefinedNeuronSet(
         node_set="Layer6",
         population="S1nonbarrel_neurons",
         sample_percentage=50,
@@ -109,7 +109,7 @@ def test_predefined_population_sampling(circuit):
 
 def test_predefined_population_symbolic_single_pop(circuit):
     """Test symbolic expression when node set resolves in only one population."""
-    nset = PredefinedBiophysicalPopulationNeuronSet(
+    nset = BiophysicalPopulationPredefinedNeuronSet(
         node_set="Layer6", population="S1nonbarrel_neurons"
     )
     nset.set_block_name("predef_pop_sym")
@@ -122,8 +122,8 @@ def test_predefined_population_symbolic_single_pop(circuit):
 
 
 def test_predefined_population_force_resolve(circuit):
-    """Test force_resolve_ids on PredefinedBiophysicalPopulationNeuronSet."""
-    nset = PredefinedBiophysicalPopulationNeuronSet(
+    """Test force_resolve_ids on BiophysicalPopulationPredefinedNeuronSet."""
+    nset = BiophysicalPopulationPredefinedNeuronSet(
         node_set="Layer6", population="S1nonbarrel_neurons"
     )
     nset.set_block_name("predef_pop_resolve")
@@ -136,7 +136,7 @@ def test_predefined_population_force_resolve(circuit):
 
 def test_predefined_population_invalid_node_set(circuit):
     """Test that a non-existent node set raises for population variant."""
-    nset = PredefinedBiophysicalPopulationNeuronSet(
+    nset = BiophysicalPopulationPredefinedNeuronSet(
         node_set="NONEXISTENT", population="S1nonbarrel_neurons"
     )
     nset.set_block_name("predef_pop_invalid")
@@ -151,7 +151,7 @@ def test_predefined_population_invalid_node_set(circuit):
 def test_predefined_biophysical_population_matching(circuit):
     """Test that a biophysical population neuron set works with a biophysical population."""
     # S1nonbarrel_neurons is biophysical -> should work
-    nset = PredefinedBiophysicalPopulationNeuronSet(
+    nset = BiophysicalPopulationPredefinedNeuronSet(
         node_set="Layer6", population="S1nonbarrel_neurons"
     )
     nset.set_block_name("predef_bio_match")
@@ -163,7 +163,7 @@ def test_predefined_biophysical_population_matching(circuit):
 def test_predefined_virtual_population_mismatch(circuit):
     """Test that a virtual population neuron set fails with a biophysical population."""
     # S1nonbarrel_neurons is biophysical, not virtual -> should raise
-    nset = PredefinedVirtualPopulationNeuronSet(node_set="Layer6", population="S1nonbarrel_neurons")
+    nset = VirtualPopulationPredefinedNeuronSet(node_set="Layer6", population="S1nonbarrel_neurons")
     nset.set_block_name("predef_virt_mismatch")
 
     with pytest.raises(ValueError, match="not found in circuit"):

--- a/tests/obi_one/scientific/blocks/neuron_sets_2/test_predefined.py
+++ b/tests/obi_one/scientific/blocks/neuron_sets_2/test_predefined.py
@@ -1,0 +1,163 @@
+"""Tests for neuron_sets_2 predefined neuron sets."""
+
+import numpy as np
+import pytest
+
+import obi_one as obi
+from obi_one.scientific.blocks.neuron_sets_2.predefined import (
+    PredefinedBiophysicalPopulationNeuronSet,
+    PredefinedNeuronSet,
+    PredefinedPopulationNeuronSet,
+    PredefinedVirtualPopulationNeuronSet,
+)
+
+from tests.utils import CIRCUIT_DIR, MATRIX_DIR
+
+CIRCUIT_NAME = "N_10__top_nodes_dim6"
+
+
+@pytest.fixture
+def circuit():
+    return obi.Circuit(
+        name=CIRCUIT_NAME,
+        path=str(CIRCUIT_DIR / CIRCUIT_NAME / "circuit_config.json"),
+        matrix_path=str(MATRIX_DIR / CIRCUIT_NAME / "connectivity_matrix.h5"),
+    )
+
+
+# --- PredefinedNeuronSet (multi-population) ---
+
+
+def test_predefined_neuron_set_symbolic(circuit):
+    """Test PredefinedNeuronSet returns symbolic expression without force_resolve."""
+    nset = PredefinedNeuronSet(node_set="Layer6")
+    nset.set_block_name("predef_layer6")
+
+    nset_def, combined = nset.get_node_set_definition(circuit)
+    assert nset_def == ["Layer6"]
+    assert combined == {}
+
+
+def test_predefined_neuron_set_resolve_ids(circuit):
+    """Test PredefinedNeuronSet with force_resolve_ids."""
+    nset = PredefinedNeuronSet(node_set="Layer6")
+    nset.set_block_name("predef_layer6_resolved")
+
+    nset_def, _ = nset.get_node_set_definition(circuit, force_resolve_ids=True)
+    # Single population -> simplified to dict
+    assert "population" in nset_def
+    assert "node_id" in nset_def
+    assert nset_def["population"] == "S1nonbarrel_neurons"
+
+
+def test_predefined_neuron_set_get_neuron_ids(circuit):
+    """Test PredefinedNeuronSet returns correct IDs."""
+    nset = PredefinedNeuronSet(node_set="Layer6")
+    nset.set_block_name("predef_ids")
+
+    ids = nset.get_neuron_ids(circuit)
+    assert "S1nonbarrel_neurons" in ids
+    np.testing.assert_array_equal(ids["S1nonbarrel_neurons"], range(1, 10))
+
+
+def test_predefined_neuron_set_get_populations(circuit):
+    """Test PredefinedNeuronSet returns populations the node set resolves in."""
+    nset = PredefinedNeuronSet(node_set="Layer6")
+    nset.set_block_name("predef_pops")
+
+    pops = nset.get_populations(circuit)
+    assert "S1nonbarrel_neurons" in pops
+
+
+def test_predefined_neuron_set_invalid_node_set(circuit):
+    """Test that a non-existent node set raises."""
+    nset = PredefinedNeuronSet(node_set="NONEXISTENT")
+    nset.set_block_name("predef_invalid")
+
+    with pytest.raises(ValueError, match="not found in circuit"):
+        nset.get_neuron_ids(circuit)
+
+
+# --- PredefinedPopulationNeuronSet (single population) ---
+
+
+def test_predefined_population_full(circuit):
+    """Test PredefinedPopulationNeuronSet without sampling."""
+    nset = PredefinedPopulationNeuronSet(node_set="Layer6", population="S1nonbarrel_neurons")
+    nset.set_block_name("predef_pop_full")
+
+    ids = nset.get_neuron_ids(circuit)
+    assert "S1nonbarrel_neurons" in ids
+    assert len(ids["S1nonbarrel_neurons"]) == 9
+
+
+def test_predefined_population_sampling(circuit):
+    """Test PredefinedPopulationNeuronSet with sampling."""
+    nset = PredefinedPopulationNeuronSet(
+        node_set="Layer6",
+        population="S1nonbarrel_neurons",
+        sample_percentage=50,
+        sample_seed=1,
+    )
+    nset.set_block_name("predef_pop_50")
+
+    ids = nset.get_neuron_ids(circuit)
+    # 9 neurons in Layer6, 50% -> 4 or 5
+    assert 4 <= len(ids["S1nonbarrel_neurons"]) <= 5
+
+
+def test_predefined_population_symbolic_single_pop(circuit):
+    """Test symbolic expression when node set resolves in only one population."""
+    nset = PredefinedPopulationNeuronSet(node_set="Layer6", population="S1nonbarrel_neurons")
+    nset.set_block_name("predef_pop_sym")
+
+    # No sampling -> symbolic path
+    nset_def, combined = nset.get_node_set_definition(circuit)
+    # Should be symbolic since Layer6 resolves only in S1nonbarrel_neurons
+    assert nset_def == ["Layer6"] or "node_id" in nset_def
+    assert combined == {}
+
+
+def test_predefined_population_force_resolve(circuit):
+    """Test force_resolve_ids on PredefinedPopulationNeuronSet."""
+    nset = PredefinedPopulationNeuronSet(node_set="Layer6", population="S1nonbarrel_neurons")
+    nset.set_block_name("predef_pop_resolve")
+
+    nset_def, _ = nset.get_node_set_definition(circuit, force_resolve_ids=True)
+    assert nset_def["population"] == "S1nonbarrel_neurons"
+    assert "node_id" in nset_def
+    assert len(nset_def["node_id"]) == 9
+
+
+def test_predefined_population_invalid_node_set(circuit):
+    """Test that a non-existent node set raises for population variant."""
+    nset = PredefinedPopulationNeuronSet(node_set="NONEXISTENT", population="S1nonbarrel_neurons")
+    nset.set_block_name("predef_pop_invalid")
+
+    with pytest.raises(ValueError, match="not found in circuit"):
+        nset.get_neuron_ids(circuit)
+
+
+# --- Population type matching ---
+
+
+def test_predefined_biophysical_population_matching(circuit):
+    """Test that a biophysical population neuron set works with a biophysical population."""
+    # S1nonbarrel_neurons is biophysical -> should work
+    nset = PredefinedBiophysicalPopulationNeuronSet(
+        node_set="Layer6", population="S1nonbarrel_neurons"
+    )
+    nset.set_block_name("predef_bio_match")
+
+    ids = nset.get_neuron_ids(circuit)
+    assert len(ids["S1nonbarrel_neurons"]) == 9
+
+
+def test_predefined_virtual_population_mismatch(circuit):
+    """Test that a virtual population neuron set fails with a biophysical population."""
+    # S1nonbarrel_neurons is biophysical, not virtual -> should raise
+    nset = PredefinedVirtualPopulationNeuronSet(node_set="Layer6", population="S1nonbarrel_neurons")
+    nset.set_block_name("predef_virt_mismatch")
+
+    with pytest.raises(ValueError, match="not found in circuit"):
+        nset.get_neuron_ids(circuit)

--- a/tests/obi_one/scientific/blocks/neuron_sets_2/test_property.py
+++ b/tests/obi_one/scientific/blocks/neuron_sets_2/test_property.py
@@ -5,9 +5,9 @@ import pytest
 
 import obi_one as obi
 from obi_one.scientific.blocks.neuron_sets_2.property import (
-    BiophysicalPropertyNeuronSet,
+    BiophysicalPopulationPropertyNeuronSet,
     NeuronPropertyFilter,
-    VirtualPropertyNeuronSet,
+    VirtualPopulationPropertyNeuronSet,
 )
 
 from tests.utils import CIRCUIT_DIR, MATRIX_DIR
@@ -25,8 +25,8 @@ def circuit():
 
 
 def test_property_neuron_set_basic(circuit):
-    """Test BiophysicalPropertyNeuronSet filters by properties correctly."""
-    nset = BiophysicalPropertyNeuronSet(
+    """Test BiophysicalPopulationPropertyNeuronSet filters by properties correctly."""
+    nset = BiophysicalPopulationPropertyNeuronSet(
         population="S1nonbarrel_neurons",
         property_filter=NeuronPropertyFilter(
             filter_dict={"layer": ["6"], "synapse_class": ["EXC"]}
@@ -41,7 +41,7 @@ def test_property_neuron_set_basic(circuit):
 
 def test_property_neuron_set_symbolic_expression(circuit):
     """Test symbolic expression when properties resolve in only one population."""
-    nset = BiophysicalPropertyNeuronSet(
+    nset = BiophysicalPopulationPropertyNeuronSet(
         population="S1nonbarrel_neurons",
         property_filter=NeuronPropertyFilter(
             filter_dict={"layer": ["3", "6"], "synapse_class": ["EXC"]}
@@ -57,8 +57,8 @@ def test_property_neuron_set_symbolic_expression(circuit):
 
 
 def test_property_neuron_set_with_sampling(circuit):
-    """Test BiophysicalPropertyNeuronSet with sub-sampling."""
-    nset = BiophysicalPropertyNeuronSet(
+    """Test BiophysicalPopulationPropertyNeuronSet with sub-sampling."""
+    nset = BiophysicalPopulationPropertyNeuronSet(
         population="S1nonbarrel_neurons",
         property_filter=NeuronPropertyFilter(
             filter_dict={"layer": ["6"], "synapse_class": ["EXC"]}
@@ -75,7 +75,7 @@ def test_property_neuron_set_with_sampling(circuit):
 
 def test_property_neuron_set_invalid_property(circuit):
     """Test that an invalid property name raises."""
-    nset = BiophysicalPropertyNeuronSet(
+    nset = BiophysicalPopulationPropertyNeuronSet(
         population="S1nonbarrel_neurons",
         property_filter=NeuronPropertyFilter(filter_dict={"INVALID_PROP": ["x"], "layer": ["6"]}),
     )
@@ -87,7 +87,7 @@ def test_property_neuron_set_invalid_property(circuit):
 
 def test_property_neuron_set_no_match(circuit):
     """Test that non-matching property values return empty."""
-    nset = BiophysicalPropertyNeuronSet(
+    nset = BiophysicalPopulationPropertyNeuronSet(
         population="S1nonbarrel_neurons",
         property_filter=NeuronPropertyFilter(filter_dict={"synapse_class": ["NONEXISTENT"]}),
     )
@@ -99,7 +99,7 @@ def test_property_neuron_set_no_match(circuit):
 
 def test_property_neuron_set_force_resolve(circuit):
     """Test force_resolve_ids returns explicit IDs."""
-    nset = BiophysicalPropertyNeuronSet(
+    nset = BiophysicalPopulationPropertyNeuronSet(
         population="S1nonbarrel_neurons",
         property_filter=NeuronPropertyFilter(
             filter_dict={"layer": ["6"], "synapse_class": ["EXC"]}
@@ -114,8 +114,8 @@ def test_property_neuron_set_force_resolve(circuit):
 
 
 def test_property_neuron_set_virtual_mismatch(circuit):
-    """Test VirtualPropertyNeuronSet fails with a biophysical population."""
-    nset = VirtualPropertyNeuronSet(
+    """Test VirtualPopulationPropertyNeuronSet fails with a biophysical population."""
+    nset = VirtualPopulationPropertyNeuronSet(
         population="S1nonbarrel_neurons",
         property_filter=NeuronPropertyFilter(filter_dict={"layer": ["6"]}),
     )
@@ -126,8 +126,8 @@ def test_property_neuron_set_virtual_mismatch(circuit):
 
 
 def test_property_neuron_set_biophysical_matching(circuit):
-    """Test BiophysicalPropertyNeuronSet works with a biophysical population."""
-    nset = BiophysicalPropertyNeuronSet(
+    """Test BiophysicalPopulationPropertyNeuronSet works with a biophysical population."""
+    nset = BiophysicalPopulationPropertyNeuronSet(
         population="S1nonbarrel_neurons",
         property_filter=NeuronPropertyFilter(
             filter_dict={"layer": ["6"], "synapse_class": ["EXC"]}

--- a/tests/obi_one/scientific/blocks/neuron_sets_2/test_property.py
+++ b/tests/obi_one/scientific/blocks/neuron_sets_2/test_property.py
@@ -1,0 +1,140 @@
+"""Tests for neuron_sets_2 property neuron sets."""
+
+import numpy as np
+import pytest
+
+import obi_one as obi
+from obi_one.scientific.blocks.neuron_sets_2.property import (
+    BiophysicalPropertyNeuronSet,
+    NeuronPropertyFilter,
+    PropertyNeuronSet,
+    VirtualPropertyNeuronSet,
+)
+
+from tests.utils import CIRCUIT_DIR, MATRIX_DIR
+
+CIRCUIT_NAME = "N_10__top_nodes_dim6"
+
+
+@pytest.fixture
+def circuit():
+    return obi.Circuit(
+        name=CIRCUIT_NAME,
+        path=str(CIRCUIT_DIR / CIRCUIT_NAME / "circuit_config.json"),
+        matrix_path=str(MATRIX_DIR / CIRCUIT_NAME / "connectivity_matrix.h5"),
+    )
+
+
+def test_property_neuron_set_basic(circuit):
+    """Test PropertyNeuronSet filters by properties correctly."""
+    nset = PropertyNeuronSet(
+        population="S1nonbarrel_neurons",
+        property_filter=NeuronPropertyFilter(
+            filter_dict={"layer": ["6"], "synapse_class": ["EXC"]}
+        ),
+    )
+    nset.set_block_name("prop_basic")
+
+    ids = nset.get_neuron_ids(circuit)
+    assert "S1nonbarrel_neurons" in ids
+    np.testing.assert_array_equal(ids["S1nonbarrel_neurons"], range(1, 10))
+
+
+def test_property_neuron_set_symbolic_expression(circuit):
+    """Test symbolic expression when properties resolve in only one population."""
+    nset = PropertyNeuronSet(
+        population="S1nonbarrel_neurons",
+        property_filter=NeuronPropertyFilter(
+            filter_dict={"layer": ["3", "6"], "synapse_class": ["EXC"]}
+        ),
+    )
+    nset.set_block_name("prop_sym")
+
+    nset_def, combined = nset.get_node_set_definition(circuit)
+    # Symbolic: property key-value pairs without population key
+    assert "population" not in nset_def
+    assert nset_def == {"layer": ["3", "6"], "synapse_class": "EXC"}
+    assert combined == {}
+
+
+def test_property_neuron_set_with_sampling(circuit):
+    """Test PropertyNeuronSet with sub-sampling."""
+    nset = PropertyNeuronSet(
+        population="S1nonbarrel_neurons",
+        property_filter=NeuronPropertyFilter(
+            filter_dict={"layer": ["6"], "synapse_class": ["EXC"]}
+        ),
+        sample_percentage=50,
+        sample_seed=1,
+    )
+    nset.set_block_name("prop_sampled")
+
+    ids = nset.get_neuron_ids(circuit)
+    # 9 EXC neurons in Layer6, 50% -> 4 or 5
+    assert 4 <= len(ids["S1nonbarrel_neurons"]) <= 5
+
+
+def test_property_neuron_set_invalid_property(circuit):
+    """Test that an invalid property name raises."""
+    nset = PropertyNeuronSet(
+        population="S1nonbarrel_neurons",
+        property_filter=NeuronPropertyFilter(filter_dict={"INVALID_PROP": ["x"], "layer": ["6"]}),
+    )
+    nset.set_block_name("prop_invalid")
+
+    with pytest.raises(ValueError, match="Invalid neuron properties"):
+        nset.get_neuron_ids(circuit)
+
+
+def test_property_neuron_set_no_match(circuit):
+    """Test that non-matching property values return empty."""
+    nset = PropertyNeuronSet(
+        population="S1nonbarrel_neurons",
+        property_filter=NeuronPropertyFilter(filter_dict={"synapse_class": ["NONEXISTENT"]}),
+    )
+    nset.set_block_name("prop_nomatch")
+
+    ids = nset.get_neuron_ids(circuit)
+    assert len(ids["S1nonbarrel_neurons"]) == 0
+
+
+def test_property_neuron_set_force_resolve(circuit):
+    """Test force_resolve_ids returns explicit IDs."""
+    nset = PropertyNeuronSet(
+        population="S1nonbarrel_neurons",
+        property_filter=NeuronPropertyFilter(
+            filter_dict={"layer": ["6"], "synapse_class": ["EXC"]}
+        ),
+    )
+    nset.set_block_name("prop_resolve")
+
+    nset_def, _ = nset.get_node_set_definition(circuit, force_resolve_ids=True)
+    assert nset_def["population"] == "S1nonbarrel_neurons"
+    assert "node_id" in nset_def
+    assert len(nset_def["node_id"]) == 9
+
+
+def test_property_neuron_set_virtual_mismatch(circuit):
+    """Test VirtualPropertyNeuronSet fails with a biophysical population."""
+    nset = VirtualPropertyNeuronSet(
+        population="S1nonbarrel_neurons",
+        property_filter=NeuronPropertyFilter(filter_dict={"layer": ["6"]}),
+    )
+    nset.set_block_name("prop_virt_mismatch")
+
+    with pytest.raises(ValueError, match="not found in circuit"):
+        nset.get_neuron_ids(circuit)
+
+
+def test_property_neuron_set_biophysical_matching(circuit):
+    """Test BiophysicalPropertyNeuronSet works with a biophysical population."""
+    nset = BiophysicalPropertyNeuronSet(
+        population="S1nonbarrel_neurons",
+        property_filter=NeuronPropertyFilter(
+            filter_dict={"layer": ["6"], "synapse_class": ["EXC"]}
+        ),
+    )
+    nset.set_block_name("prop_bio_match")
+
+    ids = nset.get_neuron_ids(circuit)
+    assert len(ids["S1nonbarrel_neurons"]) == 9

--- a/tests/obi_one/scientific/blocks/neuron_sets_2/test_property.py
+++ b/tests/obi_one/scientific/blocks/neuron_sets_2/test_property.py
@@ -7,7 +7,6 @@ import obi_one as obi
 from obi_one.scientific.blocks.neuron_sets_2.property import (
     BiophysicalPropertyNeuronSet,
     NeuronPropertyFilter,
-    PropertyNeuronSet,
     VirtualPropertyNeuronSet,
 )
 
@@ -26,8 +25,8 @@ def circuit():
 
 
 def test_property_neuron_set_basic(circuit):
-    """Test PropertyNeuronSet filters by properties correctly."""
-    nset = PropertyNeuronSet(
+    """Test BiophysicalPropertyNeuronSet filters by properties correctly."""
+    nset = BiophysicalPropertyNeuronSet(
         population="S1nonbarrel_neurons",
         property_filter=NeuronPropertyFilter(
             filter_dict={"layer": ["6"], "synapse_class": ["EXC"]}
@@ -42,7 +41,7 @@ def test_property_neuron_set_basic(circuit):
 
 def test_property_neuron_set_symbolic_expression(circuit):
     """Test symbolic expression when properties resolve in only one population."""
-    nset = PropertyNeuronSet(
+    nset = BiophysicalPropertyNeuronSet(
         population="S1nonbarrel_neurons",
         property_filter=NeuronPropertyFilter(
             filter_dict={"layer": ["3", "6"], "synapse_class": ["EXC"]}
@@ -58,8 +57,8 @@ def test_property_neuron_set_symbolic_expression(circuit):
 
 
 def test_property_neuron_set_with_sampling(circuit):
-    """Test PropertyNeuronSet with sub-sampling."""
-    nset = PropertyNeuronSet(
+    """Test BiophysicalPropertyNeuronSet with sub-sampling."""
+    nset = BiophysicalPropertyNeuronSet(
         population="S1nonbarrel_neurons",
         property_filter=NeuronPropertyFilter(
             filter_dict={"layer": ["6"], "synapse_class": ["EXC"]}
@@ -76,7 +75,7 @@ def test_property_neuron_set_with_sampling(circuit):
 
 def test_property_neuron_set_invalid_property(circuit):
     """Test that an invalid property name raises."""
-    nset = PropertyNeuronSet(
+    nset = BiophysicalPropertyNeuronSet(
         population="S1nonbarrel_neurons",
         property_filter=NeuronPropertyFilter(filter_dict={"INVALID_PROP": ["x"], "layer": ["6"]}),
     )
@@ -88,7 +87,7 @@ def test_property_neuron_set_invalid_property(circuit):
 
 def test_property_neuron_set_no_match(circuit):
     """Test that non-matching property values return empty."""
-    nset = PropertyNeuronSet(
+    nset = BiophysicalPropertyNeuronSet(
         population="S1nonbarrel_neurons",
         property_filter=NeuronPropertyFilter(filter_dict={"synapse_class": ["NONEXISTENT"]}),
     )
@@ -100,7 +99,7 @@ def test_property_neuron_set_no_match(circuit):
 
 def test_property_neuron_set_force_resolve(circuit):
     """Test force_resolve_ids returns explicit IDs."""
-    nset = PropertyNeuronSet(
+    nset = BiophysicalPropertyNeuronSet(
         population="S1nonbarrel_neurons",
         property_filter=NeuronPropertyFilter(
             filter_dict={"layer": ["6"], "synapse_class": ["EXC"]}

--- a/tests/obi_one/scientific/blocks/neuron_sets_2/test_specific.py
+++ b/tests/obi_one/scientific/blocks/neuron_sets_2/test_specific.py
@@ -1,0 +1,128 @@
+"""Tests for neuron_sets_2 specific (AllNeurons) neuron sets."""
+
+import pytest
+
+import obi_one as obi
+from obi_one.scientific.blocks.neuron_sets_2.specific import (
+    AllBiophysicalNeurons,
+    AllNeurons,
+    AllNonVirtualNeurons,
+    AllPointNeurons,
+    AllVirtualNeurons,
+)
+
+from tests.utils import CIRCUIT_DIR, MATRIX_DIR
+
+CIRCUIT_NAME = "N_10__top_nodes_dim6"
+
+
+@pytest.fixture
+def circuit():
+    return obi.Circuit(
+        name=CIRCUIT_NAME,
+        path=str(CIRCUIT_DIR / CIRCUIT_NAME / "circuit_config.json"),
+        matrix_path=str(MATRIX_DIR / CIRCUIT_NAME / "connectivity_matrix.h5"),
+    )
+
+
+def test_all_neurons(circuit):
+    """Test AllNeurons returns all populations and IDs."""
+    nset = AllNeurons()
+    nset.set_block_name("all")
+
+    pops = nset.get_populations(circuit)
+    assert len(pops) >= 1
+    assert "S1nonbarrel_neurons" in pops
+
+    ids = nset.get_neuron_ids(circuit)
+    # Should have IDs from all populations
+    total = sum(len(v) for v in ids.values())
+    assert total > 0
+
+
+def test_all_neurons_symbolic(circuit):
+    """Test AllNeurons symbolic node set definition."""
+    nset = AllNeurons()
+    nset.set_block_name("all_sym")
+
+    nset_def, combined = nset.get_node_set_definition(circuit)
+    pops = nset.get_populations(circuit)
+    # Test circuit has multiple populations -> compound expression
+    assert isinstance(nset_def, list)
+    assert len(nset_def) == len(pops)
+    assert len(combined) == len(pops)
+
+
+def test_all_neurons_force_resolve(circuit):
+    """Test AllNeurons force_resolve_ids."""
+    nset = AllNeurons()
+    nset.set_block_name("all_resolve")
+
+    nset_def, combined = nset.get_node_set_definition(circuit, force_resolve_ids=True)
+    pops = nset.get_populations(circuit)
+    # Multiple populations -> compound expression with node_id in each entry
+    assert isinstance(nset_def, list)
+    assert len(nset_def) == len(pops)
+    for key in nset_def:
+        assert "node_id" in combined[key]
+
+
+def test_all_biophysical_neurons(circuit):
+    """Test AllBiophysicalNeurons returns only biophysical populations."""
+    nset = AllBiophysicalNeurons()
+    nset.set_block_name("all_bio")
+
+    pops = nset.get_populations(circuit)
+    assert "S1nonbarrel_neurons" in pops
+
+    ids = nset.get_neuron_ids(circuit)
+    assert "S1nonbarrel_neurons" in ids
+    assert len(ids["S1nonbarrel_neurons"]) == 10
+
+
+def test_all_virtual_neurons(circuit):
+    """Test AllVirtualNeurons returns only virtual populations."""
+    nset = AllVirtualNeurons()
+    nset.set_block_name("all_virt")
+
+    pops = nset.get_populations(circuit)
+    # Should not include biophysical population
+    assert "S1nonbarrel_neurons" not in pops
+
+    ids = nset.get_neuron_ids(circuit)
+    # Virtual populations should have neurons
+    assert all(isinstance(v, list) for v in ids.values())
+
+
+def test_all_non_virtual_neurons(circuit):
+    """Test AllNonVirtualNeurons includes biophysical but not virtual."""
+    nset = AllNonVirtualNeurons()
+    nset.set_block_name("all_nonvirt")
+
+    pops = nset.get_populations(circuit)
+    assert "S1nonbarrel_neurons" in pops
+
+    # Virtual populations should not be included
+    virt_nset = AllVirtualNeurons()
+    virt_nset.set_block_name("virt_check")
+    virt_pops = virt_nset.get_populations(circuit)
+    for vp in virt_pops:
+        assert vp not in pops
+
+
+def test_all_point_neurons(circuit):
+    """Test AllPointNeurons returns only point populations."""
+    nset = AllPointNeurons()
+    nset.set_block_name("all_point")
+
+    pops = nset.get_populations(circuit)
+    # Biophysical population should not be included
+    assert "S1nonbarrel_neurons" not in pops
+
+
+def test_all_neurons_no_block_name(circuit):
+    """Test that get_node_set_definition raises without block name."""
+    nset = AllNeurons()
+
+    with pytest.raises(ValueError, match="Block name must be set"):
+        nset.get_node_set_definition(circuit)

--- a/tests/obi_one/scientific/library/test_circuit.py
+++ b/tests/obi_one/scientific/library/test_circuit.py
@@ -136,13 +136,14 @@ def test_get_node_population_names_filters(fake_snap_circuit):
     assert "virt" in fake_snap_circuit.Circuit.get_node_population_names(c)
     assert "virt" not in fake_snap_circuit.Circuit.get_node_population_names(c, incl_virtual=False)
     assert "point" not in fake_snap_circuit.Circuit.get_node_population_names(c, incl_point=False)
+    assert "bio" not in fake_snap_circuit.Circuit.get_node_population_names(c, incl_biophysical=False)
 
 
 def test_default_population_name_cases(fake_snap_circuit, monkeypatch):
     c = fake_snap_circuit.snap.Circuit("x")
     assert fake_snap_circuit.Circuit._default_population_name(c) == "bio"
 
-    def fake_get_node_pop_names(_c, *, incl_virtual=True, incl_point=True):  # noqa: ARG001
+    def fake_get_node_pop_names(_c, *, incl_virtual=True, incl_point=True, incl_biophysical=True):  # noqa: ARG001
         if not incl_point:
             return []
         return []
@@ -154,7 +155,7 @@ def test_default_population_name_cases(fake_snap_circuit, monkeypatch):
     )
     assert fake_snap_circuit.Circuit._default_population_name(c) is None
 
-    def fake_get_node_pop_names2(_c, *, incl_virtual=True, incl_point=True):  # noqa: ARG001
+    def fake_get_node_pop_names2(_c, *, incl_virtual=True, incl_point=True, incl_biophysical=True):  # noqa: ARG001
         return ["a", "b"]
 
     monkeypatch.setattr(
@@ -173,6 +174,7 @@ def test_get_edge_population_names_filters(fake_snap_circuit):
         c, incl_virtual=False
     )
     assert "e_point" not in fake_snap_circuit.Circuit.get_edge_population_names(c, incl_point=False)
+    assert "e_bio" not in fake_snap_circuit.Circuit.get_edge_population_names(c, incl_biophysical=False)
 
 
 def test_default_edge_population_name_cases(fake_snap_circuit, monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -833,14 +833,14 @@ wheels = [
 
 [[package]]
 name = "entitysdk"
-version = "0.15.7"
+version = "0.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/13/b1efdd3e36ecf2e5dcfbdc29eea6adc6dddc39bcb27ef7cd7408e50344d8/entitysdk-0.15.7.tar.gz", hash = "sha256:5fc8a233b299290e2b2509fb052a9b6fd550a0cd2c97baf6f3c6afee5ff062d2", size = 86787, upload-time = "2026-05-11T16:12:00.603Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/e7/396a78fe0710bd1635c857ca106e727b523aa7063805aeba705ca44e87f3/entitysdk-0.17.1.tar.gz", hash = "sha256:4039ac73f196976ce5d858419a3b9e40444a9fddc726cbdb38477a8185a4a597", size = 89696, upload-time = "2026-06-08T15:19:31.777Z" }
 
 [[package]]
 name = "executing"


### PR DESCRIPTION
Functional implementation of the new neuron set classes (in `/neuron_sets_2`) added according to [this proposal](https://openbraininstitute.sharepoint.com/:w:/s/OBI-Scientificstaff/IQBjp78-IWL8R74aVpqTIjdNAY24O5CXqmFWwoSTM3F_yKo?e=MAEs0x).

- Typed neuron set classes: Population, ID, Property, Predefined, Combined, Specific (AllNeurons)
- Each type has Biophysical/Point/Virtual/NonVirtual/Any variants with runtime type enforcement
- Combined neuron sets (union/intersect/diff) incl. nesting with cycle detection
- Currently limited to two neuron sets (not arbitrary list) for easier UI integration, since all UI elements exist; list support will require a new UI element (will create a separate ticket for it) --> https://github.com/openbraininstitute/prod-circuit-simulation/issues/210
- Symbolic SONATA expressions preserved when possible, explicit IDs resolved when needed
- Example notebook and unit tests added

Related issue: https://github.com/openbraininstitute/prod-circuit-simulation/issues/112