### PR TITLE
Include PredefinedNeuronSet in deprecated neuron sets so legacy configs open

### DIFF
--- a/obi_one/__init__.py
+++ b/obi_one/__init__.py
@@ -148,6 +148,7 @@ __all__ = [
     "MorphologyMetricsScanConfig",
     "MorphologyMetricsSingleConfig",
     "MorphologyMetricsTask",
+    "MultiPopulationPredefinedNeuronSet",
     "MultiPulseCurrentClampSomaticStimulus",
     "NamedPath",
     "NamedTuple",
@@ -322,6 +323,7 @@ from obi_one.scientific.blocks.neuron_sets.deprecated import (
     ExcitatoryNeurons,
     IDNeuronSet,
     InhibitoryNeurons,
+    PredefinedNeuronSet,
     nbS1POmInputs,
     nbS1VPMInputs,
     rCA1CA3Inputs,
@@ -338,8 +340,8 @@ from obi_one.scientific.blocks.neuron_sets.population import (
 )
 from obi_one.scientific.blocks.neuron_sets.predefined import (
     BiophysicalPopulationPredefinedNeuronSet,
+    MultiPopulationPredefinedNeuronSet,
     PointPopulationPredefinedNeuronSet,
-    PredefinedNeuronSet,
     VirtualPopulationPredefinedNeuronSet,
 )
 from obi_one.scientific.blocks.neuron_sets.property import (

--- a/obi_one/scientific/blocks/neuron_sets/deprecated.py
+++ b/obi_one/scientific/blocks/neuron_sets/deprecated.py
@@ -7,8 +7,10 @@ from obi_one.core.schema import SchemaKey, UIElement
 from obi_one.core.tuple import NamedTuple
 from obi_one.core.units import Units
 from obi_one.scientific.blocks.neuron_sets.base import NeuronSet, NeuronSetPopulationType
+from obi_one.scientific.blocks.neuron_sets.predefined import NodeSetType
 from obi_one.scientific.library.circuit import Circuit
 from obi_one.scientific.library.entity_property_types import (
+    CircuitMappedProperties,
     CircuitUsability,
     MappedPropertiesGroup,
 )
@@ -168,5 +170,37 @@ class IDNeuronSet(DeprecatedSampleNeuronSet):
         description="List of neuron IDs to include in the neuron set.",
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.NEURON_IDS,
+        },
+    )
+
+
+class PredefinedNeuronSet(DeprecatedSampleNeuronSet):
+    """A neuron set that uses an existing node set defined in the circuit's node sets file.
+
+    Superseded by the population-typed predefined neuron sets
+    (``BiophysicalPopulationPredefinedNeuronSet``, ``VirtualPopulationPredefinedNeuronSet``,
+    ``PointPopulationPredefinedNeuronSet``) and, for node sets spanning several populations,
+    by ``MultiPopulationPredefinedNeuronSet``.
+
+    Kept so that configs written before the population-typed taxonomy still deserialize -- it
+    is by far the most common neuron set in them -- and so that they remain openable and
+    editable. Like every ``DeprecatedNeuronSet`` it raises when resolved against a circuit, so
+    such a config still has to be migrated before it can be run.
+
+    It only names a node set, which may resolve in a population of any type, so it belongs to
+    the biophysical, point and virtual unions alike -- legacy configs use it in all three.
+    """
+
+    title: ClassVar[str] = "Predefined Neuron Set (Deprecated)"
+
+    _neuron_set_population_type: ClassVar[NeuronSetPopulationType] = NeuronSetPopulationType.ANY
+
+    node_set: NodeSetType = Field(
+        title="Node Set",
+        description="Name of the node set to use.",
+        json_schema_extra={
+            SchemaKey.UI_ELEMENT: UIElement.ENTITY_PROPERTY_DROPDOWN,
+            SchemaKey.PROPERTY_GROUP: MappedPropertiesGroup.CIRCUIT,
+            SchemaKey.PROPERTY: CircuitMappedProperties.NODE_SET,
         },
     )

--- a/obi_one/scientific/blocks/neuron_sets/predefined.py
+++ b/obi_one/scientific/blocks/neuron_sets/predefined.py
@@ -70,11 +70,15 @@ class PredefinedBaseNeuronSet(NeuronSet, abc.ABC):
         return node_populations
 
 
-class PredefinedNeuronSet(PredefinedBaseNeuronSet):
+class MultiPopulationPredefinedNeuronSet(PredefinedBaseNeuronSet):
     """Use an existing node set already defined in the circuit's node sets file.
 
     The node set may span multiple populations, as defined in the circuit's
     node set definition.
+
+    Note: the name ``PredefinedNeuronSet`` now belongs to the deprecated block of that name
+    (see ``neuron_sets.deprecated``), which is kept so that configs written before the
+    population-typed taxonomy still deserialize.
     """
 
     title: ClassVar[str] = (

--- a/obi_one/scientific/tasks/generate_simulations/task/task.py
+++ b/obi_one/scientific/tasks/generate_simulations/task/task.py
@@ -364,8 +364,8 @@ class GenerateSimulationTask(Task):
                         f"'{self.config.initialize.node_set.block_name}' is virtual. "
                         "Please use a non-virtual (biophysical or point) Neuron Set type. "
                         f"Available non-virtual populations: {non_virtual_list}. "
-                        f"You may be able to reference one through a "
-                        f"PredefinedNeuronSet block type. "
+                        f"You may be able to reference one through an "
+                        f"MultiPopulationPredefinedNeuronSet block type. "
                         "In future we will support population selection for any neuron set."
                     )
                     raise OBIONEError(msg)
@@ -387,7 +387,7 @@ class GenerateSimulationTask(Task):
         In the case where there is no neuron_sets dictionary in the config, the config's
         default_neuron_set_type is created and added to the SONATA circuit object.
         The neuron_sets dict key is always used as the name of the new node set, even for a
-        PredefinedNeuronSet, in which case a new node set is created which references the
+        predefined neuron set, in which case a new node set is created which references the
         existing one. This makes behaviour consistent whether random subsampling is used or not.
         It also means, however, that existing node_set names cannot be used as keys in neuron_sets.
         """

--- a/obi_one/scientific/unions/unions_neuron_sets.py
+++ b/obi_one/scientific/unions/unions_neuron_sets.py
@@ -10,6 +10,7 @@ from obi_one.scientific.blocks.neuron_sets.deprecated import (
     ExcitatoryNeurons,
     IDNeuronSet,
     InhibitoryNeurons,
+    PredefinedNeuronSet,
     nbS1POmInputs,
     nbS1VPMInputs,
     rCA1CA3Inputs,
@@ -39,11 +40,31 @@ from obi_one.scientific.blocks.neuron_sets.specific import (
     AllPointNeurons,
 )
 
-_DEPRECATED_BIOPHYSICAL_NEURON_SETS = (
-    AllNeurons | ExcitatoryNeurons | InhibitoryNeurons | IDNeuronSet
+# Deprecated neuron sets predate the population-typed taxonomy: back then a neuron set carried no
+# population type at all, so a config written before the rework uses any of them in either slot,
+# regardless of the type the class nominally declares now -- AllNeurons (nominally biophysical)
+# selects the virtual input population of an ME-model-with-synapses simulation, and
+# PredefinedNeuronSet merely names a node set, which may resolve in a population of either type.
+#
+# They are deliberately NOT offered for point populations: point-neuron support was introduced by
+# the same rework that deprecated them, so no pre-rework config can target a point population, and
+# these blocks have no meaning for one.
+#
+# This only affects which stored configs still load: being deprecated, every one of them raises as
+# soon as it is resolved against a circuit, so a config using one still has to be migrated before
+# it can be run.
+_DEPRECATED_NEURON_SETS = (
+    AllNeurons
+    | ExcitatoryNeurons
+    | InhibitoryNeurons
+    | IDNeuronSet
+    | PredefinedNeuronSet
+    | rCA1CA3Inputs
+    | nbS1POmInputs
+    | nbS1VPMInputs
 )
-_DEPRECATED_VIRTUAL_NEURON_SETS = rCA1CA3Inputs | nbS1POmInputs | nbS1VPMInputs
-_ALL_DEPRECATED_NEURON_SETS = _DEPRECATED_BIOPHYSICAL_NEURON_SETS | _DEPRECATED_VIRTUAL_NEURON_SETS
+
+_ALL_DEPRECATED_NEURON_SETS = _DEPRECATED_NEURON_SETS
 
 ATOMIC_BIOPHYSICAL_NEURON_SETS = (
     BiophysicalPopulationPropertyNeuronSet
@@ -51,14 +72,14 @@ ATOMIC_BIOPHYSICAL_NEURON_SETS = (
     | BiophysicalPopulationNeuronSet
     | AllBiophysicalNeurons
     | BiophysicalPopulationPredefinedNeuronSet
-    | _DEPRECATED_BIOPHYSICAL_NEURON_SETS
+    | _DEPRECATED_NEURON_SETS
 )
 ATOMIC_VIRTUAL_NEURON_SETS = (
     VirtualPopulationPropertyNeuronSet
     | VirtualPopulationIDNeuronSet
     | VirtualPopulationNeuronSet
     | VirtualPopulationPredefinedNeuronSet
-    | _DEPRECATED_VIRTUAL_NEURON_SETS
+    | _DEPRECATED_NEURON_SETS
 )
 ATOMIC_POINT_NEURON_SETS = (
     PointPopulationPropertyNeuronSet
@@ -177,8 +198,8 @@ ATOMIC_NON_VIRTUAL_NEURON_SETS_REFERENCE_UNION = (
 ATOMIC_BIOPHYSICAL_NEURON_SETS_REFERENCE_UNION = BiophysicalNeuronSetReference | NeuronSetReference
 ATOMIC_VIRTUAL_NEURON_SETS_REFERENCE_UNION = VirtualNeuronSetReference | NeuronSetReference
 # NeuronSetReference is intentionally excluded from the point union: it only references deprecated
-# biophysical/virtual neuron sets (never point sets), so it must not be offered for a point-only
-# reference field.
+# neuron sets, which are not offered for point populations (see above), so it must not be offered
+# for a point-only reference field.
 ATOMIC_POINT_NEURON_SETS_REFERENCE_UNION = PointNeuronSetReference
 
 """

--- a/tests/obi_one/scientific/blocks/neuron_sets/test_combined.py
+++ b/tests/obi_one/scientific/blocks/neuron_sets/test_combined.py
@@ -6,7 +6,7 @@ import pytest
 
 import obi_one as obi
 from obi_one.scientific.blocks.neuron_sets.combined import CombinedNeuronSet, SetOperation
-from obi_one.scientific.blocks.neuron_sets.predefined import PredefinedNeuronSet
+from obi_one.scientific.blocks.neuron_sets.predefined import MultiPopulationPredefinedNeuronSet
 from obi_one.scientific.unions.unions_neuron_sets import BiophysicalNeuronSetReference
 
 from tests.utils import CIRCUIT_DIR
@@ -26,7 +26,9 @@ def circuit():
     )
 
 
-def _resolved_ref(neuron_set: PredefinedNeuronSet, name: str) -> BiophysicalNeuronSetReference:
+def _resolved_ref(
+    neuron_set: MultiPopulationPredefinedNeuronSet, name: str
+) -> BiophysicalNeuronSetReference:
     """Return a resolved reference to a named neuron set.
 
     Mirrors what a Task/config wiring (``fill_block_references_and_names``) produces: the block
@@ -51,9 +53,14 @@ def _combined_neuron_set(
         combined_with: Sequence of (node_set_name, operation) applied in order.
         name: Block name assigned to the combined neuron set.
     """
-    base_ref = _resolved_ref(PredefinedNeuronSet(node_set=base_node_set), base_node_set)
+    base_ref = _resolved_ref(
+        MultiPopulationPredefinedNeuronSet(node_set=base_node_set), base_node_set
+    )
     combine_refs = [
-        (_resolved_ref(PredefinedNeuronSet(node_set=node_set), node_set), operation)
+        (
+            _resolved_ref(MultiPopulationPredefinedNeuronSet(node_set=node_set), node_set),
+            operation,
+        )
         for node_set, operation in combined_with
     ]
     neuron_set = CombinedNeuronSet(base_neuron_set=base_ref, combined_with=combine_refs)

--- a/tests/obi_one/scientific/blocks/neuron_sets/test_deprecated.py
+++ b/tests/obi_one/scientific/blocks/neuron_sets/test_deprecated.py
@@ -1,0 +1,112 @@
+"""Tests for the deprecated neuron sets.
+
+These blocks exist so that configs written before the population-typed neuron-set taxonomy still
+deserialize -- and so remain openable and editable in the UI -- while refusing to resolve against
+a circuit, which forces a migration before they can be run.
+"""
+
+import operator
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+import obi_one as obi
+from obi_one.scientific.blocks.neuron_sets.deprecated import PredefinedNeuronSet
+from obi_one.scientific.unions.unions_neuron_sets import (
+    AtomicBiophysicalNeuronSetUnion,
+    AtomicPointNeuronSetUnion,
+    AtomicVirtualNeuronSetUnion,
+)
+
+from tests.utils import CIRCUIT_DIR, MATRIX_DIR
+
+CIRCUIT_NAME = "N_10__top_nodes_dim6"
+
+# A neuron set exactly as stored by simulation configs written before the population-typed
+# taxonomy: no `population`, and the sampling fields that the current PredefinedNeuronSet
+# (now MultiPopulationPredefinedNeuronSet) no longer carries.
+LEGACY_PREDEFINED_NEURON_SET = {
+    "type": "PredefinedNeuronSet",
+    "node_set": "Layer6",
+    "sample_percentage": 100.0,
+    "sample_seed": 1,
+}
+
+
+@pytest.fixture
+def circuit():
+    return obi.Circuit(
+        name=CIRCUIT_NAME,
+        path=str(CIRCUIT_DIR / CIRCUIT_NAME / "circuit_config.json"),
+        matrix_path=str(MATRIX_DIR / CIRCUIT_NAME / "connectivity_matrix.h5"),
+    )
+
+
+def test_legacy_predefined_neuron_set_deserializes():
+    """A legacy PredefinedNeuronSet block still loads, fields and all."""
+    nset = PredefinedNeuronSet.model_validate(LEGACY_PREDEFINED_NEURON_SET)
+
+    assert nset.node_set == "Layer6"
+    assert nset.sample_percentage == pytest.approx(100.0)
+    assert nset.sample_seed == 1
+
+
+DEPRECATED_NEURON_SETS = [
+    LEGACY_PREDEFINED_NEURON_SET,
+    {"type": "AllNeurons", "sample_percentage": 100.0, "sample_seed": 1},
+    {"type": "ExcitatoryNeurons", "sample_percentage": 100.0, "sample_seed": 1},
+    {"type": "InhibitoryNeurons", "sample_percentage": 100.0, "sample_seed": 1},
+    {"type": "IDNeuronSet", "neuron_ids": {"name": "ids", "elements": [1, 2]}},
+    {"type": "nbS1VPMInputs", "sample_percentage": 100.0, "sample_seed": 1},
+    {"type": "nbS1POmInputs", "sample_percentage": 100.0, "sample_seed": 1},
+    {"type": "rCA1CA3Inputs", "sample_percentage": 100.0, "sample_seed": 1},
+]
+
+
+@pytest.mark.parametrize(
+    "union",
+    [AtomicBiophysicalNeuronSetUnion, AtomicVirtualNeuronSetUnion],
+    ids=["biophysical", "virtual"],
+)
+@pytest.mark.parametrize("block", DEPRECATED_NEURON_SETS, ids=operator.itemgetter("type"))
+def test_deprecated_neuron_sets_resolve_through_biophysical_and_virtual_unions(block, union):
+    """Every deprecated neuron set resolves through the biophysical and virtual unions.
+
+    That is what a stored config is validated by; without it, loading one fails with
+    `union_tag_invalid` and the UI has no schema definition to render the block with.
+
+    Both population types for every block, because the deprecated sets predate the
+    population-typed taxonomy -- a neuron set carried no population type then -- so configs
+    written before the rework use them in either slot, regardless of the type the class
+    nominally declares now. In the wild: AllNeurons (nominally biophysical) selecting the
+    virtual input population of an ME-model-with-synapses simulation.
+    """
+    nset = TypeAdapter(union).validate_python(block)
+
+    assert nset.type == block["type"]
+
+
+@pytest.mark.parametrize("block", DEPRECATED_NEURON_SETS, ids=operator.itemgetter("type"))
+def test_deprecated_neuron_sets_are_not_offered_for_point_populations(block):
+    """No deprecated neuron set is accepted for a point population.
+
+    Point-neuron support was introduced by the same rework that deprecated them, so no config
+    predating the rework can target a point population and these blocks have no meaning for one.
+    """
+    with pytest.raises(ValidationError):
+        TypeAdapter(AtomicPointNeuronSetUnion).validate_python(block)
+
+
+def test_legacy_predefined_neuron_set_is_in_the_schema():
+    """The block has a definition in the schema the frontend binds stored configs against."""
+    schema = obi.CircuitSimulationScanConfig.model_json_schema()
+
+    assert "PredefinedNeuronSet" in schema["$defs"]
+
+
+def test_legacy_predefined_neuron_set_cannot_be_resolved(circuit):
+    """Being deprecated, it refuses to resolve: the config must be migrated before it runs."""
+    nset = PredefinedNeuronSet.model_validate(LEGACY_PREDEFINED_NEURON_SET)
+
+    with pytest.raises(NotImplementedError, match="deprecated"):
+        nset.get_neuron_ids(circuit)

--- a/tests/obi_one/scientific/blocks/neuron_sets/test_predefined.py
+++ b/tests/obi_one/scientific/blocks/neuron_sets/test_predefined.py
@@ -6,7 +6,7 @@ import pytest
 import obi_one as obi
 from obi_one.scientific.blocks.neuron_sets.predefined import (
     BiophysicalPopulationPredefinedNeuronSet,
-    PredefinedNeuronSet,
+    MultiPopulationPredefinedNeuronSet,
     VirtualPopulationPredefinedNeuronSet,
 )
 
@@ -24,12 +24,12 @@ def circuit():
     )
 
 
-# --- PredefinedNeuronSet (multi-population) ---
+# --- MultiPopulationPredefinedNeuronSet (multi-population) ---
 
 
 def test_predefined_neuron_set_symbolic(circuit):
-    """Test PredefinedNeuronSet returns symbolic expression without force_resolve."""
-    nset = PredefinedNeuronSet(node_set="Layer6")
+    """Test MultiPopulationPredefinedNeuronSet gives a symbolic expression w/o force_resolve."""
+    nset = MultiPopulationPredefinedNeuronSet(node_set="Layer6")
     nset.set_block_name("predef_layer6")
 
     nset_def, combined = nset.get_node_set_definition(circuit)
@@ -38,8 +38,8 @@ def test_predefined_neuron_set_symbolic(circuit):
 
 
 def test_predefined_neuron_set_resolve_ids(circuit):
-    """Test PredefinedNeuronSet with force_resolve_ids."""
-    nset = PredefinedNeuronSet(node_set="Layer6")
+    """Test MultiPopulationPredefinedNeuronSet with force_resolve_ids."""
+    nset = MultiPopulationPredefinedNeuronSet(node_set="Layer6")
     nset.set_block_name("predef_layer6_resolved")
 
     nset_def, _ = nset.get_node_set_definition(circuit, force_resolve_ids=True)
@@ -50,8 +50,8 @@ def test_predefined_neuron_set_resolve_ids(circuit):
 
 
 def test_predefined_neuron_set_get_neuron_ids(circuit):
-    """Test PredefinedNeuronSet returns correct IDs."""
-    nset = PredefinedNeuronSet(node_set="Layer6")
+    """Test MultiPopulationPredefinedNeuronSet returns correct IDs."""
+    nset = MultiPopulationPredefinedNeuronSet(node_set="Layer6")
     nset.set_block_name("predef_ids")
 
     ids = nset.get_neuron_ids(circuit)
@@ -60,8 +60,8 @@ def test_predefined_neuron_set_get_neuron_ids(circuit):
 
 
 def test_predefined_neuron_set_get_populations(circuit):
-    """Test PredefinedNeuronSet returns populations the node set resolves in."""
-    nset = PredefinedNeuronSet(node_set="Layer6")
+    """Test MultiPopulationPredefinedNeuronSet returns populations the node set resolves in."""
+    nset = MultiPopulationPredefinedNeuronSet(node_set="Layer6")
     nset.set_block_name("predef_pops")
 
     pops = nset.get_populations(circuit)
@@ -70,7 +70,7 @@ def test_predefined_neuron_set_get_populations(circuit):
 
 def test_predefined_neuron_set_invalid_node_set(circuit):
     """Test that a non-existent node set raises."""
-    nset = PredefinedNeuronSet(node_set="NONEXISTENT")
+    nset = MultiPopulationPredefinedNeuronSet(node_set="NONEXISTENT")
     nset.set_block_name("predef_invalid")
 
     with pytest.raises(ValueError, match="not found in circuit"):


### PR DESCRIPTION
To support opening of old configs

- Adds `PredefinedNeuronSet` to `neuron_sets.deprecated` as a `DeprecatedSampleNeuronSet` + `node_set` — exactly the fields legacy configs store. It was the one old neuron set the population-typed rework never gave a backwards-compat shim, so configs using it can't be opened from the workflow table (no definition in the schema the frontend binds against; `union_tag_invalid` server-side).
- Renames the multi-population block that had taken over the name to `MultiPopulationPredefinedNeuronSet`, matching its `{Biophysical,Virtual,Point}PopulationPredefinedNeuronSet` siblings. It's in no union, so no stored config can name it and nothing needs migrating.
- Collapses the deprecated sets into one `_DEPRECATED_NEURON_SETS` group and accepts it in the **virtual** union as well as the biophysical one. They predate the taxonomy — a neuron set had no population type then — so pre-rework configs use them in either slot: `AllNeurons` (nominally biophysical) selects the virtual input population of an ME-model-with-synapses simulation.
- Keeps them **out of the point union** (and `NeuronSetReference` out of the point reference union): point-neuron support arrived with the same rework that deprecated them, so no pre-rework config can target a point population.
- Behaviour is unchanged for running: every deprecated neuron set still raises when resolved against a circuit. This only affects which stored configs load — they can now be opened and edited, then migrated.
- New `test_deprecated.py`, parametrized over all 8 deprecated neuron sets: each deserializes, resolves through the biophysical and virtual unions, has a schema definition, is rejected for a point population, and still refuses to resolve against a circuit.