### PR TITLE
EMSynapseMapping Fix: Remove Initialize from SingleConfig

### DIFF
--- a/obi_one/scientific/tasks/em_synapse_mapping/config.py
+++ b/obi_one/scientific/tasks/em_synapse_mapping/config.py
@@ -170,16 +170,3 @@ class EMSynapseMappingSingleConfig(EMSynapseMappingScanConfig, SingleConfigMixin
     _single_task_activity_type: ClassVar[TaskActivityType] = (
         TaskActivityType.em_synapse_mapping__execution
     )
-
-    class Initialize(EMSynapseMappingScanConfig.Initialize):
-        neurons: "EMSynapseMappingInputNamedTuple"
-
-    initialize: Initialize = Field(
-        title="Initialization",
-        description="Parameters for initializing the EM Synaptome.",
-        json_schema_extra={
-            SchemaKey.UI_ELEMENT: UIElement.BLOCK_SINGLE,
-            SchemaKey.GROUP: BlockGroup.SETUP_BLOCK_GROUP,
-            SchemaKey.GROUP_ORDER: 1,
-        },
-    )

--- a/obi_one/scientific/tasks/em_synapse_mapping/task.py
+++ b/obi_one/scientific/tasks/em_synapse_mapping/task.py
@@ -91,7 +91,7 @@ class EMSynapseMappingTask(Task):
         resolved_neurons = []
         pt_root_id_names: dict[int, str] = {}
 
-        for neuron_entry in init.neurons.elements:
+        for neuron_entry in init.neurons.elements:  # ty:ignore[unresolved-attribute]
             resolved_neuron = resolve_neuron(neuron_entry, db_client, out_root, spiny_dir)
             if resolved_neuron.pt_root_id in pt_root_id_names:
                 err_str = (


### PR DESCRIPTION
* Removing as this caused a deserialization error
* The ty lint errors for the use of single config parameters in a task (which are typed for parameter scans is a larger question we don't need to worry about at this point imo)