### PR TITLE
Separate Brian2 stimulus and simulation target default neuron sets

### DIFF
--- a/obi_one/scientific/blocks/stimuli/brian2_poisson.py
+++ b/obi_one/scientific/blocks/stimuli/brian2_poisson.py
@@ -25,7 +25,6 @@ from obi_one.scientific.library.circuit import Circuit
 from obi_one.scientific.library.constants import (
     DEFAULT_STIMULUS_LENGTH_MILLISECONDS,
     MAX_SIMULATION_LENGTH_MILLISECONDS,
-    MIN_NON_NEGATIVE_FLOAT_VALUE,
 )
 from obi_one.scientific.unions.unions_combined_neuron_sets import (
     POINT_NEURON_SETS_REFERENCE_TYPES,
@@ -56,8 +55,8 @@ class Brian2DirectPoissonStimulus(Block):
     )
 
     frequency: (
-        Annotated[NonNegativeFloat, Field(ge=MIN_NON_NEGATIVE_FLOAT_VALUE)]
-        | list[Annotated[NonNegativeFloat, Field(ge=MIN_NON_NEGATIVE_FLOAT_VALUE)]]
+        Annotated[NonNegativeFloat, Field(le=150.0)]
+        | list[Annotated[NonNegativeFloat, Field(le=150.0)]]
     ) = Field(
         default=150.0,
         title="Frequency",
@@ -115,29 +114,27 @@ class Brian2DirectPoissonStimulus(Block):
         self._default_node_set = default_node_set
         _ = default_timestamps or SingleTimestamp(start_time=0.0)
 
-        if self.neuron_set.block_name != "Default: All Biophysical Neurons":  # ty:ignore[unresolved-attribute]
-            neuron_set = resolve_neuron_set_ref_to_neuron_set(
-                self.neuron_set,
-                self._default_node_set,  # ty:ignore[invalid-argument-type]
+        # An untargeted stimulus has already been pointed at the `sugar` node set by the
+        # generation task (see Brian2SimulationScanConfig.default_stimulus_neuron_set_reference),
+        # which is small enough to stay under the limit; an explicit choice is checked here.
+        neuron_set = resolve_neuron_set_ref_to_neuron_set(
+            self.neuron_set,
+            self._default_node_set,  # ty:ignore[invalid-argument-type]
+        )
+        max_n_neurons = 100
+        neuron_ids = neuron_set.get_neuron_ids(circuit=circuit)  # ty:ignore[unresolved-attribute]
+        total_neurons = sum(len(ids) for ids in neuron_ids.values())
+        if total_neurons > max_n_neurons:
+            msg = (
+                f"Number of neurons used with the {self.title} exceeds the maximum "
+                f"allowed: {max_n_neurons}."
             )
-            max_n_neurons = 100
-            neuron_ids = neuron_set.get_neuron_ids(circuit=circuit)  # ty:ignore[unresolved-attribute]
-            total_neurons = sum(len(ids) for ids in neuron_ids.values())
-            if total_neurons > max_n_neurons:
-                msg = (
-                    f"Number of neurons used with the {self.title} exceeds the maximum "
-                    f"allowed: {max_n_neurons}."
-                )
-                raise ValueError(msg)
+            raise ValueError(msg)
 
         return self._generate_config()
 
     def _generate_config(self) -> dict:
-
-        if self.neuron_set.block_name == "Default: All Biophysical Neurons":  # ty:ignore[unresolved-attribute]
-            node_set = "sugar"
-        else:
-            node_set = resolve_neuron_set_ref_to_node_set(self.neuron_set, self._default_node_set)
+        node_set = resolve_neuron_set_ref_to_node_set(self.neuron_set, self._default_node_set)
 
         return {
             self.block_name: {

--- a/obi_one/scientific/tasks/generate_simulations/config/brian2/brian2_base.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/brian2/brian2_base.py
@@ -4,7 +4,10 @@ from typing import ClassVar
 from libsonata import SimulatorType
 from pydantic import PositiveFloat
 
+from obi_one.core.exception import OBIONEError
+from obi_one.scientific.blocks.neuron_sets.predefined import PointPopulationPredefinedNeuronSet
 from obi_one.scientific.blocks.neuron_sets.specific import AllPointNeurons
+from obi_one.scientific.library.circuit import Circuit
 from obi_one.scientific.library.constants import (
     SIMULATION_TIMESTEP_MILLISECONDS,
 )
@@ -22,21 +25,56 @@ class Brian2SimulationScanConfig(BaseSimulationScanConfig, abc.ABC):
     _target_simulator: ClassVar[SimulatorType] = SimulatorType.Brian2
     _timestep: ClassVar[PositiveFloat] = SIMULATION_TIMESTEP_MILLISECONDS
 
-    # discrepency between name and type here is a short term hack.
-    default_node_set_name: ClassVar[str] = "Default: Sugar gustatory receptor neurons"
+    # The simulation runs every point neuron by default, so its default neuron set is named for
+    # what it contains -- an untargeted simulation runs the whole circuit.
+    default_node_set_name: ClassVar[str] = "Default: All Point Neurons"
     default_neuron_set_type: ClassVar[type[AllPointNeurons]] = AllPointNeurons
+
+    # A stimulus left without a target instead drives the `sugar` node set -- the gustatory
+    # receptor neurons the Shiu et al. (2024) FlyWire model stimulates -- rather than the whole
+    # circuit. This is a separate, smaller default so the two never conflict.
+    default_stimulus_node_set_name: ClassVar[str] = "Default: Sugar gustatory receptor neurons"
+    default_stimulus_node_set: ClassVar[str] = "sugar"
 
     @property
     def default_neuron_set_reference(self) -> PointNeuronSetReference:
-        """Returns the default neuron set reference for the simulation."""
-        default_neuron_set_block_reference = PointNeuronSetReference(
+        """Returns the default neuron set reference for the simulation (all point neurons)."""
+        ref = PointNeuronSetReference(
             block_dict_name="neuron_sets", block_name=self.default_node_set_name
         )
+        ref.block = self.default_neuron_set_type()
+        ref.block.set_block_name(self.default_node_set_name)
+        return ref
 
-        default_neuron_set_block_reference.block = self.default_neuron_set_type()
-        default_neuron_set_block_reference.block.set_block_name(self.default_node_set_name)
+    def default_stimulus_neuron_set_reference(self, circuit: Circuit) -> PointNeuronSetReference:
+        """Returns the default neuron set reference for an untargeted stimulus (the `sugar` set).
 
-        return default_neuron_set_block_reference
+        It names an existing node set, so unlike the simulation default it has to resolve the
+        circuit's point population.
+        """
+        ref = PointNeuronSetReference(
+            block_dict_name="neuron_sets", block_name=self.default_stimulus_node_set_name
+        )
+        ref.block = PointPopulationPredefinedNeuronSet(
+            node_set=self.default_stimulus_node_set,
+            population=self._point_population(circuit),
+        )
+        ref.block.set_block_name(self.default_stimulus_node_set_name)
+        return ref
+
+    @staticmethod
+    def _point_population(circuit: Circuit) -> str:
+        """Return the circuit's single point node population."""
+        populations = Circuit.get_node_population_names(
+            circuit.sonata_circuit, incl_virtual=False, incl_biophysical=False
+        )
+        if len(populations) != 1:
+            msg = (
+                f"A Brian2 simulation needs exactly one point node population; "
+                f"circuit '{circuit.name}' has {len(populations)}: {populations}."
+            )
+            raise OBIONEError(msg)
+        return populations[0]
 
     class Initialize(BaseSimulationScanConfig.Initialize):
         pass

--- a/obi_one/scientific/tasks/generate_simulations/config/brian2/brian2_circuit.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/brian2/brian2_circuit.py
@@ -57,7 +57,12 @@ class Brian2CircuitSimulationScanConfig(Brian2SimulationScanConfig):
             BlockGroup.CIRCUIT_COMPONENTS_BLOCK_GROUP,
         ],
         SchemaKey.DEFAULT_BLOCK_REFERENCE_LABELS: {
-            PointNeuronSetReference.__name__: (Brian2SimulationScanConfig.default_node_set_name,),
+            # The simulation's own Neuron Set field is hidden (see Initialize.node_set), so the
+            # only visible PointNeuronSetReference is a stimulus target -- label it with the
+            # stimulus default (`sugar`), not the simulation default (all point neurons).
+            PointNeuronSetReference.__name__: (
+                Brian2SimulationScanConfig.default_stimulus_node_set_name,
+            ),
             TimestampsReference.__name__: DEFAULT_TIMESTAMPS_NAME,
         },
     }

--- a/obi_one/scientific/tasks/generate_simulations/task/task.py
+++ b/obi_one/scientific/tasks/generate_simulations/task/task.py
@@ -208,7 +208,13 @@ class GenerateSimulationTask(Task):
                 if is_optional_neuronsetreference(attr_type):
                     attr_value = getattr(block, attr_name, None)
                     if attr_value is None:
-                        setattr(block, attr_name, self._default_neuron_set_ref())
+                        # A Brian2 Poisson stimulus with no target drives the `sugar` node set,
+                        # not the simulation-wide default (every point neuron); see
+                        # Brian2SimulationScanConfig.
+                        if isinstance(block, Brian2DirectPoissonStimulus):
+                            setattr(block, attr_name, self._default_stimulus_neuron_set_ref())
+                        else:
+                            setattr(block, attr_name, self._default_neuron_set_ref())
 
     def _ensure_all_blocks_have_neuron_set_reference_if_neuron_sets_dictionary_exists(self) -> None:
         """Ensure all blocks have a NeuronSetReference if the neuron_sets dictionary exists."""
@@ -316,6 +322,17 @@ class GenerateSimulationTask(Task):
             )
 
         return default_neuron_set_ref
+
+    def _default_stimulus_neuron_set_ref(self) -> ALL_NEURON_SETS_REFERENCE_UNION:
+        """Returns the reference for the default stimulus neuron set (Brian2: the `sugar` set).
+
+        The circuit is already resolved: ``execute`` calls ``_resolve_circuit`` before it fills
+        in the missing neuron set references.
+        """
+        ref = self.config.default_stimulus_neuron_set_reference(self._circuit)  # ty:ignore[unresolved-attribute,invalid-argument-type]
+        if ref.block_name not in self.config.neuron_sets:  # ty:ignore[unresolved-attribute]
+            self.config.neuron_sets[ref.block_name] = ref.block  # ty:ignore[unresolved-attribute,invalid-assignment]
+        return ref
 
     """
     NEW NEURON SETS REFACTOR: SOME OF THIS CAN PROBABLY BE REMOVED NOW THE

--- a/tests/obi_one/scientific/library/simulation/data/create_data.py
+++ b/tests/obi_one/scientific/library/simulation/data/create_data.py
@@ -166,6 +166,8 @@ if __name__ == "__main__":
             {
                 "All": {"population": "drosophila"},
                 "0": {"population": "drosophila", "node_id": [0]},
+                # gustatory receptor neurons an untargeted Brian2 stimulus defaults to
+                "sugar": {"population": "drosophila", "node_id": [0, 1]},
             },
             fd,
         )

--- a/tests/obi_one/scientific/library/simulation/data/node_sets.json
+++ b/tests/obi_one/scientific/library/simulation/data/node_sets.json
@@ -1,1 +1,1 @@
-{"All": {"population": "drosophila"}, "0": {"population": "drosophila", "node_id": [0]}}
+{"All": {"population": "drosophila"}, "0": {"population": "drosophila", "node_id": [0]}, "sugar": {"population": "drosophila", "node_id": [0, 1]}}

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_brian2_default_neuron_sets.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_brian2_default_neuron_sets.py
@@ -1,0 +1,67 @@
+"""A Brian2 simulation defaults the simulation to all point neurons and a stimulus to `sugar`.
+
+An untargeted Brian2 Poisson stimulus drives the `sugar` gustatory receptor neurons, while the
+simulation itself runs every point neuron. The two are separate defaults; regressions here
+(e.g. the stimulus inheriting the simulation-wide default and tripping its 100-neuron limit, or
+the simulation target being mislabelled "Sugar…") are what this guards against.
+"""
+
+import json
+from pathlib import Path
+
+import obi_one as obi
+from obi_one.scientific.blocks.stimuli.brian2_poisson import Brian2DirectPoissonStimulus
+
+# The synthetic FlyWire-style point circuit: one `brian2_point` population `drosophila` (3
+# neurons), with a `sugar` node set covering neurons 0 and 1.
+CIRCUIT_CONFIG = (
+    Path(__file__).parents[2] / "library" / "simulation" / "data" / "circuit_config.json"
+)
+
+SIM_DEFAULT = "Default: All Point Neurons"
+STIMULUS_DEFAULT = "Default: Sugar gustatory receptor neurons"
+
+
+def _generate(tmp_path: Path) -> tuple[dict, dict]:
+    """Generate a Brian2 campaign with one untargeted stimulus; return (sim config, node sets)."""
+    sim_conf = obi.Brian2CircuitSimulationScanConfig.empty_config()
+    sim_conf.set(obi.Info(campaign_name="T", campaign_description="T"), name="info")
+
+    # No neuron_set and no initialize.node_set: both fall back to their defaults.
+    sim_conf.add(Brian2DirectPoissonStimulus(), name="DirectPoisson")
+    sim_conf.set(
+        obi.Brian2CircuitSimulationScanConfig.Initialize(
+            circuit=obi.Circuit(name="drosophila", path=str(CIRCUIT_CONFIG)),
+            simulation_length=100.0,
+        ),
+        name="initialize",
+    )
+
+    scan = obi.GridScanGenerationTask(
+        form=sim_conf.validated_config(),
+        output_root=tmp_path / "scan",
+        coordinate_directory_option="ZERO_INDEX",
+    )
+    scan.execute()
+    obi.run_tasks_for_generated_scan(scan)
+
+    out = tmp_path / "scan" / "0"
+    sim_config = json.loads((out / "simulation_config.json").read_text())
+    node_sets = json.loads((out / "node_sets.json").read_text())
+    return sim_config, node_sets
+
+
+def test_untargeted_brian2_stimulus_defaults_to_sugar_and_simulation_to_all_point(tmp_path):
+    sim_config, node_sets = _generate(tmp_path)
+
+    # The simulation targets all point neurons, named for what it is -- not "Sugar…".
+    assert sim_config["node_set"] == SIM_DEFAULT
+    assert node_sets[SIM_DEFAULT]["node_id"] == [0, 1, 2]
+
+    # The untargeted stimulus targets the sugar node set -- a strict subset, not the whole
+    # circuit -- so it stays under the block's 100-neuron limit rather than raising.
+    assert sim_config["inputs"]["DirectPoisson"]["node_set"] == STIMULUS_DEFAULT
+    assert node_sets[STIMULUS_DEFAULT]["node_id"] == [0, 1]
+
+    # The two defaults are genuinely different sets.
+    assert node_sets[SIM_DEFAULT]["node_id"] != node_sets[STIMULUS_DEFAULT]["node_id"]


### PR DESCRIPTION
- One default served both the simulation target and an untargeted stimulus — it named the simulation target "Default: Sugar gustatory receptor neurons" and drove the stimulus into every point neuron, tripping its 100-neuron limit.
- Split into two: the simulation defaults to all point neurons; an untargeted Brian2 Poisson stimulus defaults to the `sugar` node set. The UI still shows "Sugar…" on the stimulus; the block-name special-case is removed.
- Also caps the Poisson stimulus frequency at 150 Hz.
- Adds a generation regression test.