### PR TITLE
Skip overview image generation from template

### DIFF
--- a/obi_one/utils/circuit.py
+++ b/obi_one/utils/circuit.py
@@ -397,13 +397,12 @@ def get_circuit_properties(c: Circuit) -> tuple[bool, bool, bool, bool]:  # noqa
     return has_morphologies, has_point_neurons, has_electrical_cell_models, has_spines
 
 
-def generate_overview_figure(basic_plots_dir: Path | None, output_file: Path) -> Path:
+def generate_overview_figure(basic_plots_dir: Path | None, output_file: Path) -> Path | None:
     """Generate an overview figure of the circuit.
 
-    Uses the circular 2D network plot if available, otherwise falls back to a template.
+    Uses the circular 2D network plot if available. Returns None if no suitable
+    figure is found.
     """
-    from importlib.resources import files  # noqa: PLC0415
-
     from PIL import Image  # noqa: PLC0415
 
     from obi_one.core.exception import OBIONEError  # noqa: PLC0415
@@ -421,9 +420,10 @@ def generate_overview_figure(basic_plots_dir: Path | None, output_file: Path) ->
     else:
         fig_paths = None
 
-    # Use template figure from library if no circular plot available
+    # No figure available — skip without error
     if fig_paths is None:
-        fig_paths = Path(str(files("obi_one.scientific.library").joinpath("circuit_template.png")))
+        L.info("No overview figure available; skipping generation.")
+        return None
 
     # Check that output file does not exist yet
     if output_file.exists():

--- a/obi_one/utils/circuit_registration/generate.py
+++ b/obi_one/utils/circuit_registration/generate.py
@@ -136,6 +136,10 @@ def generate_overview_image_asset(
             plot_dir, output_dir / f"{OVERVIEW_IMAGE_NAME}.png"
         )
 
+    if viz_path is None:
+        L.info("No overview image generated; skipping registration.")
+        return
+
     if client and circuit_entity:
         db_sdk.add_image_assets(
             client=client,
@@ -172,6 +176,17 @@ def generate_sim_designer_image_asset(
         viz_path = circuit_utils.generate_overview_figure(
             plot_dir, output_dir / f"{SIM_DESIGNER_IMAGE_NAME}.png"
         )
+
+        # Fall back to template if no figure was generated
+        if viz_path is None:
+            from importlib.resources import files  # noqa: PLC0415
+
+            template = Path(
+                str(files("obi_one.scientific.library").joinpath("circuit_template.png"))
+            )
+            output_dir.mkdir(parents=True, exist_ok=True)
+            viz_path = output_dir / f"{SIM_DESIGNER_IMAGE_NAME}.png"
+            shutil.copy(template, viz_path)
 
     if client and circuit_entity:
         db_sdk.add_image_assets(

--- a/tests/obi_one/utils/test_circuit.py
+++ b/tests/obi_one/utils/test_circuit.py
@@ -231,28 +231,26 @@ def test_run_validation_invalid_circuit():
         run_validation(circuit_path)
 
 
-def test_generate_overview_figure_fallback_template(tmp_path):
-    """Test that template is used when no plots directory is provided."""
+def test_generate_overview_figure_skipped_when_no_plots_dir(tmp_path):
+    """Test that None is returned when no plots directory is provided (skip overview)."""
     output_file = tmp_path / "overview.png"
 
     result = generate_overview_figure(basic_plots_dir=None, output_file=output_file)
 
-    assert result == output_file
-    assert output_file.exists()
-    assert output_file.stat().st_size > 0
+    assert result is None
+    assert not output_file.exists()
 
 
-def test_generate_overview_figure_fallback_when_no_circular_plot(tmp_path):
-    """Test that template is used when plots dir exists but has no circular plot."""
+def test_generate_overview_figure_skipped_when_no_circular_plot(tmp_path):
+    """Test that None is returned when plots dir exists but has no circular plot."""
     plots_dir = tmp_path / "plots"
     plots_dir.mkdir()
     output_file = tmp_path / "overview.png"
 
     result = generate_overview_figure(basic_plots_dir=plots_dir, output_file=output_file)
 
-    assert result == output_file
-    assert output_file.exists()
-    assert output_file.stat().st_size > 0
+    assert result is None
+    assert not output_file.exists()
 
 
 def test_generate_overview_figure_with_circular_plot(tmp_path):
@@ -294,14 +292,19 @@ def test_generate_overview_figure_with_circular_and_table(tmp_path):
 
 
 def test_generate_overview_figure_raises_if_output_exists(tmp_path):
-    """Test that error is raised when output file already exists."""
-    # Create a dummy output image
-    output_file = tmp_path / "overview.png"
+    """Test that error is raised when output file already exists and a figure is available."""
+    plots_dir = tmp_path / "plots"
+    plots_dir.mkdir()
+    # Create a circular plot so the function proceeds past the early return
     img = Image.new("RGB", (123, 123), color="blue")
+    img.save(plots_dir / "small_network_in_2D_circular.png")
+
+    # Create a dummy output image that already exists
+    output_file = tmp_path / "overview.png"
     img.save(output_file)
 
     with pytest.raises(OBIONEError, match="already exists"):
-        generate_overview_figure(basic_plots_dir=None, output_file=output_file)
+        generate_overview_figure(basic_plots_dir=plots_dir, output_file=output_file)
 
 
 def test_get_circuit_properties_small_circuit():

--- a/tests/obi_one/utils/test_circuit.py
+++ b/tests/obi_one/utils/test_circuit.py
@@ -307,6 +307,21 @@ def test_generate_overview_figure_raises_if_output_exists(tmp_path):
         generate_overview_figure(basic_plots_dir=plots_dir, output_file=output_file)
 
 
+def test_generate_overview_figure_raises_on_extension_mismatch(tmp_path):
+    """Test that error is raised when output extension doesn't match figure extension."""
+    plots_dir = tmp_path / "plots"
+    plots_dir.mkdir()
+    # Create a circular plot (png)
+    img = Image.new("RGB", (123, 123), color="blue")
+    img.save(plots_dir / "small_network_in_2D_circular.png")
+
+    # Request a .jpg output — mismatch with .png source
+    output_file = tmp_path / "overview.jpg"
+
+    with pytest.raises(OBIONEError, match="does not match"):
+        generate_overview_figure(basic_plots_dir=plots_dir, output_file=output_file)
+
+
 def test_get_circuit_properties_small_circuit():
     """Test properties for a small biophysical circuit with morphologies and e-models."""
     circuit_path = str(CIRCUIT_DIR / "N_10__top_nodes_dim6" / "circuit_config.json")

--- a/tests/obi_one/utils/test_circuit_registration.py
+++ b/tests/obi_one/utils/test_circuit_registration.py
@@ -1401,6 +1401,55 @@ def test_generate_overview_image_asset_no_registration_without_client(tmp_path):
     assert (output_dir / "circuit_visualization.png").exists()
 
 
+def test_generate_overview_image_asset_skipped_when_no_figure_available(tmp_path):
+    """Test that overview image generation is skipped when no figure is available."""
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    client = MagicMock()
+    circuit_entity = MagicMock()
+
+    with patch("obi_one.utils.db_sdk.add_image_assets") as mock_add:
+        generate_overview_image_asset(
+            plot_dir=None,
+            output_dir=output_dir,
+            image_path=None,
+            client=client,
+            circuit_entity=circuit_entity,
+        )
+
+    # No image should be registered or created
+    mock_add.assert_not_called()
+    assert not (output_dir / "circuit_visualization.png").exists()
+
+
+def test_generate_sim_designer_image_asset_falls_back_to_template(tmp_path):
+    """Test that sim designer image falls back to template when no figure is available."""
+    output_dir = tmp_path / "output"
+
+    client = MagicMock()
+    circuit_entity = MagicMock()
+
+    with patch("obi_one.utils.db_sdk.add_image_assets") as mock_add:
+        generate_sim_designer_image_asset(
+            plot_dir=None,
+            output_dir=output_dir,
+            image_path=None,
+            client=client,
+            circuit_entity=circuit_entity,
+        )
+
+    # Template should be copied as the sim designer image
+    assert (output_dir / "simulation_designer_image.png").exists()
+    assert (output_dir / "simulation_designer_image.png").stat().st_size > 0
+    mock_add.assert_called_once_with(
+        client=client,
+        plot_dir=output_dir,
+        plot_files=["simulation_designer_image.png"],
+        registered_circuit=circuit_entity,
+    )
+
+
 # --- authorized_public + license check ---
 
 


### PR DESCRIPTION
After https://github.com/openbraininstitute/prod-explore-functionality/issues/516, there is no need any more to register the circuit overview image from a placeholder template if not provided by the user. This PR skips the image registration from the template.

Note: The sim designer image is still generated from a template.