### PR TITLE
Prevent cached morphometrics template value reuse

### DIFF
--- a/obi_one/scientific/library/morphology_measurement_annotation.py
+++ b/obi_one/scientific/library/morphology_measurement_annotation.py
@@ -1,5 +1,6 @@
 """NeuroM-based morphology measurement annotation helpers."""
 
+import copy
 import json
 import logging
 from collections import defaultdict
@@ -333,7 +334,7 @@ def compute_morphometrics(morphology_path: str | Path) -> list[MeasurementKind]:
     """Compute morphometric measurements for a morphology file."""
     neuron = nm.load_morphology(str(morphology_path))
     results_dict = build_results_dict(get_morphology_analysis_dict(), neuron)
-    filled = fill_json(get_morphology_template(), results_dict, entity_id="temp_id")
+    filled = fill_json(copy.deepcopy(get_morphology_template()), results_dict, entity_id="temp_id")
     measurement_kinds = filled["data"][0]["measurement_kinds"]
     return [
         mk

--- a/tests/app/routers/declared/test_morphology_analysis.py
+++ b/tests/app/routers/declared/test_morphology_analysis.py
@@ -45,6 +45,17 @@ def test_real_morphology_metrics_match_golden_values():
         assert actual[key] == pytest.approx(expected_value), key
 
 
+def test_morphology_metrics_do_not_reuse_apical_values_from_cached_template():
+    uf.get_morphology_template.cache_clear()
+    uf.get_morphology_analysis_dict.cache_clear()
+
+    with_apical = uf.compute_morphometrics(DATA_DIR / "ch150801A1.swc")
+    without_apical = uf.compute_morphometrics(DATA_DIR / "cell_morphology.asc")
+
+    assert any(m["structural_domain"] == "apical_dendrite" for m in with_apical)
+    assert not any(m["structural_domain"] == "apical_dendrite" for m in without_apical)
+
+
 def test_metric_with_nan_values_is_skipped(monkeypatch, caplog):
     monkeypatch.setattr(uf.nm, "get", lambda *_args, **_kwargs: [1.0, float("nan"), 3.0])
 


### PR DESCRIPTION
## Summary

Deep-copy the cached morphology template before filling metric values, so one morphology computation cannot leak values into the next.

Adds a regression test for apical dendrite values being reused from a previous computation.