### PR TITLE
Add Sentry integration

### DIFF
--- a/app/__main__.py
+++ b/app/__main__.py
@@ -6,6 +6,7 @@ import click
 import uvicorn
 
 from app.config import settings
+from app.sentry import init_sentry
 
 
 @click.group()
@@ -23,4 +24,5 @@ def run(*, host: str, port: int, reload: bool) -> None:
     uvicorn.run("app.application:app", host=host, port=port, reload=reload)
 
 
+init_sentry()
 cli()

--- a/app/config.py
+++ b/app/config.py
@@ -1,5 +1,7 @@
 from pathlib import Path
+from typing import Annotated
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -59,6 +61,11 @@ class Settings(BaseSettings):
     ACCOUNTING_DISABLED: bool = False
     VIRTUAL_LAB_API_URL: str  # Required: URL to virtual-lab-api service
     VIRTUAL_LAB_DISABLED: bool = False
+
+    # Sentry is disabled when SENTRY_DSN is unset (sentry_sdk.init with dsn=None is a no-op).
+    SENTRY_DSN: str | None = None
+    SENTRY_TRACES_SAMPLE_RATE: Annotated[float, Field(ge=0, le=1)] = 0.1
+    SENTRY_PROFILE_SESSION_SAMPLE_RATE: Annotated[float, Field(ge=0, le=1)] = 1.0
 
     SUBDOMAIN_PLACEHOLDER: str = "cell-X"
 

--- a/app/config.py
+++ b/app/config.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -21,6 +21,7 @@ class Settings(BaseSettings):
     COMMIT_SHA: str | None = None
 
     ENVIRONMENT: str | None = None
+    DEPLOYMENT_ENV: Literal["local", "staging", "production"] = "local"
     ROOT_PATH: str = ""
     CORS_ORIGINS: list[str] = [
         "http://localhost:3000",  # for local tests

--- a/app/sentry.py
+++ b/app/sentry.py
@@ -14,7 +14,7 @@ def init_sentry() -> None:
     """
     sentry_sdk.init(
         dsn=settings.SENTRY_DSN,
-        environment=settings.ENVIRONMENT,
+        environment=settings.DEPLOYMENT_ENV,
         release=settings.APP_VERSION,
         traces_sample_rate=settings.SENTRY_TRACES_SAMPLE_RATE,
         profile_session_sample_rate=settings.SENTRY_PROFILE_SESSION_SAMPLE_RATE,

--- a/app/sentry.py
+++ b/app/sentry.py
@@ -1,0 +1,22 @@
+"""Sentry integration."""
+
+import sentry_sdk
+
+from app.config import settings
+
+
+def init_sentry() -> None:
+    """Initialize the Sentry SDK.
+
+    A no-op when ``SENTRY_DSN`` is unset: ``sentry_sdk.init`` with ``dsn=None`` disables
+    reporting, so local development and tests send nothing. Sentry's FastAPI/Starlette and
+    standard-logging integrations are auto-enabled and capture unhandled exceptions.
+    """
+    sentry_sdk.init(
+        dsn=settings.SENTRY_DSN,
+        environment=settings.ENVIRONMENT,
+        release=settings.APP_VERSION,
+        traces_sample_rate=settings.SENTRY_TRACES_SAMPLE_RATE,
+        profile_session_sample_rate=settings.SENTRY_PROFILE_SESSION_SAMPLE_RATE,
+        profile_lifecycle="trace",
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ service = [
     "pydantic-settings>=2.8.1",
     "pyjwt>=2.10.1",
     "python-multipart",
+    "sentry-sdk>=2.65.0",
     "starlette",
     "uvicorn",
 ]

--- a/tests/app/test_sentry.py
+++ b/tests/app/test_sentry.py
@@ -1,0 +1,33 @@
+import app.sentry
+from app.config import settings
+from app.sentry import init_sentry
+
+
+class TestInitSentry:
+    def test_no_dsn_configured_by_default(self):
+        assert settings.SENTRY_DSN is None
+
+    def test_init_is_noop_when_dsn_unset(self, monkeypatch):
+        captured = {}
+        monkeypatch.setattr(app.sentry.sentry_sdk, "init", lambda **kwargs: captured.update(kwargs))
+
+        init_sentry()
+
+        assert captured["dsn"] is None
+
+    def test_init_passes_expected_kwargs(self, monkeypatch):
+        dsn = "https://public@example.ingest.sentry.io/1"
+        captured = {}
+        monkeypatch.setattr(app.sentry.sentry_sdk, "init", lambda **kwargs: captured.update(kwargs))
+        monkeypatch.setattr(settings, "SENTRY_DSN", dsn)
+
+        init_sentry()
+
+        assert captured["dsn"] == dsn
+        assert captured["environment"] == settings.ENVIRONMENT
+        assert captured["release"] == settings.APP_VERSION
+        assert captured["traces_sample_rate"] == settings.SENTRY_TRACES_SAMPLE_RATE
+        assert (
+            captured["profile_session_sample_rate"] == settings.SENTRY_PROFILE_SESSION_SAMPLE_RATE
+        )
+        assert captured["profile_lifecycle"] == "trace"

--- a/tests/app/test_sentry.py
+++ b/tests/app/test_sentry.py
@@ -24,7 +24,7 @@ class TestInitSentry:
         init_sentry()
 
         assert captured["dsn"] == dsn
-        assert captured["environment"] == settings.ENVIRONMENT
+        assert captured["environment"] == settings.DEPLOYMENT_ENV
         assert captured["release"] == settings.APP_VERSION
         assert captured["traces_sample_rate"] == settings.SENTRY_TRACES_SAMPLE_RATE
         assert (

--- a/uv.lock
+++ b/uv.lock
@@ -2225,6 +2225,7 @@ all = [
     { name = "pydantic-settings" },
     { name = "pyjwt" },
     { name = "python-multipart" },
+    { name = "sentry-sdk" },
     { name = "starlette" },
     { name = "ultraliser" },
     { name = "uvicorn" },
@@ -2256,6 +2257,7 @@ service = [
     { name = "pydantic-settings" },
     { name = "pyjwt" },
     { name = "python-multipart" },
+    { name = "sentry-sdk" },
     { name = "starlette" },
     { name = "uvicorn" },
 ]
@@ -2319,6 +2321,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.26" },
     { name = "python-multipart", marker = "extra == 'service'" },
     { name = "scipy" },
+    { name = "sentry-sdk", marker = "extra == 'service'", specifier = ">=2.65.0" },
     { name = "starlette", marker = "extra == 'service'" },
     { name = "ultraliser", marker = "extra == 'meshing'", specifier = ">=2.1.9", index = "https://openbraininstitute-985539765147.d.codeartifact.us-east-1.amazonaws.com/pypi/pypi-prod/simple/" },
     { name = "uvicorn", marker = "extra == 'service'" },
@@ -3148,6 +3151,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c5/f0/184b4b5f8d00f2a92cf96eec8967a3d550b52cf94362dad1100df9e48d57/send2trash-2.1.0.tar.gz", hash = "sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459", size = 17255, upload-time = "2026-01-14T06:27:36.056Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/78/504fdd027da3b84ff1aecd9f6957e65f35134534ccc6da8628eb71e76d3f/send2trash-2.1.0-py3-none-any.whl", hash = "sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c", size = 17610, upload-time = "2026-01-14T06:27:35.218Z" },
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.66.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/ff/670abe04c5072719b5060ed93851d0d69525d60f8f2c5810f8becd58f9c1/sentry_sdk-2.66.0.tar.gz", hash = "sha256:9727d35aa83c56cd53294676fe65b96296a334c9ce107fa2142bd70f47acb265", size = 935745, upload-time = "2026-07-16T12:42:04.663Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/bb/49b10783f29067da2eec179320617e94faf63196609de47aeab3c26c3325/sentry_sdk-2.66.0-py3-none-any.whl", hash = "sha256:096136c214c602be2b323524d30755dc5b30ec5a218a206207f33b12c05c6f11", size = 504769, upload-time = "2026-07-16T12:42:02.919Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -906,14 +906,14 @@ wheels = [
 
 [[package]]
 name = "entitysdk"
-version = "0.19.5"
+version = "0.19.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/54/4a/e8c09e6fe42765ae8b5bea4fa12be91589abd8fa4dc8a1d6561c039c180b/entitysdk-0.19.5.tar.gz", hash = "sha256:249b604a45730ada252053a6b816e7ab6201962ef154ebfb38de6e118e28a247", size = 92063, upload-time = "2026-07-20T11:11:08.848Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/ee/415775fefb4066b147467c1096b0f9faffa26f31945be27ce717684231a2/entitysdk-0.19.6.tar.gz", hash = "sha256:375ee5e268df2b9664bbe04fed76a654d732711176b108cabd67882dff6f1ac3", size = 92133, upload-time = "2026-07-20T12:36:38.002Z" }
 
 [[package]]
 name = "executing"


### PR DESCRIPTION
## Summary

Enables Sentry error tracking + performance/profiling for the FastAPI service, mirroring the pattern already used by the other Open Brain Institute services (entitycore). Sentry is **DSN-gated**: when `SENTRY_DSN` is unset, `sentry_sdk.init` is a no-op, so local dev and CI stay quiet with no behavior change.

## Changes

- **`app/sentry.py`** (new) — `init_sentry()` calls `sentry_sdk.init(...)` with the same sampling as entitycore (`traces_sample_rate=0.1`, `profile_session_sample_rate=1.0`, `profile_lifecycle="trace"`). No manual `capture_exception` hooks — the auto-enabled FastAPI/Starlette/logging integrations capture unhandled exceptions (which today fall through to Starlette's default 500 uncaptured).
- **`app/__main__.py`** — `init_sentry()` called once at module load (before `cli()`), so it runs in the production serving process (`python -m app run`, in-process uvicorn).
- **`app/config.py`** — new settings: `SENTRY_DSN` (`None` default), `SENTRY_TRACES_SAMPLE_RATE`, `SENTRY_PROFILE_SESSION_SAMPLE_RATE`, and a validated `DEPLOYMENT_ENV: Literal["local", "staging", "production"] = "local"` used for Sentry's `environment` (matching the other services). `release` reuses `APP_VERSION`.
- **`pyproject.toml`** — `sentry-sdk>=2.65.0` in the `service` extra.
- **`tests/app/test_sentry.py`** (new) — covers the no-DSN no-op and that `init` receives the expected kwargs.
