### PR TITLE
Drop incomplete morphology aggregate metrics

### DIFF
--- a/obi_one/scientific/library/morphology_measurement_annotation.py
+++ b/obi_one/scientific/library/morphology_measurement_annotation.py
@@ -335,31 +335,40 @@ def _is_valid_measurement_value(value: Any) -> bool:
     """Return True when a measurement item value should be kept."""
     if value is None:
         return False
-    return not (isinstance(value, (float, np.floating)) and np.isnan(value))
+    return not (isinstance(value, (float, np.floating)) and not np.isfinite(value))
 
 
 def _filter_valid_measurement_kinds(
     measurement_kinds: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    """Drop null/NaN measurement items, then drop empty measurement kinds."""
+    """Drop measurement kinds containing null/NaN/non-finite aggregate values."""
     valid_measurement_kinds = []
+
     for measurement_kind in measurement_kinds:
-        original_item_names = {
-            item.get("name") for item in measurement_kind.get("measurement_items", [])
-        }
+        original_items = measurement_kind.get("measurement_items", [])
+        original_item_names = {item.get("name") for item in original_items}
+
         measurement_items = [
             item
-            for item in measurement_kind.get("measurement_items", [])
+            for item in original_items
             if _is_valid_measurement_value(item.get("value"))
         ]
         measurement_item_names = {item.get("name") for item in measurement_items}
-        if AGGREGATE_ITEM_NAMES.issubset(original_item_names) and not AGGREGATE_ITEM_NAMES.issubset(
-            measurement_item_names
+
+        if (
+            AGGREGATE_ITEM_NAMES.issubset(original_item_names)
+            and not AGGREGATE_ITEM_NAMES.issubset(measurement_item_names)
         ):
             continue
+
         if measurement_items:
-            measurement_kind["measurement_items"] = measurement_items
-            valid_measurement_kinds.append(measurement_kind)
+            valid_measurement_kinds.append(
+                {
+                    **measurement_kind,
+                    "measurement_items": measurement_items,
+                }
+            )
+
     return valid_measurement_kinds
 
 

--- a/obi_one/scientific/library/morphology_measurement_annotation.py
+++ b/obi_one/scientific/library/morphology_measurement_annotation.py
@@ -349,15 +349,12 @@ def _filter_valid_measurement_kinds(
         original_item_names = {item.get("name") for item in original_items}
 
         measurement_items = [
-            item
-            for item in original_items
-            if _is_valid_measurement_value(item.get("value"))
+            item for item in original_items if _is_valid_measurement_value(item.get("value"))
         ]
         measurement_item_names = {item.get("name") for item in measurement_items}
 
-        if (
-            AGGREGATE_ITEM_NAMES.issubset(original_item_names)
-            and not AGGREGATE_ITEM_NAMES.issubset(measurement_item_names)
+        if AGGREGATE_ITEM_NAMES.issubset(original_item_names) and not AGGREGATE_ITEM_NAMES.issubset(
+            measurement_item_names
         ):
             continue
 

--- a/obi_one/scientific/library/morphology_measurement_annotation.py
+++ b/obi_one/scientific/library/morphology_measurement_annotation.py
@@ -6,7 +6,7 @@ import logging
 from collections import defaultdict
 from functools import cache
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import neurom as nm
 import numpy as np
@@ -20,6 +20,7 @@ TARGET_NEURITE_DOMAINS = ("apical_dendrite", "axon")
 
 MIN_MEASUREMENT_ITEM_ENTRIES = 2
 EMPTY_NAME_SET = {None, ""}
+AGGREGATE_ITEM_NAMES = {"minimum", "maximum", "median", "mean", "standard_deviation"}
 
 _TEMPLATE_PATH = Path(__file__).with_name("morphology_template.json")
 
@@ -330,17 +331,45 @@ def fill_json(
     return template
 
 
+def _is_valid_measurement_value(value: Any) -> bool:
+    """Return True when a measurement item value should be kept."""
+    if value is None:
+        return False
+    return not (isinstance(value, (float, np.floating)) and np.isnan(value))
+
+
+def _filter_valid_measurement_kinds(
+    measurement_kinds: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Drop null/NaN measurement items, then drop empty measurement kinds."""
+    valid_measurement_kinds = []
+    for measurement_kind in measurement_kinds:
+        original_item_names = {
+            item.get("name") for item in measurement_kind.get("measurement_items", [])
+        }
+        measurement_items = [
+            item
+            for item in measurement_kind.get("measurement_items", [])
+            if _is_valid_measurement_value(item.get("value"))
+        ]
+        measurement_item_names = {item.get("name") for item in measurement_items}
+        if AGGREGATE_ITEM_NAMES.issubset(original_item_names) and not AGGREGATE_ITEM_NAMES.issubset(
+            measurement_item_names
+        ):
+            continue
+        if measurement_items:
+            measurement_kind["measurement_items"] = measurement_items
+            valid_measurement_kinds.append(measurement_kind)
+    return valid_measurement_kinds
+
+
 def compute_morphometrics(morphology_path: str | Path) -> list[MeasurementKind]:
     """Compute morphometric measurements for a morphology file."""
     neuron = nm.load_morphology(str(morphology_path))
     results_dict = build_results_dict(get_morphology_analysis_dict(), neuron)
     filled = fill_json(copy.deepcopy(get_morphology_template()), results_dict, entity_id="temp_id")
     measurement_kinds = filled["data"][0]["measurement_kinds"]
-    return [
-        mk
-        for mk in measurement_kinds
-        if any(mi.get("value") is not None for mi in mk.get("measurement_items", []))
-    ]
+    return cast("list[MeasurementKind]", _filter_valid_measurement_kinds(measurement_kinds))
 
 
 def _has_neurite_type(neuron: Morphology, neurite_type: int) -> bool:

--- a/tests/app/routers/declared/test_morphology_analysis.py
+++ b/tests/app/routers/declared/test_morphology_analysis.py
@@ -74,3 +74,62 @@ def test_scalar_nan_metric_is_skipped(monkeypatch, caplog):
     assert result == ["soma_radius", None, "um"]
     assert "Skipping NaN value for morphology metric soma_radius" in caplog.text
     json.dumps(result, allow_nan=False)
+
+
+def test_invalid_raw_measurement_items_are_filtered():
+    measurement_kinds = [
+        {
+            "structural_domain": "soma",
+            "pref_label": "soma_radius",
+            "measurement_items": [
+                {"name": "raw", "unit": "um", "value": 1.0},
+                {"name": "raw", "unit": "um", "value": None},
+            ],
+        },
+        {
+            "structural_domain": "soma",
+            "pref_label": "soma_surface_area",
+            "measurement_items": [
+                {"name": "raw", "unit": "um2", "value": None},
+            ],
+        },
+    ]
+
+    result = uf._filter_valid_measurement_kinds(measurement_kinds)
+
+    assert result == [
+        {
+            "structural_domain": "soma",
+            "pref_label": "soma_radius",
+            "measurement_items": [{"name": "raw", "unit": "um", "value": 1.0}],
+        },
+    ]
+    json.dumps(result, allow_nan=False)
+
+
+def test_incomplete_aggregate_measurement_is_filtered():
+    measurement_kinds = [
+        {
+            "structural_domain": "axon",
+            "pref_label": "section_lengths",
+            "measurement_items": [
+                {"name": "minimum", "unit": "um", "value": 1.0},
+                {"name": "maximum", "unit": "um", "value": None},
+                {"name": "median", "unit": "um", "value": 2.0},
+                {"name": "mean", "unit": "um", "value": None},
+                {"name": "standard_deviation", "unit": "um", "value": None},
+            ],
+        },
+        {
+            "structural_domain": "axon",
+            "pref_label": "local_bifurcation_angles",
+            "measurement_items": [
+                {"name": "minimum", "unit": "radian", "value": None},
+            ],
+        },
+    ]
+
+    result = uf._filter_valid_measurement_kinds(measurement_kinds)
+
+    assert result == []
+    json.dumps(result, allow_nan=False)

--- a/tests/app/routers/declared/test_morphology_analysis.py
+++ b/tests/app/routers/declared/test_morphology_analysis.py
@@ -76,13 +76,12 @@ def test_scalar_nan_metric_is_skipped(monkeypatch, caplog):
     json.dumps(result, allow_nan=False)
 
 
-def test_invalid_raw_measurement_items_are_filtered():
+def test_invalid_raw_measurement_is_filtered():
     measurement_kinds = [
         {
             "structural_domain": "soma",
             "pref_label": "soma_radius",
             "measurement_items": [
-                {"name": "raw", "unit": "um", "value": 1.0},
                 {"name": "raw", "unit": "um", "value": None},
             ],
         },
@@ -90,7 +89,7 @@ def test_invalid_raw_measurement_items_are_filtered():
             "structural_domain": "soma",
             "pref_label": "soma_surface_area",
             "measurement_items": [
-                {"name": "raw", "unit": "um2", "value": None},
+                {"name": "raw", "unit": "um2", "value": 10.0},
             ],
         },
     ]
@@ -100,8 +99,10 @@ def test_invalid_raw_measurement_items_are_filtered():
     assert result == [
         {
             "structural_domain": "soma",
-            "pref_label": "soma_radius",
-            "measurement_items": [{"name": "raw", "unit": "um", "value": 1.0}],
+            "pref_label": "soma_surface_area",
+            "measurement_items": [
+                {"name": "raw", "unit": "um2", "value": 10.0},
+            ],
         },
     ]
     json.dumps(result, allow_nan=False)


### PR DESCRIPTION
This follows up on https://github.com/openbraininstitute/obi-one/pull/815.

That change handled NaN values coming from the raw NeuroM results. This PR handles an additional output-side case where an aggregate metric can still be serialized with only part of the expected statistics, for example minimum and median present, but maximum, mean, and standard_deviation missing. For aggregate morphometrics, partial results are misleading, so this change drops the whole aggregate metric unless all expected statistic values are valid.