### PR TITLE
Support cost estimation for single and pair circuit simulations

### DIFF
--- a/app/services/accounting.py
+++ b/app/services/accounting.py
@@ -24,6 +24,8 @@ from obi_one.scientific.tasks.skeletonization.estimate import estimate_skeletoni
 from obi_one.utils.db_sdk import select_json_asset_content
 
 CIRCUIT_SCALE_TO_SERVICE_SUBTYPE = {
+    CircuitScale.single: ServiceSubtype.SINGLE_SIM,
+    CircuitScale.pair: ServiceSubtype.PAIR_SIM,
     CircuitScale.small: ServiceSubtype.SMALL_SIM,
     CircuitScale.microcircuit: ServiceSubtype.MICROCIRCUIT_SIM,
     CircuitScale.region: ServiceSubtype.REGION_SIM,

--- a/tests/app/endpoints/test_task.py
+++ b/tests/app/endpoints/test_task.py
@@ -16,7 +16,7 @@ from app.mappings import APP_TAG, OBI_ONE_CODE_PATH, OBI_ONE_DEPS_DIR, TASK_DEFI
 from app.schemas.accounting import AccountingParameters
 from app.schemas.callback import CallBack, CallBackAction, CallBackEvent, HttpRequestCallBackConfig
 from app.schemas.task import TaskAccountingInfo, TaskLaunchInfo
-from app.services.accounting import CIRCUIT_SCALE_TO_SERVICE_SUBTYPE
+from app.services.accounting import _DURATION_BILLING_SCALES, CIRCUIT_SCALE_TO_SERVICE_SUBTYPE
 from app.types import TaskType
 
 from tests.utils import PROJECT_ID, VIRTUAL_LAB_ID, assert_request
@@ -266,6 +266,8 @@ def _circuit_metadata(*, circuit_id: UUID, target_simulator: str, circuit_scale:
 @pytest.mark.parametrize(
     "circuit_scale",
     [
+        CircuitScale.single,
+        CircuitScale.pair,
         CircuitScale.small,
         CircuitScale.microcircuit,
         CircuitScale.region,
@@ -365,6 +367,8 @@ def test_task_launch_success__circuit_simulation(
     ).json()
 
     expected_task_type = {
+        (TargetSimulator.NEURON, CircuitScale.single): TaskType.circuit_simulation_neuron,
+        (TargetSimulator.NEURON, CircuitScale.pair): TaskType.circuit_simulation_neuron,
         (TargetSimulator.NEURON, CircuitScale.small): TaskType.circuit_simulation_neuron,
         (
             TargetSimulator.NEURON,
@@ -382,6 +386,8 @@ def test_task_launch_success__circuit_simulation(
             TargetSimulator.NEURON,
             CircuitScale.whole_brain,
         ): TaskType.circuit_simulation_neurodamus_cluster,
+        (TargetSimulator.CORENEURON, CircuitScale.single): TaskType.circuit_simulation_neuron,
+        (TargetSimulator.CORENEURON, CircuitScale.pair): TaskType.circuit_simulation_neuron,
         (TargetSimulator.CORENEURON, CircuitScale.small): TaskType.circuit_simulation_neuron,
         (
             TargetSimulator.CORENEURON,
@@ -399,6 +405,14 @@ def test_task_launch_success__circuit_simulation(
             TargetSimulator.CORENEURON,
             CircuitScale.whole_brain,
         ): TaskType.circuit_simulation_neurodamus_cluster,
+        (
+            TargetSimulator.LearningEngine,
+            CircuitScale.single,
+        ): TaskType.circuit_simulation_inait_machine,
+        (
+            TargetSimulator.LearningEngine,
+            CircuitScale.pair,
+        ): TaskType.circuit_simulation_inait_machine,
         (
             TargetSimulator.LearningEngine,
             CircuitScale.small,
@@ -478,7 +492,7 @@ def test_task_launch_success__circuit_simulation(
                     "accounting_service_subtype": str(
                         CIRCUIT_SCALE_TO_SERVICE_SUBTYPE[circuit_scale]
                     ),
-                    "count": 1 if circuit_scale == CircuitScale.small else 100,
+                    "count": 100 if circuit_scale in _DURATION_BILLING_SCALES else 1,
                 },
             },
         },
@@ -530,7 +544,7 @@ def test_task_launch_success__circuit_simulation(
                     "accounting_service_subtype": str(
                         CIRCUIT_SCALE_TO_SERVICE_SUBTYPE[circuit_scale]
                     ),
-                    "count": 1 if circuit_scale == CircuitScale.small else 100,
+                    "count": 100 if circuit_scale in _DURATION_BILLING_SCALES else 1,
                 },
             },
         },
@@ -653,6 +667,8 @@ def test_task_estimate(client, task_type):
 @pytest.mark.parametrize(
     "circuit_scale",
     [
+        CircuitScale.single,
+        CircuitScale.pair,
         CircuitScale.small,
         CircuitScale.microcircuit,
         CircuitScale.region,
@@ -714,6 +730,10 @@ def test_task_estimate__circuit_simulation(client, target_simulator, circuit_sca
     )
     assert data["config_id"] == str(simulation_id)
     assert data["cost"] == 1000
+    assert data["parameters"]["service_subtype"] == CIRCUIT_SCALE_TO_SERVICE_SUBTYPE[circuit_scale]
+    if circuit_scale not in _DURATION_BILLING_SCALES:
+        # single/pair/small are billed as a fixed single unit, independent of duration.
+        assert data["parameters"]["count"] == 1
 
 
 @pytest.mark.parametrize("task_type", TASK_DEFINITIONS.keys())

--- a/tests/app/services/test_accounting.py
+++ b/tests/app/services/test_accounting.py
@@ -333,7 +333,55 @@ def test_evaluate_circuit_simulation_parameters__default_duration(db_client, htt
     assert res.count == 419
 
 
-def test_evaluate_circuit_simulation_parameters__error(db_client, httpx_mock):
+@pytest.mark.parametrize(
+    ("scale", "number_neurons", "expected_subtype"),
+    [
+        ("single", 1, ServiceSubtype.SINGLE_SIM),
+        ("pair", 2, ServiceSubtype.PAIR_SIM),
+    ],
+)
+def test_evaluate_circuit_simulation_parameters__single_pair_scale_ignores_duration(
+    db_client, httpx_mock, scale, number_neurons, expected_subtype
+):
+    """For single/pair scale circuits, duration should not factor into the count."""
+    config_id = uuid4()
+    entity_id = uuid4()
+    simulation_campaign_id = uuid4()
+
+    httpx_mock.add_response(
+        url=f"http://my-url/simulation/{config_id}",
+        method="GET",
+        json={
+            "id": str(config_id),
+            "simulation_campaign_id": str(simulation_campaign_id),
+            "entity_id": str(entity_id),
+            "number_neurons": number_neurons,
+            "scan_parameters": {},
+        },
+    )
+    httpx_mock.add_response(
+        url=f"http://my-url/circuit/{entity_id}",
+        method="GET",
+        json={
+            "id": str(entity_id),
+            "number_neurons": number_neurons,
+            "number_synapses": 10,
+            "number_connections": 12,
+            "scale": scale,
+            "build_category": "computational_model",
+        },
+    )
+
+    res = test_module._evaluate_circuit_simulation_parameters(
+        db_client=db_client,
+        simulation_id=config_id,
+    )
+
+    assert res.service_subtype == expected_subtype
+    assert res.count == 1
+
+
+def test_evaluate_circuit_simulation_parameters__error(db_client, httpx_mock, monkeypatch):
     config_id = uuid4()
     entity_id = uuid4()
     simulation_campaign_id = uuid4()
@@ -361,6 +409,10 @@ def test_evaluate_circuit_simulation_parameters__error(db_client, httpx_mock):
             "build_category": "computational_model",
         },
     )
+
+    # Simulate a circuit scale with no service-subtype mapping to exercise the defensive
+    # fallback (e.g. a new scale added to entitysdk but not yet mapped here).
+    monkeypatch.setattr(test_module, "CIRCUIT_SCALE_TO_SERVICE_SUBTYPE", {})
 
     with pytest.raises(HTTPException, match="Unsupported circuit scale"):
         test_module._evaluate_circuit_simulation_parameters(


### PR DESCRIPTION
## Summary

Extends cost estimation to support simulating circuits of scale `single` and `pair`.

The `/declared/task/estimate` and `/declared/task/launch` endpoints already route
`single`/`pair`-scale circuit simulations to `circuit_simulation_neuron` via
`select_simulation_task`. However, cost evaluation failed with
`HTTP 400 "Unsupported circuit scale"` because `CIRCUIT_SCALE_TO_SERVICE_SUBTYPE`
(in `app/services/accounting.py`) had no entries for these scales.

This maps:
- `CircuitScale.single` → `ServiceSubtype.SINGLE_SIM`
- `CircuitScale.pair` → `ServiceSubtype.PAIR_SIM`

Both bill as a fixed count of `1` (like `small`), since neither is in
`_DURATION_BILLING_SCALES`.

## Tests

- Added a parametrized unit test pinning `single → SINGLE_SIM` / `pair → PAIR_SIM`
  with `count == 1` (duration ignored).
- Extended the estimate and launch endpoint tests to cover `single`/`pair` scales.
- Repaired the `__error` test (it previously used `pair` as its "unsupported scale"
  example) to exercise the defensive fallback by simulating an unmapped scale.

## Related

Original issue: [Add workflow coordinate pricing modal on Launch press](https://github.com/openbraininstitute/prod-circuit-simulation/issues/213).