### PR TITLE
Retry transient CAVEClient materialization errors in EM synapse mapping

### DIFF
--- a/obi_one/config.py
+++ b/obi_one/config.py
@@ -9,6 +9,13 @@ class CircuitExtractionSettings(BaseModel):
 
 class CaveClientConfig(BaseModel):
     microns_api_key: str = "CAVECLIENT_MICRONS_API_KEY"
+    # Retry behaviour for the CAVEClient materialization engine (urllib3 Retry).
+    # The engine intermittently returns 503s; these widen caveclient's weak
+    # built-in defaults so transient outages are ridden out before failing.
+    max_retries: int = 8
+    retry_backoff_factor: float = 0.5
+    retry_backoff_max: float = 120.0
+    retry_status_forcelist: tuple[int, ...] = (429, 502, 503, 504)
 
 
 class Settings(BaseSettings):

--- a/obi_one/scientific/from_id/em_dataset_from_id.py
+++ b/obi_one/scientific/from_id/em_dataset_from_id.py
@@ -1,17 +1,52 @@
+import functools
+from collections.abc import Callable
 from typing import ClassVar
 
 import numpy  # NOQA: ICN001
 import pandas  # NOQA: ICN001
-from caveclient import CAVEclient
+import requests
+from caveclient import CAVEclient, set_session_defaults
 from entitysdk import Client
 from entitysdk.models import EMDenseReconstructionDataset
 from entitysdk.models.entity import Entity
 from pydantic import PrivateAttr
 
+from obi_one.config import settings
 from obi_one.core.entity_from_id import EntityFromID
+from obi_one.core.exception import OBIONEError
 
 _C_P_LOCS = ["synapse_x", "synapse_y", "synapse_z"]
 _NM_to_UM = 1e-3
+
+
+def _graceful_materialize_errors[T](func: Callable[..., T]) -> Callable[..., T]:
+    """Convert exhausted CAVEClient request failures into a clean OBIONEError.
+
+    The CAVEClient materialization engine intermittently returns transient errors
+    (e.g. 503). caveclient retries these at the HTTP-session layer (see
+    ``_make_cave_client``); once retries are exhausted it raises a ``requests``
+    exception. This decorator translates that into an actionable ``OBIONEError``
+    so the task fails gracefully rather than with a raw traceback.
+
+    Args:
+        func: The materialize-backed method to wrap.
+
+    Returns:
+        The wrapped method.
+    """
+
+    @functools.wraps(func)
+    def wrapper(self: "EMDataSetFromID", *args: object, **kwargs: object) -> T:
+        try:
+            return func(self, *args, **kwargs)
+        except requests.exceptions.RequestException as e:
+            msg = (
+                "The EM materialization engine is temporarily unavailable after "
+                f"retries; please try again later (underlying error: {e})."
+            )
+            raise OBIONEError(msg) from e
+
+    return wrapper
 
 
 class EMDataSetFromID(EntityFromID):
@@ -20,6 +55,7 @@ class EMDataSetFromID(EntityFromID):
     _viewer_resolution: numpy.ndarray | None = PrivateAttr(default=None)
     auth_token: str | None = None
 
+    @_graceful_materialize_errors
     def synapse_info_df(
         self,
         pt_root_id: int,
@@ -48,6 +84,7 @@ class EMDataSetFromID(EntityFromID):
         )
         return syns, notice_text
 
+    @_graceful_materialize_errors
     def neuron_info_df(
         self, table_name: str, cave_version: int, db_client: Client | None = None
     ) -> tuple[pandas.DataFrame, str]:
@@ -59,10 +96,12 @@ class EMDataSetFromID(EntityFromID):
         notice_text = client.materialize.get_table_metadata(table_name).get("notice_text")  # ty:ignore[unresolved-attribute]
         return tbl, notice_text
 
+    @_graceful_materialize_errors
     def get_versions(self, db_client: Client | None = None) -> list:
         client = self._make_cave_client(db_client)  # ty:ignore[invalid-argument-type]
         return client.materialize.get_versions()  # ty:ignore[unresolved-attribute]
 
+    @_graceful_materialize_errors
     def get_tables(self, cave_version: int, db_client: Client | None = None) -> dict:
         client = self._make_cave_client(db_client, cave_version=cave_version)  # ty:ignore[invalid-argument-type]
         tables = {}
@@ -74,6 +113,7 @@ class EMDataSetFromID(EntityFromID):
             }
         return tables
 
+    @_graceful_materialize_errors
     def viewer_resolution(self, db_client: Client | None = None) -> list:
         if self._viewer_resolution is None:
             self._viewer_resolution = self._make_cave_client(
@@ -85,6 +125,18 @@ class EMDataSetFromID(EntityFromID):
         entity = self.entity(db_client=db_client)
         datastack_name_ = entity.cave_datastack  # ty:ignore[unresolved-attribute]
         cave_client_url_ = entity.cave_client_url  # ty:ignore[unresolved-attribute]
+
+        # Widen caveclient's retry behaviour so transient materialization-engine
+        # errors (e.g. 503) are ridden out. set_session_defaults() only mutates a
+        # module-level dict and applies to every client/session created afterwards,
+        # so it is cheap and idempotent to (re)apply here before each client build.
+        cfg = settings.cave_client_config
+        set_session_defaults(
+            max_retries=cfg.max_retries,
+            backoff_factor=cfg.retry_backoff_factor,
+            backoff_max=cfg.retry_backoff_max,
+            status_forcelist=cfg.retry_status_forcelist,
+        )
 
         cave_client = CAVEclient(
             datastack_name_, server_address=cave_client_url_, auth_token=self.auth_token

--- a/obi_one/scientific/from_id/em_dataset_from_id.py
+++ b/obi_one/scientific/from_id/em_dataset_from_id.py
@@ -36,9 +36,9 @@ def _graceful_materialize_errors[T](func: Callable[..., T]) -> Callable[..., T]:
     """
 
     @functools.wraps(func)
-    def wrapper(self: "EMDataSetFromID", *args: object, **kwargs: object) -> T:
+    def wrapper(*args: object, **kwargs: object) -> T:
         try:
-            return func(self, *args, **kwargs)
+            return func(*args, **kwargs)
         except requests.exceptions.RequestException as e:
             msg = (
                 "The EM materialization engine is temporarily unavailable after "
@@ -47,6 +47,27 @@ def _graceful_materialize_errors[T](func: Callable[..., T]) -> Callable[..., T]:
             raise OBIONEError(msg) from e
 
     return wrapper
+
+
+def _configure_caveclient_retries() -> None:
+    """Widen caveclient's process-global retry behaviour from settings.
+
+    The CAVEClient materialization engine intermittently returns transient errors
+    (e.g. 503). caveclient retries 502/503/504 at the HTTP-session layer but with
+    weak defaults; this widens them so transient outages are ridden out before
+    failing. ``set_session_defaults`` mutates a process-global dict that applies to
+    every client created afterwards, so it is invoked once at import time below.
+    """
+    cfg = settings.cave_client_config
+    set_session_defaults(
+        max_retries=cfg.max_retries,
+        backoff_factor=cfg.retry_backoff_factor,
+        backoff_max=cfg.retry_backoff_max,
+        status_forcelist=cfg.retry_status_forcelist,
+    )
+
+
+_configure_caveclient_retries()
 
 
 class EMDataSetFromID(EntityFromID):
@@ -125,18 +146,6 @@ class EMDataSetFromID(EntityFromID):
         entity = self.entity(db_client=db_client)
         datastack_name_ = entity.cave_datastack  # ty:ignore[unresolved-attribute]
         cave_client_url_ = entity.cave_client_url  # ty:ignore[unresolved-attribute]
-
-        # Widen caveclient's retry behaviour so transient materialization-engine
-        # errors (e.g. 503) are ridden out. set_session_defaults() only mutates a
-        # module-level dict and applies to every client/session created afterwards,
-        # so it is cheap and idempotent to (re)apply here before each client build.
-        cfg = settings.cave_client_config
-        set_session_defaults(
-            max_retries=cfg.max_retries,
-            backoff_factor=cfg.retry_backoff_factor,
-            backoff_max=cfg.retry_backoff_max,
-            status_forcelist=cfg.retry_status_forcelist,
-        )
 
         cave_client = CAVEclient(
             datastack_name_, server_address=cave_client_url_, auth_token=self.auth_token

--- a/tests/obi_one/scientific/from_id/test_em_dataset_from_id.py
+++ b/tests/obi_one/scientific/from_id/test_em_dataset_from_id.py
@@ -6,7 +6,10 @@ import requests
 
 from obi_one.config import settings
 from obi_one.core.exception import OBIONEError
-from obi_one.scientific.from_id.em_dataset_from_id import EMDataSetFromID
+from obi_one.scientific.from_id.em_dataset_from_id import (
+    EMDataSetFromID,
+    _configure_caveclient_retries,
+)
 
 _MODULE = "obi_one.scientific.from_id.em_dataset_from_id"
 
@@ -22,17 +25,10 @@ def _http_error(status=503):
 
 
 class TestRetryConfiguration:
-    def test_make_cave_client_widens_retry_defaults_from_settings(self):
-        """_make_cave_client should configure caveclient retries from settings."""
-        ds = _make_dataset()
-        entity = SimpleNamespace(cave_datastack="stack", cave_client_url="http://cave")
-
-        with (
-            patch.object(EMDataSetFromID, "entity", return_value=entity),
-            patch(f"{_MODULE}.CAVEclient"),
-            patch(f"{_MODULE}.set_session_defaults") as mock_set_defaults,
-        ):
-            ds._make_cave_client(Mock(), cave_version=3)
+    def test_configure_caveclient_retries_from_settings(self):
+        """Retry session defaults should be sourced from settings.cave_client_config."""
+        with patch(f"{_MODULE}.set_session_defaults") as mock_set_defaults:
+            _configure_caveclient_retries()
 
         cfg = settings.cave_client_config
         mock_set_defaults.assert_called_once_with(
@@ -50,7 +46,6 @@ class TestRetryConfiguration:
         with (
             patch.object(EMDataSetFromID, "entity", return_value=entity),
             patch(f"{_MODULE}.CAVEclient") as mock_cave,
-            patch(f"{_MODULE}.set_session_defaults"),
         ):
             ds._make_cave_client(Mock(), cave_version=7)
 
@@ -63,41 +58,26 @@ class TestRetryConfiguration:
 
 
 class TestGracefulMaterializeErrors:
-    def test_get_versions_wraps_request_error(self):
-        """A transient request failure on get_versions surfaces as OBIONEError."""
+    @pytest.mark.parametrize(
+        ("method_name", "kwargs", "make_error"),
+        [
+            ("get_versions", {}, lambda: _http_error(503)),
+            ("get_tables", {"cave_version": 3}, lambda: _http_error(503)),
+            ("get_versions", {}, lambda: requests.exceptions.ConnectionError("boom")),
+        ],
+        ids=["get_versions-http-503", "get_tables-http-503", "get_versions-connection"],
+    )
+    def test_request_errors_wrapped_in_obi_error(self, method_name, kwargs, make_error):
+        """Transient request failures surface as a clean OBIONEError."""
         ds = _make_dataset()
         client = Mock()
-        client.materialize.get_versions.side_effect = _http_error(503)
+        getattr(client.materialize, method_name).side_effect = make_error()
 
         with (
             patch.object(EMDataSetFromID, "_make_cave_client", return_value=client),
             pytest.raises(OBIONEError, match="temporarily unavailable"),
         ):
-            ds.get_versions()
-
-    def test_get_tables_wraps_request_error(self):
-        """A transient request failure on get_tables surfaces as OBIONEError."""
-        ds = _make_dataset()
-        client = Mock()
-        client.materialize.get_tables.side_effect = _http_error(503)
-
-        with (
-            patch.object(EMDataSetFromID, "_make_cave_client", return_value=client),
-            pytest.raises(OBIONEError, match="temporarily unavailable"),
-        ):
-            ds.get_tables(cave_version=3)
-
-    def test_connection_error_is_wrapped(self):
-        """Non-HTTP request errors (e.g. connection errors) are also wrapped."""
-        ds = _make_dataset()
-        client = Mock()
-        client.materialize.get_versions.side_effect = requests.exceptions.ConnectionError("boom")
-
-        with (
-            patch.object(EMDataSetFromID, "_make_cave_client", return_value=client),
-            pytest.raises(OBIONEError),
-        ):
-            ds.get_versions()
+            getattr(ds, method_name)(**kwargs)
 
     def test_non_request_errors_propagate_unchanged(self):
         """Errors unrelated to the request layer must not be masked as OBIONEError."""

--- a/tests/obi_one/scientific/from_id/test_em_dataset_from_id.py
+++ b/tests/obi_one/scientific/from_id/test_em_dataset_from_id.py
@@ -1,0 +1,112 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from obi_one.config import settings
+from obi_one.core.exception import OBIONEError
+from obi_one.scientific.from_id.em_dataset_from_id import EMDataSetFromID
+
+_MODULE = "obi_one.scientific.from_id.em_dataset_from_id"
+
+
+def _make_dataset():
+    return EMDataSetFromID(id_str="dataset-1", auth_token="fake-token")  # noqa: S106
+
+
+def _http_error(status=503):
+    response = Mock()
+    response.status_code = status
+    return requests.HTTPError(f"{status} Server Error", response=response)
+
+
+class TestRetryConfiguration:
+    def test_make_cave_client_widens_retry_defaults_from_settings(self):
+        """_make_cave_client should configure caveclient retries from settings."""
+        ds = _make_dataset()
+        entity = SimpleNamespace(cave_datastack="stack", cave_client_url="http://cave")
+
+        with (
+            patch.object(EMDataSetFromID, "entity", return_value=entity),
+            patch(f"{_MODULE}.CAVEclient"),
+            patch(f"{_MODULE}.set_session_defaults") as mock_set_defaults,
+        ):
+            ds._make_cave_client(Mock(), cave_version=3)
+
+        cfg = settings.cave_client_config
+        mock_set_defaults.assert_called_once_with(
+            max_retries=cfg.max_retries,
+            backoff_factor=cfg.retry_backoff_factor,
+            backoff_max=cfg.retry_backoff_max,
+            status_forcelist=cfg.retry_status_forcelist,
+        )
+
+    def test_make_cave_client_passes_entity_metadata(self):
+        """The CAVEclient should be built from the entity's datastack/url + auth token."""
+        ds = _make_dataset()
+        entity = SimpleNamespace(cave_datastack="stack", cave_client_url="http://cave")
+
+        with (
+            patch.object(EMDataSetFromID, "entity", return_value=entity),
+            patch(f"{_MODULE}.CAVEclient") as mock_cave,
+            patch(f"{_MODULE}.set_session_defaults"),
+        ):
+            ds._make_cave_client(Mock(), cave_version=7)
+
+        mock_cave.assert_called_once_with(
+            "stack",
+            server_address="http://cave",
+            auth_token="fake-token",  # noqa: S106
+        )
+        assert mock_cave.return_value.version == 7
+
+
+class TestGracefulMaterializeErrors:
+    def test_get_versions_wraps_request_error(self):
+        """A transient request failure on get_versions surfaces as OBIONEError."""
+        ds = _make_dataset()
+        client = Mock()
+        client.materialize.get_versions.side_effect = _http_error(503)
+
+        with (
+            patch.object(EMDataSetFromID, "_make_cave_client", return_value=client),
+            pytest.raises(OBIONEError, match="temporarily unavailable"),
+        ):
+            ds.get_versions()
+
+    def test_get_tables_wraps_request_error(self):
+        """A transient request failure on get_tables surfaces as OBIONEError."""
+        ds = _make_dataset()
+        client = Mock()
+        client.materialize.get_tables.side_effect = _http_error(503)
+
+        with (
+            patch.object(EMDataSetFromID, "_make_cave_client", return_value=client),
+            pytest.raises(OBIONEError, match="temporarily unavailable"),
+        ):
+            ds.get_tables(cave_version=3)
+
+    def test_connection_error_is_wrapped(self):
+        """Non-HTTP request errors (e.g. connection errors) are also wrapped."""
+        ds = _make_dataset()
+        client = Mock()
+        client.materialize.get_versions.side_effect = requests.exceptions.ConnectionError("boom")
+
+        with (
+            patch.object(EMDataSetFromID, "_make_cave_client", return_value=client),
+            pytest.raises(OBIONEError),
+        ):
+            ds.get_versions()
+
+    def test_non_request_errors_propagate_unchanged(self):
+        """Errors unrelated to the request layer must not be masked as OBIONEError."""
+        ds = _make_dataset()
+        client = Mock()
+        client.materialize.get_versions.side_effect = ValueError("unrelated")
+
+        with (
+            patch.object(EMDataSetFromID, "_make_cave_client", return_value=client),
+            pytest.raises(ValueError, match="unrelated"),
+        ):
+            ds.get_versions()


### PR DESCRIPTION
## Context

Addresses openbraininstitute/prod-build-circuit#45 — the CAVEClient materialization engine intermittently returns **503** errors during the EM synapse mapping task (notably via `materialize.get_tables()` / `materialize.get_versions()`), failing the whole run with a raw `requests.HTTPError`.

caveclient already retries 502/503/504 at the HTTP-session layer, but with weak defaults (`max_retries=3`, `backoff_factor=0.1` → ~0.6 s of total backoff), which isn't enough to outlast a transient outage.

## Changes

- **Tune caveclient's built-in retry** (`obi_one/config.py`): new env-overridable knobs on `CaveClientConfig` — `max_retries=8`, `retry_backoff_factor=0.5`, `retry_backoff_max=120.0`, `retry_status_forcelist=(429, 502, 503, 504)`. With these, the backoff schedule is 0/1/2/4/8/16/32/64 s (~127 s total) before giving up.
- **Apply the config once** via `_configure_caveclient_retries()` at module import in `em_dataset_from_id.py`. Because every materialize call shares the client's HTTP session, this covers all of them (`synapse_query`, `query_table`, `get_table_metadata`, `get_tables`, `get_versions`, `viewer_resolution`).
- **Graceful failure**: a `_graceful_materialize_errors` decorator on the public materialize-backed methods converts an exhausted `requests` failure into a clean `OBIONEError` with an actionable message instead of a raw traceback. Non-request errors propagate unchanged.
- Tests for retry configuration and graceful-failure handling.

Client *initialization* is intentionally **not** wrapped — per discussion on the ticket, the materialization-engine calls are the issue.
