### PR TITLE
Fix the default neuron set name checked by the Brian2 Poisson stimulus

### DIFF
--- a/obi_one/scientific/blocks/stimuli/brian2_poisson.py
+++ b/obi_one/scientific/blocks/stimuli/brian2_poisson.py
@@ -115,7 +115,7 @@ class Brian2DirectPoissonStimulus(Block):
         self._default_node_set = default_node_set
         _ = default_timestamps or SingleTimestamp(start_time=0.0)
 
-        if self.neuron_set.block_name != "Default: All Biophysical Neurons":  # ty:ignore[unresolved-attribute]
+        if self.neuron_set.block_name != "Default: Sugar gustatory receptor neurons":  # ty:ignore[unresolved-attribute]
             neuron_set = resolve_neuron_set_ref_to_neuron_set(
                 self.neuron_set,
                 self._default_node_set,  # ty:ignore[invalid-argument-type]
@@ -134,7 +134,7 @@ class Brian2DirectPoissonStimulus(Block):
 
     def _generate_config(self) -> dict:
 
-        if self.neuron_set.block_name == "Default: All Biophysical Neurons":  # ty:ignore[unresolved-attribute]
+        if self.neuron_set.block_name == "Default: Sugar gustatory receptor neurons":  # ty:ignore[unresolved-attribute]
             node_set = "sugar"
         else:
             node_set = resolve_neuron_set_ref_to_node_set(self.neuron_set, self._default_node_set)


### PR DESCRIPTION
- `Brian2DirectPoissonStimulus` compared its neuron set against `"Default: All Biophysical Neurons"`, but a Brian2 simulation's default neuron set is named `"Default: Sugar gustatory receptor neurons"` — so the branch never matched.
- A stimulus left without a target was therefore checked against, and driven into, every point neuron in the circuit, tripping the block's 100-neuron limit (the "default population is too large" error in the frontend).
- Comparing against the right name restores the previous behaviour: an untargeted stimulus drives the `sugar` node set.

An explicitly chosen neuron set is unaffected (still subject to the 100-neuron limit), and the simulation target (`initialize.node_set`) still resolves to all point neurons.