### PR TITLE
Circuit extraction resource allocation update

### DIFF
--- a/app/endpoints/task.py
+++ b/app/endpoints/task.py
@@ -91,6 +91,7 @@ def task_launch_endpoint(
             db_client=db_client,
             task_definition=task_definition,
             compute_cell=compute_cell,
+            accounting_parameters=accounting_info.parameters,
         )
         task_definition = task_definition.model_copy(update={"resources": updated_resources})
 

--- a/app/schemas/task.py
+++ b/app/schemas/task.py
@@ -52,6 +52,7 @@ class MachineResources(Schema):
     compute_cell: str
     timelimit: str | None = None
     image_type: MachineExecutorImageType = MachineExecutorImageType.python_3_12_compiler
+    ephemeral_storage: int | None = None
 
 
 class ClusterResources(Schema):

--- a/app/services/resource_estimation/circuit_extraction.py
+++ b/app/services/resource_estimation/circuit_extraction.py
@@ -131,7 +131,7 @@ def estimate_task_resources(  # noqa: PLR0914
     )
     input_size_synapses = (sbio + svirt) if single_config.initialize.do_virtual else sbio  # ty:ignore[unresolved-attribute]
     output_fraction = (accounting_parameters.count / nbio) if accounting_parameters else 1.0
-    output_size_synapses = input_size_synapses * output_fraction # Rough scaling based on fraction of neurons, if available
+    output_size_synapses = input_size_synapses * output_fraction
     output_size_gb = 1 + output_size_synapses * 1.85e-7
     storage_gb = _get_required_extra_storage_space(output_size_gb)
 

--- a/app/services/resource_estimation/circuit_extraction.py
+++ b/app/services/resource_estimation/circuit_extraction.py
@@ -6,6 +6,7 @@ from entitysdk import models
 
 from app.schemas.accounting import AccountingParameters
 from app.schemas.task import Resources, TaskDefinition, TaskLaunchSubmit
+from app.types import MachineExecutorImageType
 from obi_one import deserialize_obi_object_from_json_data
 from obi_one.core.registry import task_registry
 from obi_one.scientific.library.circuit_metrics import (
@@ -142,7 +143,7 @@ def estimate_task_resources(  # noqa: PLR0914
             "memory": mem_gb,
             "timelimit": f"{time_h:02d}:00",
             "compute_cell": compute_cell,
-            "image_type": "python_3_12_compiler",
+            "image_type": MachineExecutorImageType.python_3_12_compiler,
             "ephemeral_storage": storage_gb,
         }
     )

--- a/app/services/resource_estimation/circuit_extraction.py
+++ b/app/services/resource_estimation/circuit_extraction.py
@@ -4,6 +4,7 @@ import entitysdk
 import numpy as np
 from entitysdk import models
 
+from app.schemas.accounting import AccountingParameters
 from app.schemas.task import Resources, TaskDefinition, TaskLaunchSubmit
 from obi_one import deserialize_obi_object_from_json_data
 from obi_one.core.registry import task_registry
@@ -38,18 +39,25 @@ def _get_required_cpu_memory_combo(mem_gb_required: float) -> tuple[int, int]:
     raise ValueError(msg)
 
 
-def _check_available_disk_space(disk_space_gb_required: float) -> None:
-    """Checks if the required disk space is available."""
+def _get_required_extra_storage_space(disk_space_gb_required: float) -> int | None:
+    """Return the required extra storage space."""
     # From launch-system
-    disk_space_limit_gb = 20
+    default_disk_space_limit_gb = 20
+    extra_disk_space_limit_gb = 200
 
-    if disk_space_gb_required > disk_space_limit_gb:
-        msg = (
-            f"Not enough disk space"
-            f" (required: {disk_space_gb_required:.1f} GB,"
-            f" available: {disk_space_limit_gb:.1f} GB)!"
-        )
-        raise ValueError(msg)
+    if disk_space_gb_required <= default_disk_space_limit_gb:
+        # No extra space requires, use default
+        return None
+    if disk_space_gb_required <= extra_disk_space_limit_gb:
+        # Allocate extra space
+        return np.ceil(disk_space_gb_required).astype(int)
+
+    msg = (
+        f"Not enough disk space"
+        f" (required: {disk_space_gb_required:.1f} GB,"
+        f" available: {extra_disk_space_limit_gb:.1f} GB)!"
+    )
+    raise ValueError(msg)
 
 
 def estimate_task_resources(  # noqa: PLR0914
@@ -57,6 +65,7 @@ def estimate_task_resources(  # noqa: PLR0914
     db_client: entitysdk.Client,
     task_definition: TaskDefinition,
     compute_cell: str,
+    accounting_parameters: AccountingParameters | None = None,
 ) -> Resources:
     """Estimate machine resources for a circuit extraction task."""
     # Get extraction config
@@ -105,7 +114,7 @@ def estimate_task_resources(  # noqa: PLR0914
     # Estimate time limit based on the number input neurons
     time_h = np.ceil(input_size_neurons * 5e-6).astype(int)
 
-    # Estimate disk space based in the number of input synapses
+    # Estimate storage space based on the number of output synapses
     sbio = np.sum(
         [
             epop.number_of_edges  # ty:ignore[unresolved-attribute]
@@ -121,9 +130,10 @@ def estimate_task_resources(  # noqa: PLR0914
         ]
     )
     input_size_synapses = (sbio + svirt) if single_config.initialize.do_virtual else sbio  # ty:ignore[unresolved-attribute]
-    output_size_synapses = input_size_synapses  # Using maximum output count
+    output_fraction = (accounting_parameters.count / nbio) if accounting_parameters else 1.0
+    output_size_synapses = input_size_synapses * output_fraction # Rough scaling based on fraction of neurons, if available
     output_size_gb = 1 + output_size_synapses * 1.85e-7
-    _check_available_disk_space(output_size_gb)
+    storage_gb = _get_required_extra_storage_space(output_size_gb)
 
     # Update resources
     return task_definition.resources.model_copy(
@@ -132,5 +142,7 @@ def estimate_task_resources(  # noqa: PLR0914
             "memory": mem_gb,
             "timelimit": f"{time_h:02d}:00",
             "compute_cell": compute_cell,
+            "image_type": "python_3_12_compiler",
+            "ephemeral_storage": storage_gb,
         }
     )

--- a/app/services/task.py
+++ b/app/services/task.py
@@ -20,6 +20,7 @@ import app.services.resource_estimation.circuit_simulation
 from app.config import settings
 from app.errors import ApiError, ApiErrorCode
 from app.logger import L
+from app.schemas.accounting import AccountingParameters
 from app.schemas.callback import CallBack, HttpRequestCallBackConfig
 from app.schemas.task import (
     Resources,
@@ -321,6 +322,7 @@ def estimate_task_resources(
     db_client: entitysdk.Client,
     task_definition: TaskDefinition,
     compute_cell: str,
+    accounting_parameters: AccountingParameters | None = None,
 ) -> Resources:
     """Estimates the machine resources for a given task."""
     match task_definition.task_type:
@@ -330,6 +332,7 @@ def estimate_task_resources(
                 db_client=db_client,
                 task_definition=task_definition,
                 compute_cell=compute_cell,
+                accounting_parameters=accounting_parameters,
             )
         case TaskType.circuit_simulation_neurodamus_cluster:
             return app.services.resource_estimation.circuit_simulation.estimate_task_resources(

--- a/obi_one/scientific/tasks/circuit_extraction/estimate.py
+++ b/obi_one/scientific/tasks/circuit_extraction/estimate.py
@@ -47,7 +47,7 @@ def estimate_circuit_extraction_count(*, db_client: Client, config_id: UUID) -> 
             )
             neuron_ids = single_config.neuron_set.get_neuron_ids(circuit=staged_circuit)
     else:
-        neuron_ids = single_config.neuron_set.get_neuron_ids(circuit=parent_circuit)
+        neuron_ids = single_config.neuron_set.get_neuron_ids(circuit=parent_circuit)  # ty:ignore[invalid-argument-type]
 
     neuron_count = sum(len(v) for v in neuron_ids.values())
     if neuron_count == 0:

--- a/obi_one/scientific/tasks/circuit_extraction/estimate.py
+++ b/obi_one/scientific/tasks/circuit_extraction/estimate.py
@@ -45,12 +45,9 @@ def estimate_circuit_extraction_count(*, db_client: Client, config_id: UUID) -> 
                 dest_dir=Path(temp_dir) / "sonata_circuit",
                 entity_cache=False,
             )
-            neuron_ids = single_config.neuron_set.get_neuron_ids(circuit=staged_circuit)[
-                staged_circuit.default_population_name
-            ]
-            return max(1, len(neuron_ids))
+            neuron_ids = single_config.neuron_set.get_neuron_ids(circuit=staged_circuit)
+    else:
+        neuron_ids = single_config.neuron_set.get_neuron_ids(circuit=parent_circuit)
 
-    neuron_ids = single_config.neuron_set.get_neuron_ids(circuit=parent_circuit)[  # ty:ignore[invalid-argument-type]
-        parent_circuit.default_population_name  # ty:ignore[unresolved-attribute]
-    ]
-    return max(1, len(neuron_ids))
+    neuron_count = sum(len(v) for v in neuron_ids.values())
+    return neuron_count

--- a/obi_one/scientific/tasks/circuit_extraction/estimate.py
+++ b/obi_one/scientific/tasks/circuit_extraction/estimate.py
@@ -50,4 +50,7 @@ def estimate_circuit_extraction_count(*, db_client: Client, config_id: UUID) -> 
         neuron_ids = single_config.neuron_set.get_neuron_ids(circuit=parent_circuit)
 
     neuron_count = sum(len(v) for v in neuron_ids.values())
+    if neuron_count == 0:
+        msg = "Circuit extraction neuron set resolved to 0 neurons."
+        raise ValueError(msg)
     return neuron_count

--- a/tests/app/services/test_circuit_extraction.py
+++ b/tests/app/services/test_circuit_extraction.py
@@ -4,8 +4,10 @@ from uuid import uuid4
 
 import entitysdk
 import pytest
+from obp_accounting_sdk.constants import ServiceSubtype
 
 from app.mappings import TASK_DEFINITIONS
+from app.schemas.accounting import AccountingParameters
 from app.schemas.task import TaskLaunchSubmit, TaskType
 from app.services.resource_estimation import circuit_extraction as test_module
 from obi_one.scientific.library.circuit_metrics import (
@@ -43,13 +45,20 @@ def test_get_required_cpu_memory_combo_too_large():
         test_module._get_required_cpu_memory_combo(200)
 
 
-def test_check_available_disk_space_ok():
-    test_module._check_available_disk_space(10.0)
+def test_get_required_extra_storage_space_default():
+    # Under 20 GB -> no extra storage needed
+    assert test_module._get_required_extra_storage_space(10.0) is None
 
 
-def test_check_available_disk_space_too_large():
+def test_get_required_extra_storage_space_extra():
+    # Between 20 and 200 GB -> allocate extra storage (ceiling)
+    assert test_module._get_required_extra_storage_space(25.0) == 25
+    assert test_module._get_required_extra_storage_space(25.3) == 26
+
+
+def test_get_required_extra_storage_space_too_large():
     with pytest.raises(ValueError, match="Not enough disk space"):
-        test_module._check_available_disk_space(25.0)
+        test_module._get_required_extra_storage_space(250.0)
 
 
 def _make_circuit_metrics(nbio_nodes, nvirt_nodes, sbio_edges, svirt_edges):
@@ -115,7 +124,9 @@ def _make_circuit_metrics(nbio_nodes, nvirt_nodes, sbio_edges, svirt_edges):
     )
 
 
-def _run_estimate_task_resources(db_client, circuit_metrics, do_virtual):
+def _run_estimate_task_resources(
+    db_client, circuit_metrics, do_virtual, accounting_parameters=None
+):
     """Run estimate_task_resources for circuit_extraction with mocked dependencies."""
     task_definition = TASK_DEFINITIONS[TaskType.circuit_extraction]
     json_model = TaskLaunchSubmit(task_type=TaskType.circuit_extraction, config_id=uuid4())
@@ -148,6 +159,7 @@ def _run_estimate_task_resources(db_client, circuit_metrics, do_virtual):
             db_client=db_client,
             task_definition=task_definition,
             compute_cell="cell_b",
+            accounting_parameters=accounting_parameters,
         )
 
 
@@ -204,12 +216,12 @@ def test_estimate_task_resources_allocation(
 @pytest.mark.parametrize(
     ("sbio", "svirt", "do_virtual"),
     [
-        # do_virtual=True: total = 60M + 50M = 110M synapses
-        #   disk = 1 + 110e6 * 1.85e-7 = 21.35 GB > 20 GB limit
-        (60_000_000, 50_000_000, True),
-        # do_virtual=False: only bio = 110M synapses
-        #   disk = 1 + 110e6 * 1.85e-7 = 21.35 GB > 20 GB limit
-        (110_000_000, 50_000_000, False),
+        # do_virtual=True: total = 600M + 500M = 1100M synapses
+        #   disk = 1 + 1100e6 * 1.85e-7 = 204.5 GB > 200 GB limit
+        (600_000_000, 500_000_000, True),
+        # do_virtual=False: only bio = 1100M synapses
+        #   disk = 1 + 1100e6 * 1.85e-7 = 204.5 GB > 200 GB limit
+        (1_100_000_000, 500_000_000, False),
     ],
     ids=["too_many_synapses_with_virtual", "too_many_synapses_without_virtual"],
 )
@@ -232,3 +244,57 @@ def test_estimate_task_resources_disk_ok_without_virtual(db_client, sbio, svirt,
     metrics = _make_circuit_metrics(1000, 500, sbio, svirt)
     result = _run_estimate_task_resources(db_client, metrics, do_virtual)
     assert result.cores >= 1
+
+
+def test_estimate_task_resources_with_accounting_parameters_reduces_disk(db_client):
+    """When accounting_parameters.count < nbio, output_fraction scales down disk estimate."""
+    # nbio=100_000, sbio=500M synapses
+    # Without accounting_parameters: output_fraction=1.0
+    #   disk = 1 + 500e6 * 1.85e-7 = 93.5 GB -> extra storage = 94
+    # With count=10_000 (10% of nbio): output_fraction=0.1
+    #   disk = 1 + 500e6 * 0.1 * 1.85e-7 = 10.25 GB -> no extra storage (None)
+    metrics = _make_circuit_metrics(100_000, 0, 500_000_000, 0)
+
+    result_without = _run_estimate_task_resources(db_client, metrics, do_virtual=False)
+    assert result_without.ephemeral_storage == 94
+
+    accounting_params = AccountingParameters(
+        count=10_000,
+        service_subtype=ServiceSubtype.CIRCUIT_EXTRACTION,
+    )
+    result_with = _run_estimate_task_resources(
+        db_client, metrics, do_virtual=False, accounting_parameters=accounting_params
+    )
+    assert result_with.ephemeral_storage is None
+
+
+def test_estimate_task_resources_with_accounting_parameters_full_extraction(db_client):
+    """When accounting_parameters.count == nbio, output_fraction is 1.0 (same as None)."""
+    # nbio=100_000, sbio=500M synapses, count=100_000 -> fraction=1.0
+    #   disk = 1 + 500e6 * 1.85e-7 = 93.5 GB -> extra storage = 94
+    metrics = _make_circuit_metrics(100_000, 0, 500_000_000, 0)
+
+    accounting_params = AccountingParameters(
+        count=100_000,
+        service_subtype=ServiceSubtype.CIRCUIT_EXTRACTION,
+    )
+    result = _run_estimate_task_resources(
+        db_client, metrics, do_virtual=False, accounting_parameters=accounting_params
+    )
+    assert result.ephemeral_storage == 94
+
+
+def test_estimate_task_resources_with_accounting_parameters_disk_limit(db_client):
+    """Even with accounting_parameters, large extractions can exceed the disk limit."""
+    # nbio=100_000, sbio=2000M synapses, count=100_000 -> fraction=1.0
+    #   disk = 1 + 2000e6 * 1.85e-7 = 371 GB > 200 GB limit
+    metrics = _make_circuit_metrics(100_000, 0, 2_000_000_000, 0)
+
+    accounting_params = AccountingParameters(
+        count=100_000,
+        service_subtype=ServiceSubtype.CIRCUIT_EXTRACTION,
+    )
+    with pytest.raises(ValueError, match="Not enough disk space"):
+        _run_estimate_task_resources(
+            db_client, metrics, do_virtual=False, accounting_parameters=accounting_params
+        )

--- a/tests/app/services/test_task.py
+++ b/tests/app/services/test_task.py
@@ -702,6 +702,7 @@ def test_estimate_task_resources_circuit_extraction(db_client):
         db_client=db_client,
         task_definition=task_definition,
         compute_cell="cell_b",
+        accounting_parameters=None,
     )
 
 

--- a/tests/app/services/test_task.py
+++ b/tests/app/services/test_task.py
@@ -338,6 +338,7 @@ def test_inait_job_data(config_id, activity_id, callbacks):
             "compute_cell": "local",
             "timelimit": "02:00",
             "image_type": "python_3_12_inait",
+            "ephemeral_storage": None,
         },
         "inputs": [
             "sonata-simulation-task",
@@ -399,6 +400,7 @@ def test_brian2_job_data(config_id, activity_id, callbacks):
             "compute_cell": "local",
             "timelimit": "02:00",
             "image_type": "python_3_12_compiler",
+            "ephemeral_storage": None,
         },
         "inputs": [
             "sonata-simulation-task",
@@ -506,6 +508,7 @@ def test_generic_job_data(config_id, activity_id, callbacks):
             "timelimit": "00:10",
             "compute_cell": "local",
             "image_type": "python_3_12_compiler",
+            "ephemeral_storage": None,
         },
         "code": {
             "type": "python_repository",

--- a/tests/obi_one/scientific/tasks/test_circuit_extraction_estimate.py
+++ b/tests/obi_one/scientific/tasks/test_circuit_extraction_estimate.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from uuid import uuid4
 
 import entitysdk
+import pytest
 
 from obi_one.scientific.tasks.circuit_extraction.estimate import estimate_circuit_extraction_count
 
@@ -12,9 +13,9 @@ def test_estimate_circuit_extraction_count_from_neuron_set_size():
     db_client = entitysdk.Client(api_url="http://my-url", token_manager="token")  # noqa: S106
     config_id = uuid4()
     task_config = SimpleNamespace()
-    fake_circuit = SimpleNamespace(default_population_name="default_pop")
+    fake_circuit = SimpleNamespace()
     fake_neuron_set = SimpleNamespace(
-        get_neuron_ids=lambda **_kwargs: {"default_pop": [101, 202, 303]}
+        get_neuron_ids=lambda **_kwargs: {"pop_a": [101, 202], "pop_b": [303]}
     )
     fake_config = SimpleNamespace(
         initialize=SimpleNamespace(circuit=fake_circuit),
@@ -44,12 +45,12 @@ def test_estimate_circuit_extraction_count_from_neuron_set_size():
         assert estimate_circuit_extraction_count(db_client=db_client, config_id=config_id) == 3
 
 
-def test_estimate_circuit_extraction_count_has_minimum_one_for_empty_set():
+def test_estimate_circuit_extraction_count_raises_for_empty_set():
     db_client = entitysdk.Client(api_url="http://my-url", token_manager="token")  # noqa: S106
     config_id = uuid4()
     task_config = SimpleNamespace()
-    fake_circuit = SimpleNamespace(default_population_name="default_pop")
-    fake_neuron_set = SimpleNamespace(get_neuron_ids=lambda **_kwargs: {"default_pop": []})
+    fake_circuit = SimpleNamespace()
+    fake_neuron_set = SimpleNamespace(get_neuron_ids=lambda **_kwargs: {})
     fake_config = SimpleNamespace(
         initialize=SimpleNamespace(circuit=fake_circuit),
         neuron_set=fake_neuron_set,
@@ -74,15 +75,16 @@ def test_estimate_circuit_extraction_count_has_minimum_one_for_empty_set():
             "obi_one.scientific.tasks.circuit_extraction.estimate.CircuitExtractionSingleConfig.model_validate",
             return_value=fake_config,
         ),
+        pytest.raises(ValueError, match="resolved to 0 neurons"),
     ):
-        assert estimate_circuit_extraction_count(db_client=db_client, config_id=config_id) == 1
+        estimate_circuit_extraction_count(db_client=db_client, config_id=config_id)
 
 
 def test_estimate_circuit_extraction_count_with_circuit_from_id_staging():
     db_client = entitysdk.Client(api_url="http://my-url", token_manager="token")  # noqa: S106
     config_id = uuid4()
     task_config = SimpleNamespace()
-    staged_circuit = SimpleNamespace(default_population_name="default_pop")
+    staged_circuit = SimpleNamespace()
     fake_deserialized = SimpleNamespace(
         model_dump=lambda: {"type": "CircuitExtractionSingleConfig"}
     )
@@ -93,7 +95,7 @@ def test_estimate_circuit_extraction_count_with_circuit_from_id_staging():
 
     fake_circuit_from_id = FakeCircuitFromID()
     fake_neuron_set = SimpleNamespace(
-        get_neuron_ids=lambda **_kwargs: {"default_pop": [1, 2]},
+        get_neuron_ids=lambda **_kwargs: {"pop_a": [1], "pop_b": [2]},
     )
     fake_config = SimpleNamespace(
         initialize=SimpleNamespace(circuit=fake_circuit_from_id),


### PR DESCRIPTION
Updates of resource allocation for circuit extraction:
- Estimation of disk space based in the number of output synapses
- Estimation of number of output synapses as fraction of extracted neurons
- Reusing number of extracted neurons from accounting parameters, if available
- Otherwise, fall back to maximum count, as before
- Updated count estimate in accounting parameters based on new neuron sets
- Requesting extra ephemeral storage space, if needed (21-200GB)
- Raising errors in case
  - 0 neurons extracted
  - estimated storage exceeds 200GB
- Added & updated tests

Related issues:
- https://github.com/openbraininstitute/prod-build-circuit/issues/28
- https://github.com/openbraininstitute/prod-build-circuit/issues/34