### PR TITLE
Reduce pairwise distance chunks for lower memory usage

### DIFF
--- a/obi_one/scientific/library/map_em_synapses/map_synapse_locations.py
+++ b/obi_one/scientific/library/map_em_synapses/map_synapse_locations.py
@@ -160,7 +160,7 @@ def morph_to_spine_and_soma_df(m: MorphologyWithSpines) -> pandas.DataFrame:
 
 
 def map_points_to_segs_df(segs: pandas.DataFrame, pts: numpy.ndarray) -> pandas.DataFrame:
-    chunk_sz = 1000
+    chunk_sz = 250
     if len(pts) <= chunk_sz:
         res = _map_points_to_segs_df(segs, pts.to_numpy())  # ty:ignore[unresolved-attribute]
     else:


### PR DESCRIPTION
Tasks were being killed with OOM. This helps by loading smaller chunks to compute in memory.