### PR TITLE
Default edge popul fix

### DIFF
--- a/obi_one/scientific/library/circuit.py
+++ b/obi_one/scientific/library/circuit.py
@@ -144,7 +144,7 @@ class Circuit(OBIBaseModel):
         return popul_names
 
     @staticmethod
-    def _default_edge_population_name(c: snap.Circuit) -> str:
+    def _default_edge_population_name(c: snap.Circuit) -> str | None:
         """Returns the default edge population name of a SONATA circuit c."""
         try:
             default_npop = Circuit._default_population_name(c)
@@ -161,18 +161,19 @@ class Circuit(OBIBaseModel):
             and c.edges[epop].target.name == default_npop
         ]
         if len(intrinsic_epops) == 0:
-            return None  # ty:ignore[invalid-return-type]
+            return None
         if len(intrinsic_epops) > 1:
             # Try to infer from population name
-            intrinsic_epops = [pop for pop in intrinsic_epops if pop.startswith(f"{default_npop}__{default_npop}")]
+            intrinsic_epops = [
+                pop for pop in intrinsic_epops if pop.startswith(f"{default_npop}__{default_npop}")
+            ]
         if len(intrinsic_epops) == 1:
             return intrinsic_epops[0]
-        else:
-            msg = "Default edge population unknown!"
-            raise ValueError(msg)
+        msg = "Default edge population unknown!"
+        raise ValueError(msg)
 
     @property
-    def default_edge_population_name(self) -> str:
+    def default_edge_population_name(self) -> str | None:
         """Returns the default edge population name."""
         return self._default_edge_population_name(self.sonata_circuit)
 

--- a/obi_one/scientific/library/circuit.py
+++ b/obi_one/scientific/library/circuit.py
@@ -163,9 +163,13 @@ class Circuit(OBIBaseModel):
         if len(intrinsic_epops) == 0:
             return None  # ty:ignore[invalid-return-type]
         if len(intrinsic_epops) > 1:
+            # Try to infer from population name
+            intrinsic_epops = [pop for pop in intrinsic_epops if pop.startswith(f"{default_npop}__{default_npop}")]
+        if len(intrinsic_epops) == 1:
+            return intrinsic_epops[0]
+        else:
             msg = "Default edge population unknown!"
             raise ValueError(msg)
-        return intrinsic_epops[0]
 
     @property
     def default_edge_population_name(self) -> str:

--- a/obi_one/scientific/library/simulation/brian2/simulate_brian2.py
+++ b/obi_one/scientific/library/simulation/brian2/simulate_brian2.py
@@ -12,8 +12,8 @@ from pathlib import Path
 
 import bluepysnap
 import bluepysnap.input
-import brian2  # ty:ignore[unresolved-import]
-import brian2.units  # ty:ignore[unresolved-import]
+import brian2
+import brian2.units
 import click
 import h5py
 import libsonata

--- a/obi_one/utils/circuit.py
+++ b/obi_one/utils/circuit.py
@@ -536,6 +536,9 @@ def run_connectivity_matrix_extraction(
     )
     if edge_population is None:
         edge_population = circuit.default_edge_population_name
+    if edge_population is None:
+        msg = "No edge population specified and circuit has no default edge population."
+        raise OBIONEError(msg)
 
     # Only request node properties that exist in the circuit's point or biophysical
     # node populations (excluding virtual ones), since not all circuits (e.g.

--- a/tests/obi_one/scientific/library/test_circuit.py
+++ b/tests/obi_one/scientific/library/test_circuit.py
@@ -219,6 +219,34 @@ def test_default_edge_population_name_cases(fake_snap_circuit, monkeypatch):
         fake_snap_circuit.Circuit._default_edge_population_name(c)
 
 
+def test_default_edge_population_name_infer_from_name(fake_snap_circuit, monkeypatch):
+    """When multiple intrinsic edge pops exist, infer from population naming convention."""
+    c = fake_snap_circuit.snap.Circuit("x")
+
+    # Set up two intrinsic edge populations where one follows the naming convention
+    c.edges._pops["bio__bio__chemical"] = _FakePopulation(
+        "edges",
+        source=_FakePopulation("biophysical", name="bio"),
+        target=_FakePopulation("biophysical", name="bio"),
+    )
+    c.edges._pops["other_intrinsic"] = _FakePopulation(
+        "edges",
+        source=_FakePopulation("biophysical", name="bio"),
+        target=_FakePopulation("biophysical", name="bio"),
+    )
+
+    def fake_get_edge_pop_names(_c, *, incl_virtual=True, incl_point=True):  # noqa: ARG001
+        return ["bio__bio__chemical", "other_intrinsic"]
+
+    monkeypatch.setattr(
+        fake_snap_circuit.Circuit,
+        "get_edge_population_names",
+        staticmethod(fake_get_edge_pop_names),
+    )
+    # Should infer "bio__bio__chemical" because it starts with "bio__bio"
+    assert fake_snap_circuit.Circuit._default_edge_population_name(c) == "bio__bio__chemical"
+
+
 def test_connectivity_matrix_none_raises(fake_snap_circuit, tmp_path):
     cfg = tmp_path / "circuit_config.json"
     cfg.write_text("{}")

--- a/uv.lock
+++ b/uv.lock
@@ -906,14 +906,14 @@ wheels = [
 
 [[package]]
 name = "entitysdk"
-version = "0.19.1"
+version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/7d/206c0182356d33ac87a14e5a3c1b4cbd532f761b342128f5f6a261005cf4/entitysdk-0.19.1.tar.gz", hash = "sha256:c54e97201f2ca4a675375384379a1c435e98b1c77ff1e27b6ba6b65e0ba911c5", size = 90822, upload-time = "2026-07-06T18:07:22.782Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/69/90527f90ab96b650bb88f185fa131788abe6079e44c9f4443234d6ccc46a/entitysdk-0.19.2.tar.gz", hash = "sha256:308dedc77531963ab66bd8a5ab8ad3accdce3c5db7d751c911c5acdb1122cfc7", size = 90827, upload-time = "2026-07-08T13:16:27.367Z" }
 
 [[package]]
 name = "executing"


### PR DESCRIPTION
Small fix for resolving the default edge population based on the population name. Required for circuits like nbS1 which has local and midrange connectivity.