### PR TITLE
feat(circuit-viz): allow 'single' scale circuits

### DIFF
--- a/app/services/circuit_visualization.py
+++ b/app/services/circuit_visualization.py
@@ -35,12 +35,12 @@ def circuit_asset_id(client: Client, circuit_id: UUID) -> UUID:
             },
         ) from e
 
-    if circuit.scale not in {CircuitScale.small, CircuitScale.pair}:
+    if circuit.scale not in {CircuitScale.single, CircuitScale.pair, CircuitScale.small}:
         raise HTTPException(
             status_code=HTTPStatus.BAD_REQUEST,
             detail={
                 "code": ApiErrorCode.INVALID_REQUEST,
-                "detail": "Circuit's scale should be 'small' or 'pair'",
+                "detail": "Circuit's scale should be 'single', 'pair' or 'small'",
             },
         )
 

--- a/tests/app/routers/declared/test_circuit_viz.py
+++ b/tests/app/routers/declared/test_circuit_viz.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from pathlib import Path
 from typing import cast
 from unittest.mock import MagicMock, patch
@@ -9,13 +10,14 @@ import pytest
 from entitysdk.models import Asset, Circuit
 from entitysdk.models.asset import AssetLabel, ContentType, StorageType
 from entitysdk.models.circuit import CircuitBuildCategory, CircuitScale
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from app.dependencies.auth import user_verified
 from app.dependencies.entitysdk import get_client
 from app.dependencies.file import _create_temp_dir
 from app.endpoints.circuit_visualization import router
+from app.errors import ApiErrorCode
 from app.schemas.circuit_visualization import Node, Section
 from app.services.circuit_visualization import (
     circuit_asset_id,
@@ -145,10 +147,9 @@ def test_circuit_dict():
     }
 
 
-def test_circuit_asset_id(mock_client, test_circuit_dict, test_asset_dict):
-    test_circuit = Circuit(
-        **test_circuit_dict, assets=[Asset(**test_asset_dict)], scale=CircuitScale.small
-    )
+@pytest.mark.parametrize("scale", [CircuitScale.single, CircuitScale.pair, CircuitScale.small])
+def test_circuit_asset_id(scale, mock_client, test_circuit_dict, test_asset_dict):
+    test_circuit = Circuit(**test_circuit_dict, assets=[Asset(**test_asset_dict)], scale=scale)
 
     expected_asset_id = test_circuit.assets[0].id
 
@@ -159,6 +160,30 @@ def test_circuit_asset_id(mock_client, test_circuit_dict, test_asset_dict):
 
     assert result == expected_asset_id
     mock_client.get_entity.assert_called_once_with(entity_id=test_circuit.id, entity_type=Circuit)
+
+
+@pytest.mark.parametrize(
+    "scale",
+    [
+        CircuitScale.microcircuit,
+        CircuitScale.region,
+        CircuitScale.system,
+        CircuitScale.whole_brain,
+    ],
+)
+def test_circuit_asset_id_rejects_large_scales(
+    scale, mock_client, test_circuit_dict, test_asset_dict
+):
+    test_circuit = Circuit(**test_circuit_dict, assets=[Asset(**test_asset_dict)], scale=scale)
+
+    mock_client.get_entity.return_value = test_circuit
+
+    with pytest.raises(HTTPException) as exc_info:
+        circuit_asset_id(mock_client, cast("UUID", test_circuit.id))
+
+    assert exc_info.value.status_code == HTTPStatus.BAD_REQUEST
+    assert exc_info.value.detail["code"] == ApiErrorCode.INVALID_REQUEST
+    mock_client.select_assets.assert_not_called()
 
 
 @pytest.fixture


### PR DESCRIPTION
## What

Adds `CircuitScale.single` to the scale allowlist in `circuit_asset_id`, so `/circuit/viz/{id}/nodes` and `/circuit/viz/{id}/morphologies/{path}` accept single-neuron circuits.

## Why

This unblocks reusing the shared 3D circuit viewer on synaptome (beta) pages, which are circuits with `scale='single'`. Today those pages run a separate in-browser SONATA/h5wasm loader that duplicates this endpoint; the frontend side of that consolidation is tracked in [openbraininstitute/prod-singlecell-simulation#284](https://github.com/openbraininstitute/prod-singlecell-simulation/issues/284).
