### PR TITLE
Fix neuronal manipulation variable parsing and validation

### DIFF
--- a/obi_one/scientific/blocks/neuronal_manipulations/neuronal_manipulations.py
+++ b/obi_one/scientific/blocks/neuronal_manipulations/neuronal_manipulations.py
@@ -88,7 +88,8 @@ class ByNeuronModification(ComplexVariableHolder):
         default="GLOBAL",
         description="Variable type: 'RANGE' (section-specific) or 'GLOBAL' (neuron-wide)",
     )
-    new_value: float | list[float] = Field(
+    new_value: float | list[float] | None = Field(
+        default=None,
         description="New value(s) that applies to entire neuron (GLOBAL) or all sections (RANGE)",
     )
 
@@ -193,7 +194,11 @@ class ByNeuronMechanismVariableNeuronalManipulation(Block):
             entry for all sections.
             For section properties (cm, Ra): list[dict] with a single
             conditions.modifications entry for all sections.
+            Empty list if no new_value is provided (use existing defaults).
         """
+        if self.modification.new_value is None:
+            return []
+
         # Handle RANGE variables (including section properties)
         if self.modification.variable_type == "RANGE":
             node_set = resolve_neuron_set_ref_to_node_set(self.neuron_set, default_node_set)

--- a/obi_one/scientific/library/emodel_parameters.py
+++ b/obi_one/scientific/library/emodel_parameters.py
@@ -233,9 +233,8 @@ def _parse_optimization_parameters(
         # the final HOC file. They are not runtime-modifiable NEURON variables.
         # Detection: section_list is not a recognized name AND variable has no
         # ion channel suffix.
-        if (
-            section_list not in _VALID_SECTION_LISTS
-            and not _extract_channel_suffix(neuron_variable, known_suffixes)
+        if section_list not in _VALID_SECTION_LISTS and not _extract_channel_suffix(
+            neuron_variable, known_suffixes
         ):
             continue
 

--- a/obi_one/scientific/library/emodel_parameters.py
+++ b/obi_one/scientific/library/emodel_parameters.py
@@ -23,6 +23,17 @@ _MULTILOC_MAP = {
     "all": ["apical", "basal", "somatic", "axonal"],
 }
 
+# All recognized section list names (concrete names + aliases).
+# Used to detect when the second part of a parameter name is NOT a section list,
+# which indicates a distribution meta-parameter (e.g. "constant.distribution_decay").
+_VALID_SECTION_LISTS: set[str] = {
+    "somatic",
+    "basal",
+    "apical",
+    "axonal",
+    *_MULTILOC_MAP.keys(),
+}
+
 
 def _expand_section_list(section_list: str) -> list[str]:
     """Expand a section-list alias into concrete section lists."""
@@ -195,7 +206,13 @@ def _parse_optimization_parameters(
 
     Each parameter name follows the format "<neuron_variable>.<section_list>"
     (e.g. "decay_CaDynamics_DC0.somatic", "g_pas.all").
+
+    Parameters whose second part is not a recognized section list AND whose first
+    part has no ion channel suffix are treated as GLOBAL distribution parameters
+    (e.g. "constant.distribution_decay").
     """
+    known_suffixes = [icm.nmodl_suffix for icm in emodel.ion_channel_models or []]
+
     parsed = []
     for param in parameters_json:
         name = param.get("name", "")
@@ -209,6 +226,18 @@ def _parse_optimization_parameters(
 
         # Add limits for variables starting with 'g'
         limits = [0.0, 10.0] if neuron_variable.startswith("g") else None
+
+        # Skip distribution meta-parameters (e.g. "constant.distribution_decay").
+        # These are optimization parameters for spatial distribution formulas
+        # (like exp(distance * constant) * value) that are already substituted into
+        # the final HOC file. They are not runtime-modifiable NEURON variables.
+        # Detection: section_list is not a recognized name AND variable has no
+        # ion channel suffix.
+        if (
+            section_list not in _VALID_SECTION_LISTS
+            and not _extract_channel_suffix(neuron_variable, known_suffixes)
+        ):
+            continue
 
         # Determine variable type: GLOBAL only if in neuron_block.global_, otherwise RANGE
         variable_type = "GLOBAL" if _is_global_variable(emodel, neuron_variable) else "RANGE"

--- a/tests/obi_one/scientific/library/test_emodel_parameters.py
+++ b/tests/obi_one/scientific/library/test_emodel_parameters.py
@@ -5,6 +5,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from obi_one.scientific.library.emodel_parameters import (
+    _VALID_SECTION_LISTS,
+    _expand_section_list,
     _parse_optimization_parameters,
 )
 
@@ -28,6 +30,45 @@ def _make_icm(suffix, name=None, range_vars=None, global_vars=None):
     icm.neuron_block = neuron_block
 
     return icm
+
+
+class TestValidSectionLists:
+    """Tests for _VALID_SECTION_LISTS constant."""
+
+    def test_contains_standard_sections(self):
+        """Standard section lists are included."""
+        assert "somatic" in _VALID_SECTION_LISTS
+        assert "basal" in _VALID_SECTION_LISTS
+        assert "apical" in _VALID_SECTION_LISTS
+        assert "axonal" in _VALID_SECTION_LISTS
+
+    def test_contains_multiloc_aliases(self):
+        """Multi-location aliases are included."""
+        assert "all" in _VALID_SECTION_LISTS
+        assert "alldend" in _VALID_SECTION_LISTS
+        assert "somadend" in _VALID_SECTION_LISTS
+        assert "allnoaxon" in _VALID_SECTION_LISTS
+        assert "somaxon" in _VALID_SECTION_LISTS
+        assert "allact" in _VALID_SECTION_LISTS
+
+
+class TestExpandSectionList:
+    """Tests for _expand_section_list."""
+
+    def test_expand_all(self):
+        """'all' expands to all 4 section lists."""
+        result = _expand_section_list("all")
+        assert result == ["apical", "basal", "somatic", "axonal"]
+
+    def test_expand_alldend(self):
+        """'alldend' expands to apical and basal."""
+        result = _expand_section_list("alldend")
+        assert result == ["apical", "basal"]
+
+    def test_passthrough_unknown(self):
+        """Unknown section lists pass through unchanged."""
+        result = _expand_section_list("somatic")
+        assert result == ["somatic"]
 
 
 class TestParseOptimizationParameters:
@@ -57,6 +98,24 @@ class TestParseOptimizationParameters:
         assert result[0].neuron_variable == "gNaTgbar_NaTg"
         assert result[0].section_list == "somatic"
         assert result[0].value == pytest.approx(0.1)
+
+    def test_skips_multiple_distribution_params(self):
+        """Multiple distribution meta-parameters are all skipped."""
+        icm = _make_icm("NaTg")
+        emodel = _make_emodel(ion_channel_models=[icm])
+
+        parameters_json = [
+            {"name": "constant.distribution_decay", "value": 0.5},
+            {"name": "exponential.scale_factor", "value": 1.2},
+            {"name": "linear.offset_value", "value": 0.01},
+            {"name": "gNaTgbar_NaTg.somatic", "value": 0.1},
+        ]
+
+        result = _parse_optimization_parameters(parameters_json, emodel)
+
+        # Only the valid parameter should remain
+        assert len(result) == 1
+        assert result[0].neuron_variable == "gNaTgbar_NaTg"
 
     def test_does_not_skip_param_with_known_suffix_and_unknown_section(self):
         """Parameters with a recognized ion channel suffix are kept even if section_list is unusual.
@@ -96,3 +155,19 @@ class TestParseOptimizationParameters:
         assert len(g_pas_vars) == 4  # "all" expands to apical, basal, somatic, axonal
         assert len(e_pas_vars) == 1
         assert e_pas_vars[0].section_list == "somatic"
+
+    def test_multiloc_alias_expansion(self):
+        """Multi-location aliases are properly expanded."""
+        icm = _make_icm("pas")
+        emodel = _make_emodel(ion_channel_models=[icm])
+
+        parameters_json = [
+            {"name": "g_pas.alldend", "value": 0.001},
+        ]
+
+        result = _parse_optimization_parameters(parameters_json, emodel)
+
+        # "alldend" expands to apical and basal
+        assert len(result) == 2
+        section_lists = {v.section_list for v in result}
+        assert section_lists == {"apical", "basal"}

--- a/tests/obi_one/scientific/library/test_emodel_parameters.py
+++ b/tests/obi_one/scientific/library/test_emodel_parameters.py
@@ -1,0 +1,96 @@
+"""Tests for emodel_parameters module."""
+
+from unittest.mock import MagicMock
+
+from obi_one.scientific.library.emodel_parameters import (
+    _parse_optimization_parameters,
+)
+
+
+def _make_emodel(ion_channel_models=None):
+    """Create a mock EModel with optional ion channel models."""
+    emodel = MagicMock()
+    emodel.ion_channel_models = ion_channel_models or []
+    return emodel
+
+
+def _make_icm(suffix, name=None, range_vars=None, global_vars=None):
+    """Create a mock IonChannelModel."""
+    icm = MagicMock()
+    icm.nmodl_suffix = suffix
+    icm.name = name or suffix
+
+    neuron_block = MagicMock()
+    neuron_block.range = range_vars or []
+    neuron_block.global_ = global_vars or []
+    icm.neuron_block = neuron_block
+
+    return icm
+
+
+class TestParseOptimizationParameters:
+    """Tests for _parse_optimization_parameters."""
+
+    def test_skips_distribution_meta_parameters(self):
+        """Distribution meta-parameters (e.g. 'constant.distribution_decay') are skipped.
+
+        These have a section_list that is not a recognized section list name
+        AND the neuron_variable has no ion channel suffix.
+        """
+        icm = _make_icm("NaTg")
+        emodel = _make_emodel(ion_channel_models=[icm])
+
+        parameters_json = [
+            # This is a distribution meta-parameter that should be skipped:
+            # "constant" has no known suffix, "distribution_decay" is not a valid section list
+            {"name": "constant.distribution_decay", "value": 0.5},
+            # This is a valid parameter that should NOT be skipped:
+            {"name": "gNaTgbar_NaTg.somatic", "value": 0.1},
+        ]
+
+        result = _parse_optimization_parameters(parameters_json, emodel)
+
+        # Only the valid parameter should be in the result
+        assert len(result) == 1
+        assert result[0].neuron_variable == "gNaTgbar_NaTg"
+        assert result[0].section_list == "somatic"
+        assert result[0].value == 0.1
+
+    def test_does_not_skip_param_with_known_suffix_and_unknown_section(self):
+        """Parameters with a recognized ion channel suffix are kept even if section_list is unusual.
+
+        E.g. 'decay_CaDynamics_DC0.some_other' has suffix 'CaDynamics_DC0' which is known,
+        so it should NOT be skipped even though 'some_other' is not a standard section list.
+        """
+        icm = _make_icm("CaDynamics_DC0")
+        emodel = _make_emodel(ion_channel_models=[icm])
+
+        parameters_json = [
+            {"name": "decay_CaDynamics_DC0.some_custom_section", "value": 2.0},
+        ]
+
+        result = _parse_optimization_parameters(parameters_json, emodel)
+
+        # Should NOT be skipped because the suffix is known
+        assert len(result) == 1
+        assert result[0].neuron_variable == "decay_CaDynamics_DC0"
+
+    def test_valid_section_list_params_are_kept(self):
+        """Parameters with valid section lists are parsed normally."""
+        icm = _make_icm("pas")
+        emodel = _make_emodel(ion_channel_models=[icm])
+
+        parameters_json = [
+            {"name": "g_pas.all", "value": 0.001},
+            {"name": "e_pas.somatic", "value": -75.0},
+        ]
+
+        result = _parse_optimization_parameters(parameters_json, emodel)
+
+        # "all" expands to 4 section lists
+        g_pas_vars = [v for v in result if v.neuron_variable == "g_pas"]
+        e_pas_vars = [v for v in result if v.neuron_variable == "e_pas"]
+
+        assert len(g_pas_vars) == 4  # "all" expands to apical, basal, somatic, axonal
+        assert len(e_pas_vars) == 1
+        assert e_pas_vars[0].section_list == "somatic"

--- a/tests/obi_one/scientific/library/test_emodel_parameters.py
+++ b/tests/obi_one/scientific/library/test_emodel_parameters.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock
 
+import pytest
+
 from obi_one.scientific.library.emodel_parameters import (
     _parse_optimization_parameters,
 )
@@ -54,7 +56,7 @@ class TestParseOptimizationParameters:
         assert len(result) == 1
         assert result[0].neuron_variable == "gNaTgbar_NaTg"
         assert result[0].section_list == "somatic"
-        assert result[0].value == 0.1
+        assert result[0].value == pytest.approx(0.1)
 
     def test_does_not_skip_param_with_known_suffix_and_unknown_section(self):
         """Parameters with a recognized ion channel suffix are kept even if section_list is unusual.


### PR DESCRIPTION
Solves:
https://github.com/openbraininstitute/prod-singlecell-simulation/issues/294
https://github.com/openbraininstitute/prod-singlecell-simulation/issues/295

1. Skip distribution meta-parameters in emodel optimisation parsing
- Parameters like constant.distribution_decay are spatial distribution formula constants used during optimization (e.g. exp(distance * constant) * value). They are baked into the HOC file and are not runtime-modifiable NEURON variables.

- Previously, these were misclassified as RANGE variables with an invalid section list, causing:

```ValueError: section_list modification 'modify_constant_distribution_decay': unknown section list name 'distribution_decay'```

- Detection: second part of param name is not a recognised section list AND first part has no ion channel suffix.

2. Make ByNeuron manipulation new_value optional
- Allow Full Neuron Variable Modification to be configured without a user-provided value. When new_value is None, no modification is generated and the simulation uses existing defaults — matching the behavior of Variable Modification by Section List.

- Previously, new_value was required, causing frontend validation to block simulation generation even though defaults exist.


- Verified endpoint response for MEModel `c2b7c94c-a342-49ab-aa15-6501de5caf1f` (L2_TPC with constant.distribution_decay) — parameter is correctly filtered out. 
- For review, the above MEModel can be tested in the example `examples/A_service_and_entitycore/test_endpoints/test_endpoints.ipynb` for `declared/mapped-circuit-properties` endpoint.