### PR TITLE
Fix morphometrics measurement kind typing

### DIFF
--- a/app/endpoints/morphology_metrics.py
+++ b/app/endpoints/morphology_metrics.py
@@ -7,7 +7,6 @@ from uuid import UUID
 import entitysdk.client
 import entitysdk.exception
 from entitysdk.models.cell_morphology import CellMorphology
-from entitysdk.models.measurement_annotation import MeasurementKind
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from app.dependencies.auth import user_verified
@@ -77,7 +76,7 @@ def neuron_morphology_metrics_endpoint(
 def _run_analysis_with_temp_file(
     content: bytes,
     suffix: Literal[".swc", ".h5", ".asc"],
-) -> list[MeasurementKind]:
+) -> list[dict[str, Any]]:
     with tempfile.NamedTemporaryFile(suffix=suffix) as tmp:
         tmp.write(content)
         tmp.flush()
@@ -88,7 +87,7 @@ def compute_measurement_kinds(
     cell_morphology_id: UUID,
     db_client: entitysdk.client.Client,
     morphology_format: str = "h5",
-) -> list[MeasurementKind]:
+) -> list[dict[str, Any]]:
     morphology = db_client.get_entity(
         entity_id=cell_morphology_id,
         entity_type=CellMorphology,

--- a/app/endpoints/morphology_metrics_calculation.py
+++ b/app/endpoints/morphology_metrics_calculation.py
@@ -20,7 +20,6 @@ from entitysdk.models import (
     Subject,
 )
 from entitysdk.models.core import Identifiable
-from entitysdk.models.measurement_annotation import MeasurementKind
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel
@@ -103,7 +102,7 @@ def _validate_file_extension(filename: str | None) -> str:
     return file_extension
 
 
-def run_morphology_analysis(morphology_path: str) -> list[MeasurementKind]:
+def run_morphology_analysis(morphology_path: str) -> list[dict[str, Any]]:
     try:
         return compute_morphometrics(morphology_path)
     except Exception as e:

--- a/obi_one/scientific/library/morphology_measurement_annotation.py
+++ b/obi_one/scientific/library/morphology_measurement_annotation.py
@@ -6,11 +6,10 @@ import logging
 from collections import defaultdict
 from functools import cache
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 import neurom as nm
 import numpy as np
-from entitysdk.models.measurement_annotation import MeasurementKind
 from neurom.core import Morphology
 
 L = logging.getLogger(__name__)
@@ -369,13 +368,13 @@ def _filter_valid_measurement_kinds(
     return valid_measurement_kinds
 
 
-def compute_morphometrics(morphology_path: str | Path) -> list[MeasurementKind]:
+def compute_morphometrics(morphology_path: str | Path) -> list[dict[str, Any]]:
     """Compute morphometric measurements for a morphology file."""
     neuron = nm.load_morphology(str(morphology_path))
     results_dict = build_results_dict(get_morphology_analysis_dict(), neuron)
     filled = fill_json(copy.deepcopy(get_morphology_template()), results_dict, entity_id="temp_id")
     measurement_kinds = filled["data"][0]["measurement_kinds"]
-    return cast("list[MeasurementKind]", _filter_valid_measurement_kinds(measurement_kinds))
+    return _filter_valid_measurement_kinds(measurement_kinds)
 
 
 def _has_neurite_type(neuron: Morphology, neurite_type: int) -> bool:

--- a/obi_one/scientific/library/morphology_registration.py
+++ b/obi_one/scientific/library/morphology_registration.py
@@ -3,6 +3,7 @@
 import logging
 import pathlib
 from pathlib import Path
+from typing import Any
 from uuid import UUID
 
 from entitysdk import Client
@@ -73,13 +74,16 @@ def upload_morphology_content(
 def register_morphometrics(
     client: Client,
     entity_id: UUID,
-    measurement_kinds: list[MeasurementKind],
+    measurement_kinds: list[dict[str, Any]],
 ) -> MeasurementAnnotation:
     """Register morphometric measurements for a CellMorphology entity."""
     measurement_annotation = MeasurementAnnotation(
         entity_id=entity_id,
         entity_type=MeasurableEntity.cell_morphology,
-        measurement_kinds=measurement_kinds,
+        measurement_kinds=[
+            MeasurementKind.model_validate(measurement_kind)
+            for measurement_kind in measurement_kinds
+        ],
     )
     return client.register_entity(entity=measurement_annotation)
 


### PR DESCRIPTION
This removes the incorrect cast from morphometrics output (https://github.com/openbraininstitute/obi-one/pull/870#discussion_r3497420921). The computation and preview paths now return the dict payload they actually produce and registration converts those payloads into MeasurementKind models before creating the annotation.