### PR TITLE
circuit-split: change validation to ignore some properties

### DIFF
--- a/obi_one/utils/circuit.py
+++ b/obi_one/utils/circuit.py
@@ -26,6 +26,16 @@ from obi_one.utils.filesystem import filter_extension
 
 L = logging.getLogger(__name__)
 
+# see https://github.com/openbraininstitute/prod-build-circuit/issues/46
+IGNORED_EDGE_PROPERTIES = [
+    "afferent_surface_x",
+    "afferent_surface_y",
+    "afferent_surface_z",
+    "spine_length",
+    "afferent_section_type",
+    "afferent_section_type",
+]
+
 
 def fix_node_sets_file(circuit_path: Path) -> None:
     """Fixes the node sets file in case references are broken.
@@ -170,7 +180,11 @@ def rebase_config(config_dict: dict, old_base: str, new_base: str) -> None:
 def run_validation(circuit_path: str | Path) -> None:
     """Run SONATA circuit validation."""
     errors = snap.circuit_validation.validate(
-        str(circuit_path), skip_slow=False, only_errors=True, print_errors=False
+        str(circuit_path),
+        skip_slow=False,
+        only_errors=True,
+        print_errors=False,
+        ignore_edge_properties=IGNORED_EDGE_PROPERTIES,
     )
     if len(errors) > 0:
         msg = f"Circuit validation error(s) found:\n{errors}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "bluecellulab>=2.6.99",
     "blueetl",
     "bluepyefe>=2.3.57",
-    "bluepysnap>=3.0.5",
+    "bluepysnap>=3.0.7",
     "brainbuilder>=0.20.4",
     "brian2",
     "caveclient>=7.11.0",

--- a/uv.lock
+++ b/uv.lock
@@ -295,7 +295,7 @@ wheels = [
 
 [[package]]
 name = "bluepysnap"
-version = "3.0.5"
+version = "3.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -310,7 +310,7 @@ dependencies = [
     { name = "pandas" },
     { name = "referencing" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ee/08/7e02f9e347c6a9b22f7bdb000c9abcdad9e5828b018dcb5999bf84c0d528/bluepysnap-3.0.5.tar.gz", hash = "sha256:e818e76e2a62fc8ddb844066fc462d6c715fab3c8fca500ea47b699b383a4adb", size = 1053136, upload-time = "2026-06-09T12:43:26.733Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/b1/58fefcd7212c9792ef2c3c544ae8c6f1825d429f16d8cafefc2ee9f4e132/bluepysnap-3.0.7.tar.gz", hash = "sha256:7671ef1e8a78dd19fb1b5743ae783a434264d5a165b37037868550d62db1577e", size = 969535, upload-time = "2026-07-24T12:07:56.578Z" }
 
 [[package]]
 name = "bluerecording"
@@ -2284,7 +2284,7 @@ requires-dist = [
     { name = "bluecellulab", specifier = ">=2.6.99" },
     { name = "blueetl" },
     { name = "bluepyefe", specifier = ">=2.3.57" },
-    { name = "bluepysnap", specifier = ">=3.0.5" },
+    { name = "bluepysnap", specifier = ">=3.0.7" },
     { name = "bluerecording", marker = "extra == 'bluerecording'", specifier = ">=0.4.6" },
     { name = "brainbuilder", specifier = ">=0.20.4" },
     { name = "brian2" },


### PR DESCRIPTION
* The properties are "required" in the spec, but aren't used.
* see https://github.com/openbraininstitute/prod-build-circuit/issues/46