### PR TITLE
Fixed a potential indexing error with EM Synapse Mapping.

### DIFF
--- a/obi_one/scientific/library/map_em_synapses/map_synapse_locations.py
+++ b/obi_one/scientific/library/map_em_synapses/map_synapse_locations.py
@@ -77,8 +77,8 @@ def add_competing_mesh_distances(
     )
     mask = competitor_dists < 0
     mask_idx = competitor_dists[mask].index
-    k = 100
     max_k = len(mesh_pt_df)
+    k = numpy.minimum(100, max_k)
 
     while len(mask_idx) > 0:
         dist, idx = tree.query(pts.loc[mask_idx], k=k)

--- a/obi_one/scientific/library/map_em_synapses/map_synapse_locations.py
+++ b/obi_one/scientific/library/map_em_synapses/map_synapse_locations.py
@@ -78,9 +78,9 @@ def add_competing_mesh_distances(
     mask = competitor_dists < 0
     mask_idx = competitor_dists[mask].index
     k = 100
-    max_k = 1e6
+    max_k = len(mesh_pt_df)
 
-    while (len(mask_idx) > 0) and (k < max_k):
+    while len(mask_idx) > 0:
         dist, idx = tree.query(pts.loc[mask_idx], k=k)
         competitor_ids = mesh_pt_df.spine_sharing_id.to_numpy()[idx]
         is_different = competitor_ids[:, 0] != competitor_ids[:, -1]
@@ -94,7 +94,9 @@ def add_competing_mesh_distances(
 
         mask = competitor_dists < 0
         mask_idx = competitor_dists[mask].index
-        k *= 4
+        if k == max_k:
+            break
+        k = numpy.minimum(k * 4, max_k)
     return competitor_dists
 
 

--- a/tests/obi_one/scientific/library/test_map_synapse_locations.py
+++ b/tests/obi_one/scientific/library/test_map_synapse_locations.py
@@ -1,0 +1,32 @@
+"""Test functionality used to map synapse locations to morphologies"""
+
+import numpy as np
+import pandas as pd
+
+from obi_one.scientific.library.map_em_synapses.map_synapse_locations import (
+    add_competing_mesh_distances,
+)
+
+RNG_ = np.random.default_rng()
+
+
+def test_competing_distances_no_solution():
+    mesh_pt_df = pd.DataFrame(
+        [[0.0, 0.0, 0.0, 0], [0.0, 1.0, 0.0, 0], [0.0, 2.0, 0.0, 0]],
+        columns=["x", "y", "z", "spine_sharing_id"],
+    )
+    pts = pd.DataFrame(RNG_.random(size=(10, 3)), columns=["x", "y", "z"])
+    # Must be all -1 because all spine_sharing_ids are the same
+    competitors = add_competing_mesh_distances(mesh_pt_df, pts)
+    assert (competitors == -1).all()
+
+
+def test_competing_distances_good_solution():
+    mesh_pt_df = pd.DataFrame(
+        [[0.0, 0.0, 0.0, 1], [0.0, 1.0, 0.0, 2], [0.0, 2.0, 0.0, 3]],
+        columns=["x", "y", "z", "spine_sharing_id"],
+    )
+    pts = pd.DataFrame(RNG_.random(size=(10, 3)), columns=["x", "y", "z"])
+    # Must be all -1 because all spine_sharing_ids are the same
+    competitors = add_competing_mesh_distances(mesh_pt_df, pts)
+    assert not (competitors == -1).any()


### PR DESCRIPTION
It occured because I was increasing the size of a KDTree query until a hit was achieved or an arbitrary maximum size was reached. Usually, a hit is achieved long before the maximum size is reached. However, in some circumstances this allowed the size of the query to exceed the number of elements in the KDTree. In that case, invalid indices were returned.

Now, the maximum size is set to the size of the KDTree.