### PR TITLE
Additional simulation generation tests

### DIFF
--- a/obi_one/scientific/mappings_and_registry/block_reference_registry.py
+++ b/obi_one/scientific/mappings_and_registry/block_reference_registry.py
@@ -20,6 +20,9 @@ from obi_one.scientific.unions_and_references.neuron_sets import (
     PointNeuronSetReference,
     VirtualNeuronSetReference,
 )
+from obi_one.scientific.unions_and_references.neuronal_manipulations import (
+    NeuronalManipulationReference,
+)
 from obi_one.scientific.unions_and_references.recordings import RecordingReference
 from obi_one.scientific.unions_and_references.stimuli import StimulusReference
 from obi_one.scientific.unions_and_references.synaptic_model_assigner import (
@@ -38,6 +41,7 @@ AllBlockReferenceTypes = [
     PointNeuronSetReference,
     StimulusReference,
     SynapticManipulationsReference,
+    NeuronalManipulationReference,
     RecordingReference,
     TimestampsReference,
     MorphologyLocationsReference,

--- a/obi_one/scientific/tasks/generate_simulations/config/base.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/base.py
@@ -18,7 +18,11 @@ from obi_one.core.serialization_constants import (
 )
 from obi_one.core.single import SingleConfigMixin
 from obi_one.core.units import Units
-from obi_one.scientific.blocks.neuron_sets.specific import AllBiophysicalNeurons
+from obi_one.scientific.blocks.neuron_sets.specific import (
+    AllBiophysicalNeurons,
+    AllPointNeurons,
+    AllVirtualNeurons,
+)
 from obi_one.scientific.from_id.circuit_from_id import (
     CircuitFromID,
     MEModelWithSynapsesCircuitFromID,
@@ -36,6 +40,8 @@ from obi_one.scientific.library.info_scan_config.config import InfoScanConfig
 from obi_one.scientific.library.ion_channel_model_circuit import CircuitFromIonChannelModels
 from obi_one.scientific.unions_and_references.neuron_sets import (
     BiophysicalNeuronSetReference,
+    PointNeuronSetReference,
+    VirtualNeuronSetReference,
 )
 
 SONATA_VERSION = 2.4
@@ -74,6 +80,15 @@ class BaseSimulationScanConfig(InfoScanConfig, abc.ABC):
     default_node_set_name: ClassVar[str] = "Default: All Biophysical Neurons"
     default_neuron_set_type: ClassVar[type[AllBiophysicalNeurons]] = AllBiophysicalNeurons
 
+    # A neuron set reference left unset is filled in with the default for its own population
+    # type, which may differ from the simulation-wide default. Every simulation config needs all
+    # three, whatever its own default is: a point-only config can still hold a virtual set, and a
+    # biophysical one can hold both.
+    default_virtual_node_set_name: ClassVar[str] = "Default: All Virtual Neurons"
+    default_point_node_set_name: ClassVar[str] = "Default: All Point Neurons"
+    default_virtual_neuron_set_type: ClassVar[type[AllVirtualNeurons]] = AllVirtualNeurons
+    default_point_neuron_set_type: ClassVar[type[AllPointNeurons]] = AllPointNeurons
+
     @property
     def default_neuron_set_reference(
         self,
@@ -87,6 +102,30 @@ class BaseSimulationScanConfig(InfoScanConfig, abc.ABC):
         default_neuron_set_block_reference.block.set_block_name(self.default_node_set_name)
 
         return default_neuron_set_block_reference
+
+    @property
+    def default_virtual_neuron_set_reference(
+        self,
+    ) -> VirtualNeuronSetReference:
+        """The default virtual neuron set reference for the simulation."""
+        ref = VirtualNeuronSetReference(
+            block_dict_name="neuron_sets", block_name=self.default_virtual_node_set_name
+        )
+        ref.block = self.default_virtual_neuron_set_type()
+        ref.block.set_block_name(self.default_virtual_node_set_name)
+        return ref
+
+    @property
+    def default_point_neuron_set_reference(
+        self,
+    ) -> PointNeuronSetReference:
+        """The default point neuron set reference for the simulation."""
+        ref = PointNeuronSetReference(
+            block_dict_name="neuron_sets", block_name=self.default_point_node_set_name
+        )
+        ref.block = self.default_point_neuron_set_type()
+        ref.block.set_block_name(self.default_point_node_set_name)
+        return ref
 
     json_schema_extra_additions: ClassVar[dict] = {
         SchemaKey.PROPERTY_ENDPOINTS: {

--- a/obi_one/scientific/tasks/generate_simulations/config/neuron/neuron_base.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/neuron/neuron_base.py
@@ -6,11 +6,6 @@ from pydantic import Field, NonNegativeFloat, PositiveFloat
 
 from obi_one.core.schema import SchemaKey, UIElement
 from obi_one.core.units import Units
-from obi_one.scientific.blocks.neuron_sets.specific import (
-    AllBiophysicalNeurons,
-    AllPointNeurons,
-    AllVirtualNeurons,
-)
 from obi_one.scientific.library.constants import (
     SIMULATION_TIMESTEP_MILLISECONDS,
     SONATA,
@@ -22,11 +17,6 @@ from obi_one.scientific.tasks.generate_simulations.config.base import (
 from obi_one.scientific.unions_and_references.morphology_locations import (
     MorphologyLocationsReference,
     MorphologyLocationUnion,
-)
-from obi_one.scientific.unions_and_references.neuron_sets import (
-    BiophysicalNeuronSetReference,
-    PointNeuronSetReference,
-    VirtualNeuronSetReference,
 )
 from obi_one.scientific.unions_and_references.recordings import (
     RecordingReference,
@@ -44,50 +34,6 @@ class NeuronSimulationScanConfig(BaseSimulationScanConfig, abc.ABC):
     _target_simulator: ClassVar[SimulatorType] = SimulatorType.NEURON
     _spike_location: ClassVar[str] = SONATA.SPIKE_LOCATION_SOMA
     _timestep: ClassVar[PositiveFloat] = SIMULATION_TIMESTEP_MILLISECONDS
-    default_node_set_name: ClassVar[str] = "Default: All Biophysical Neurons"
-    default_virtual_node_set_name: ClassVar[str] = "Default: All Virtual Neurons"
-    default_point_node_set_name: ClassVar[str] = "Default: All Point Neurons"
-    default_neuron_set_type: ClassVar[type[AllBiophysicalNeurons]] = AllBiophysicalNeurons
-    default_virtual_neuron_set_type: ClassVar[type[AllVirtualNeurons]] = AllVirtualNeurons
-    default_point_neuron_set_type: ClassVar[type[AllPointNeurons]] = AllPointNeurons
-
-    @property
-    def default_neuron_set_reference(
-        self,
-    ) -> BiophysicalNeuronSetReference:
-        """The default neuron set reference for the simulation."""
-        default_neuron_set_block_reference = BiophysicalNeuronSetReference(
-            block_dict_name="neuron_sets", block_name=self.default_node_set_name
-        )
-
-        default_neuron_set_block_reference.block = self.default_neuron_set_type()
-        default_neuron_set_block_reference.block.set_block_name(self.default_node_set_name)
-
-        return default_neuron_set_block_reference
-
-    @property
-    def default_virtual_neuron_set_reference(
-        self,
-    ) -> VirtualNeuronSetReference:
-        """The default virtual neuron set reference for the simulation."""
-        ref = VirtualNeuronSetReference(
-            block_dict_name="neuron_sets", block_name=self.default_virtual_node_set_name
-        )
-        ref.block = self.default_virtual_neuron_set_type()
-        ref.block.set_block_name(self.default_virtual_node_set_name)
-        return ref
-
-    @property
-    def default_point_neuron_set_reference(
-        self,
-    ) -> PointNeuronSetReference:
-        """The default point neuron set reference for the simulation."""
-        ref = PointNeuronSetReference(
-            block_dict_name="neuron_sets", block_name=self.default_point_node_set_name
-        )
-        ref.block = self.default_point_neuron_set_type()
-        ref.block.set_block_name(self.default_point_node_set_name)
-        return ref
 
     recordings: dict[str, RecordingUnion] = Field(
         default_factory=dict,

--- a/obi_one/scientific/tasks/generate_simulations/task/task.py
+++ b/obi_one/scientific/tasks/generate_simulations/task/task.py
@@ -306,18 +306,18 @@ class GenerateSimulationTask(Task):
 
     def _default_virtual_neuron_set_ref(self) -> ALL_NEURON_SETS_REFERENCE_UNION:
         """Returns the reference for the default virtual neuron set."""
-        ref = self.config.default_virtual_neuron_set_reference  # ty:ignore[unresolved-attribute]
+        ref = self.config.default_virtual_neuron_set_reference
         if (
             ref.block_name in self.config.neuron_sets  # ty:ignore[unresolved-attribute]
             and not isinstance(
                 self.config.neuron_sets[ref.block_name],  # ty:ignore[unresolved-attribute]
-                self.config.default_virtual_neuron_set_type,  # ty:ignore[unresolved-attribute]
+                self.config.default_virtual_neuron_set_type,
             )
         ):
             msg = (
                 f"Default virtual neuron set name '{ref.block_name}' already exists in "
                 f"neuron_sets but is not an "
-                f"{self.config.default_virtual_neuron_set_type.__name__} set!"  # ty:ignore[unresolved-attribute]
+                f"{self.config.default_virtual_neuron_set_type.__name__} set!"
             )
             raise OBIONEError(msg)
         if ref.block_name not in self.config.neuron_sets:  # ty:ignore[unresolved-attribute]
@@ -326,18 +326,18 @@ class GenerateSimulationTask(Task):
 
     def _default_point_neuron_set_ref(self) -> ALL_NEURON_SETS_REFERENCE_UNION:
         """Returns the reference for the default point neuron set."""
-        ref = self.config.default_point_neuron_set_reference  # ty:ignore[unresolved-attribute]
+        ref = self.config.default_point_neuron_set_reference
         if (
             ref.block_name in self.config.neuron_sets  # ty:ignore[unresolved-attribute]
             and not isinstance(
                 self.config.neuron_sets[ref.block_name],  # ty:ignore[unresolved-attribute]
-                self.config.default_point_neuron_set_type,  # ty:ignore[unresolved-attribute]
+                self.config.default_point_neuron_set_type,
             )
         ):
             msg = (
                 f"Default point neuron set name '{ref.block_name}' already exists in "
                 f"neuron_sets but is not an "
-                f"{self.config.default_point_neuron_set_type.__name__} set!"  # ty:ignore[unresolved-attribute]
+                f"{self.config.default_point_neuron_set_type.__name__} set!"
             )
             raise OBIONEError(msg)
         if ref.block_name not in self.config.neuron_sets:  # ty:ignore[unresolved-attribute]

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/conftest.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/conftest.py
@@ -1,0 +1,301 @@
+"""Shared fixtures for the simulation generation tests.
+
+The tests in this package drive ``GenerateSimulationTask`` directly rather than through a scan.
+A ``SingleConfig`` is assembled by hand (``empty_config`` -> ``set``/``add`` ->
+``fill_block_references_and_names``), pointed at a temporary output directory, and executed. That
+keeps every test a black-box check of "config in, SONATA artefacts out", so the suite survives a
+refactor of the task's internals.
+"""
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import obi_one as obi
+from obi_one.scientific.library.memodel_circuit import (
+    MEModelCircuit,
+    MEModelWithSynapsesCircuit,
+)
+from obi_one.scientific.tasks.generate_simulations.config.brian2.brian2_circuit import (
+    Brian2CircuitSimulationSingleConfig,
+)
+from obi_one.scientific.tasks.generate_simulations.config.learning_engine.le_circuit import (
+    LearningEngineCircuitSimulationSingleConfig,
+)
+from obi_one.scientific.tasks.generate_simulations.config.neuron.neuron_circuit import (
+    CircuitSimulationSingleConfig,
+)
+from obi_one.scientific.tasks.generate_simulations.config.neuron.neuron_me_model import (
+    MEModelSimulationSingleConfig,
+)
+from obi_one.scientific.tasks.generate_simulations.config.neuron.neuron_me_model_with_synapses import (  # ruff: ignore[line-too-long]
+    MEModelWithSynapsesCircuitSimulationSingleConfig,
+)
+from obi_one.scientific.tasks.generate_simulations.task.task import GenerateSimulationTask
+
+from tests.utils import CIRCUIT_DIR, SINGLE_NEURON_CIRCUIT_DIR
+
+# A biophysical circuit with 10 neurons in `S1nonbarrel_neurons` plus the `VPM` and `POm` virtual
+# populations -- enough to exercise biophysical, virtual and multi-population neuron sets.
+MULTI_POPULATION_CIRCUIT_PATH = CIRCUIT_DIR / "N_10__top_nodes_dim6" / "circuit_config.json"
+
+# A circuit with detailed morphologies, needed by the morphology-location blocks.
+MORPHOLOGY_CIRCUIT_PATH = CIRCUIT_DIR / "nbS1-O1-E2Sst-maxNsyn-HEX0-L5" / "circuit_config.json"
+
+# A single-neuron circuit, used for the ME-model configs.
+SINGLE_NEURON_CIRCUIT_PATH = (
+    SINGLE_NEURON_CIRCUIT_DIR / "SingleNeuronCircuit__top_nodes_dim6__IDX0" / "circuit_config.json"
+)
+
+# The synthetic FlyWire-style point circuit: one `brian2_point` population `drosophila` with 3
+# neurons and a `sugar` node set covering neurons 0 and 1.
+POINT_CIRCUIT_PATH = (
+    Path(__file__).parents[2] / "library" / "simulation" / "data" / "circuit_config.json"
+)
+
+BIOPHYSICAL_POPULATION = "S1nonbarrel_neurons"
+VIRTUAL_POPULATION = "VPM"
+POINT_POPULATION = "drosophila"
+
+DEFAULT_BIOPHYSICAL_NODE_SET = "Default: All Biophysical Neurons"
+DEFAULT_VIRTUAL_NODE_SET = "Default: All Virtual Neurons"
+DEFAULT_POINT_NODE_SET = "Default: All Point Neurons"
+DEFAULT_BRIAN2_STIMULUS_NODE_SET = "Default: Sugar gustatory receptor neurons"
+
+
+@dataclass
+class GeneratedSimulation:
+    """Everything a generation run wrote to disk, already parsed."""
+
+    directory: Path
+    sonata_config: dict
+    node_sets: dict
+    compartment_sets: dict | None
+
+    @property
+    def inputs(self) -> dict:
+        return self.sonata_config["inputs"]
+
+    @property
+    def reports(self) -> dict:
+        return self.sonata_config["reports"]
+
+    @property
+    def conditions(self) -> dict:
+        return self.sonata_config["conditions"]
+
+
+@dataclass
+class RecordedCall:
+    """A single method call captured by :class:`FakeDBClient`."""
+
+    method: str
+    kwargs: dict
+
+
+@dataclass
+class FakeDBClient:
+    """Records the entitysdk calls the task makes, without touching a database.
+
+    ``GenerateSimulationTask`` only ever calls ``update_entity`` and ``upload_file`` on the
+    client, and only when one is supplied, so a recorder is enough to pin the persistence
+    behaviour.
+    """
+
+    calls: list[RecordedCall] = field(default_factory=list)
+
+    def update_entity(self, **kwargs: Any) -> None:
+        self.calls.append(RecordedCall(method="update_entity", kwargs=kwargs))
+
+    def upload_file(self, **kwargs: Any) -> None:
+        self.calls.append(RecordedCall(method="upload_file", kwargs=kwargs))
+
+    def calls_to(self, method: str) -> list[RecordedCall]:
+        return [call for call in self.calls if call.method == method]
+
+    def uploaded_labels(self) -> list[str]:
+        return [call.kwargs["asset_label"] for call in self.calls_to("upload_file")]
+
+
+@dataclass
+class _StubEntity:
+    """Stands in for the registered ``entitysdk`` Simulation entity."""
+
+    id: str = "00000000-0000-0000-0000-000000000000"
+
+
+def build_config(
+    config_class: type,
+    *,
+    circuit: Any,
+    blocks: dict[str, Any] | None = None,
+    initialize: dict[str, Any] | None = None,
+    root_blocks: dict[str, Any] | None = None,
+) -> Any:
+    """Assemble a SingleConfig without going through a scan.
+
+    ``blocks`` maps the name a block is registered under to the block itself, applied in insertion
+    order. A value may also be a callable taking no arguments and returning the block; it is
+    invoked at add time, which is how a block gets to reference the ``.ref`` of one added before
+    it (``.ref`` only exists once ``add`` has run). ``initialize`` supplies extra keyword arguments
+    for the config's ``Initialize`` block.
+    """
+    config = config_class.empty_config()
+    config.set(
+        obi.Info(campaign_name="Test campaign", campaign_description="Test description"),
+        name="info",
+    )
+
+    for name, block_or_factory in (blocks or {}).items():
+        block = block_or_factory() if callable(block_or_factory) else block_or_factory
+        config.add(block, name=name)
+
+    for name, block in (root_blocks or {}).items():
+        config.set(block, name=name)
+
+    config.set(
+        config_class.Initialize(
+            circuit=circuit,
+            **{"simulation_length": 100.0, **(initialize or {})},
+        ),
+        name="initialize",
+    )
+
+    config.fill_block_references_and_names()
+    return config
+
+
+def generate(
+    config: Any,
+    tmp_path: Path,
+    *,
+    db_client: Any = None,
+    entity_cache: bool = False,
+    subdirectory: str = "0",
+) -> GeneratedSimulation:
+    """Run ``GenerateSimulationTask`` on ``config`` and parse everything it wrote."""
+    coordinate_root = tmp_path / subdirectory
+    coordinate_root.mkdir(parents=True, exist_ok=True)
+
+    config.idx = 0
+    config.scan_output_root = tmp_path
+    config.coordinate_output_root = coordinate_root
+    if db_client is not None:
+        config.set_single_entity(_StubEntity())
+
+    GenerateSimulationTask(config=config).execute(db_client=db_client, entity_cache=entity_cache)
+
+    return read_generated(coordinate_root)
+
+
+def read_generated(coordinate_root: Path) -> GeneratedSimulation:
+    """Parse the artefacts a generation run left in ``coordinate_root``."""
+    compartment_sets_path = coordinate_root / "compartment_sets.json"
+
+    return GeneratedSimulation(
+        directory=coordinate_root,
+        sonata_config=json.loads((coordinate_root / "simulation_config.json").read_text()),
+        node_sets=json.loads((coordinate_root / "node_sets.json").read_text()),
+        compartment_sets=(
+            json.loads(compartment_sets_path.read_text())
+            if compartment_sets_path.exists()
+            else None
+        ),
+    )
+
+
+@pytest.fixture
+def circuit():
+    """A 10-neuron biophysical circuit with virtual VPM/POm populations."""
+    return obi.Circuit(name="N_10__top_nodes_dim6", path=str(MULTI_POPULATION_CIRCUIT_PATH))
+
+
+@pytest.fixture
+def morphology_circuit():
+    """A circuit with detailed morphologies, for morphology-location targeting."""
+    return obi.Circuit(name="nbS1-O1-E2Sst-maxNsyn-HEX0-L5", path=str(MORPHOLOGY_CIRCUIT_PATH))
+
+
+@pytest.fixture
+def me_model_circuit():
+    """A single-neuron circuit for the ME-model config."""
+    return MEModelCircuit(name="me_model", path=str(SINGLE_NEURON_CIRCUIT_PATH))
+
+
+@pytest.fixture
+def me_model_with_synapses_circuit():
+    """A single-neuron circuit with synapses for the ME-model-with-synapses config."""
+    return MEModelWithSynapsesCircuit(
+        name="me_model_with_synapses", path=str(SINGLE_NEURON_CIRCUIT_PATH)
+    )
+
+
+@pytest.fixture
+def point_circuit():
+    """The synthetic drosophila point-neuron circuit used by Brian2 and LearningEngine."""
+    return obi.Circuit(name="drosophila", path=str(POINT_CIRCUIT_PATH))
+
+
+@pytest.fixture
+def db_client():
+    """A recording stand-in for an entitysdk client."""
+    return FakeDBClient()
+
+
+@pytest.fixture
+def circuit_config(circuit):
+    """Factory building a ``CircuitSimulationSingleConfig`` on the biophysical circuit."""
+
+    def _build(**kwargs):
+        return build_config(CircuitSimulationSingleConfig, circuit=circuit, **kwargs)
+
+    return _build
+
+
+@pytest.fixture
+def me_model_config(me_model_circuit):
+    """Factory building an ``MEModelSimulationSingleConfig``."""
+
+    def _build(**kwargs):
+        return build_config(MEModelSimulationSingleConfig, circuit=me_model_circuit, **kwargs)
+
+    return _build
+
+
+@pytest.fixture
+def me_model_with_synapses_config(me_model_with_synapses_circuit):
+    """Factory building an ``MEModelWithSynapsesCircuitSimulationSingleConfig``."""
+
+    def _build(**kwargs):
+        return build_config(
+            MEModelWithSynapsesCircuitSimulationSingleConfig,
+            circuit=me_model_with_synapses_circuit,
+            **kwargs,
+        )
+
+    return _build
+
+
+@pytest.fixture
+def brian2_config(point_circuit):
+    """Factory building a ``Brian2CircuitSimulationSingleConfig``."""
+
+    def _build(**kwargs):
+        return build_config(Brian2CircuitSimulationSingleConfig, circuit=point_circuit, **kwargs)
+
+    return _build
+
+
+@pytest.fixture
+def learning_engine_config(point_circuit):
+    """Factory building a ``LearningEngineCircuitSimulationSingleConfig``."""
+
+    def _build(**kwargs):
+        return build_config(
+            LearningEngineCircuitSimulationSingleConfig, circuit=point_circuit, **kwargs
+        )
+
+    return _build

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/conftest.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/conftest.py
@@ -78,28 +78,24 @@ def union_member_names(union: Any) -> set[str]:
     return {cls.__name__ for cls in typing.get_args(inner) if inspect.isclass(cls)}
 
 
-def reference_field_names(block_class: type) -> list[str]:
-    """Names of the fields on ``block_class`` that hold a block reference.
+def reference_types_in(annotation: Any) -> set[type]:
+    """Every ``BlockReference`` subclass reachable inside a field annotation.
 
-    Reference fields are declared as ``SomeReference | ... | None`` and sometimes nest a further
-    union inside, so both levels are searched.
+    References are nested to varying depths: directly in a union (``SomeReference | None``), one
+    union deeper, and inside the tuple-of-tuples that ``CombinedBaseNeuronSet.combined_with``
+    uses. The search is fully recursive so no field shape is silently missed.
     """
+    if inspect.isclass(annotation) and issubclass(annotation, BlockReference):
+        return {annotation}
+    return {found for arg in typing.get_args(annotation) for found in reference_types_in(arg)}
 
-    def holds_a_reference(annotation: Any) -> bool:
-        for arg in typing.get_args(annotation):
-            if inspect.isclass(arg) and issubclass(arg, BlockReference):
-                return True
-            if any(
-                inspect.isclass(nested) and issubclass(nested, BlockReference)
-                for nested in typing.get_args(arg)
-            ):
-                return True
-        return False
 
+def reference_field_names(block_class: type) -> list[str]:
+    """Names of the fields on ``block_class`` that hold a block reference."""
     return [
         name
         for name, field_info in block_class.model_fields.items()
-        if holds_a_reference(field_info.annotation)
+        if reference_types_in(field_info.annotation)
     ]
 
 

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/conftest.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/conftest.py
@@ -7,7 +7,9 @@ keeps every test a black-box check of "config in, SONATA artefacts out", so the 
 refactor of the task's internals.
 """
 
+import inspect
 import json
+import typing
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -15,6 +17,7 @@ from typing import Any
 import pytest
 
 import obi_one as obi
+from obi_one.core.block_reference import BlockReference
 from obi_one.scientific.library.memodel_circuit import (
     MEModelCircuit,
     MEModelWithSynapsesCircuit,
@@ -66,6 +69,44 @@ DEFAULT_POINT_NODE_SET = "Default: All Point Neurons"
 DEFAULT_BRIAN2_STIMULUS_NODE_SET = "Default: Sugar gustatory receptor neurons"
 
 
+def union_member_names(union: Any) -> set[str]:
+    """The block class names a discriminated block union accepts."""
+    inner = typing.get_args(union)[0]
+    if inspect.isclass(inner):
+        # A single-member "union" annotates the class directly.
+        return {inner.__name__}
+    return {cls.__name__ for cls in typing.get_args(inner) if inspect.isclass(cls)}
+
+
+def reference_field_names(block_class: type) -> list[str]:
+    """Names of the fields on ``block_class`` that hold a block reference.
+
+    Reference fields are declared as ``SomeReference | ... | None`` and sometimes nest a further
+    union inside, so both levels are searched.
+    """
+
+    def holds_a_reference(annotation: Any) -> bool:
+        for arg in typing.get_args(annotation):
+            if inspect.isclass(arg) and issubclass(arg, BlockReference):
+                return True
+            if any(
+                inspect.isclass(nested) and issubclass(nested, BlockReference)
+                for nested in typing.get_args(arg)
+            ):
+                return True
+        return False
+
+    return [
+        name
+        for name, field_info in block_class.model_fields.items()
+        if holds_a_reference(field_info.annotation)
+    ]
+
+
+# The node set names a generated SONATA config can refer to, by the key each section uses.
+NODE_SET_REFERENCE_KEYS = ("node_set", "cells", "source", "target")
+
+
 @dataclass
 class GeneratedSimulation:
     """Everything a generation run wrote to disk, already parsed."""
@@ -86,6 +127,29 @@ class GeneratedSimulation:
     @property
     def conditions(self) -> dict:
         return self.sonata_config["conditions"]
+
+    def referenced_node_sets(self) -> set[str]:
+        """Every node set name the generated config points at, from all its sections."""
+        sections = [
+            self.sonata_config.get("inputs", {}).values(),
+            self.sonata_config.get("reports", {}).values(),
+            self.sonata_config.get("connection_overrides", []),
+            self.conditions.get("modifications", []),
+        ]
+        names = {
+            entry[key]
+            for section in sections
+            for entry in section
+            for key in NODE_SET_REFERENCE_KEYS
+            if key in entry
+        }
+        if "node_set" in self.sonata_config:
+            names.add(self.sonata_config["node_set"])
+        return names
+
+    def dangling_node_sets(self) -> set[str]:
+        """Referenced node set names that were never written to ``node_sets.json``."""
+        return self.referenced_node_sets() - set(self.node_sets)
 
 
 @dataclass

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_circuit_resolution.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_circuit_resolution.py
@@ -1,0 +1,135 @@
+"""How the task turns the config's circuit field into a staged circuit and a ``network`` path.
+
+A locally-pathed circuit is referenced in place; a database-backed one is staged to disk first,
+and the ``network`` entry then becomes a path relative to the coordinate output directory so the
+generated config stays relocatable.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+import obi_one as obi
+from obi_one.core.exception import OBIONEError
+from obi_one.scientific.from_id.circuit_from_id import CircuitFromID
+from obi_one.scientific.library.circuit import Circuit
+from obi_one.scientific.tasks.generate_simulations.config.neuron.neuron_circuit import (
+    CircuitSimulationSingleConfig,
+)
+from obi_one.scientific.tasks.generate_simulations.task.task import GenerateSimulationTask
+
+from tests.obi_one.scientific.tasks.simulation_campaign_generation.conftest import (
+    MULTI_POPULATION_CIRCUIT_PATH,
+    build_config,
+    generate,
+)
+
+CIRCUIT_ID = "11111111-2222-3333-4444-555555555555"
+
+
+@pytest.fixture
+def staging_recorder(monkeypatch):
+    """Replace ``CircuitFromID.stage_circuit`` with a recorder returning the local test circuit.
+
+    Real staging downloads assets from entitycore. Everything the task depends on is the returned
+    ``Circuit`` and the directory it was asked to stage into, so both are captured here.
+    """
+    calls: list[dict] = []
+
+    def _stage_circuit(self, *, dest_dir=Path(), db_client=None, entity_cache=False):
+        calls.append(
+            {"dest_dir": Path(dest_dir), "entity_cache": entity_cache, "db_client": db_client}
+        )
+        return Circuit(name=str(self), path=str(MULTI_POPULATION_CIRCUIT_PATH))
+
+    monkeypatch.setattr(CircuitFromID, "stage_circuit", _stage_circuit)
+    return calls
+
+
+class TestLocalCircuit:
+    def test_network_is_the_absolute_circuit_config_path(self, circuit_config, circuit, tmp_path):
+        result = generate(circuit_config(), tmp_path)
+
+        assert result.sonata_config["network"] == str(Path(circuit.path).resolve())
+
+    def test_a_relative_circuit_path_is_resolved(self, tmp_path):
+        relative_path = os.path.relpath(MULTI_POPULATION_CIRCUIT_PATH, Path.cwd())
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=obi.Circuit(name="relative", path=relative_path),
+        )
+
+        result = generate(config, tmp_path)
+
+        assert Path(result.sonata_config["network"]).is_absolute()
+        assert Path(result.sonata_config["network"]).exists()
+
+    def test_the_resolved_circuit_is_kept_on_the_task(self, circuit_config, tmp_path):
+        config = circuit_config()
+        coordinate_root = tmp_path / "0"
+        coordinate_root.mkdir(parents=True)
+        config.scan_output_root = tmp_path
+        config.coordinate_output_root = coordinate_root
+
+        task = GenerateSimulationTask(config=config)
+        task.execute()
+
+        assert isinstance(task._circuit, Circuit)
+
+
+class TestCircuitFromID:
+    def _config(self):
+        return build_config(CircuitSimulationSingleConfig, circuit=CircuitFromID(id_str=CIRCUIT_ID))
+
+    def test_circuit_is_staged_into_the_coordinate_directory(
+        self, staging_recorder, tmp_path, db_client
+    ):
+        generate(self._config(), tmp_path, db_client=db_client)
+
+        assert staging_recorder[0]["dest_dir"] == tmp_path / "0" / "sonata_circuit"
+        assert staging_recorder[0]["entity_cache"] is False
+
+    def test_entity_cache_stages_into_a_shared_scan_level_directory(
+        self, staging_recorder, tmp_path, db_client
+    ):
+        """With the cache on, the circuit is staged once per entity for the whole scan."""
+        generate(self._config(), tmp_path, db_client=db_client, entity_cache=True)
+
+        assert staging_recorder[0]["dest_dir"] == (
+            tmp_path / "entity_cache" / "sonata_circuit" / CIRCUIT_ID
+        )
+        assert staging_recorder[0]["entity_cache"] is True
+
+    @pytest.mark.usefixtures("staging_recorder")
+    def test_network_becomes_a_relative_path(self, tmp_path, db_client):
+        """A staged circuit is referenced relatively so the output directory can be moved."""
+        result = generate(self._config(), tmp_path, db_client=db_client)
+
+        network = result.sonata_config["network"]
+        assert not Path(network).is_absolute()
+        assert (result.directory / network).resolve() == MULTI_POPULATION_CIRCUIT_PATH.resolve()
+
+    def test_the_db_client_is_passed_through_to_staging(
+        self, staging_recorder, tmp_path, db_client
+    ):
+        generate(self._config(), tmp_path, db_client=db_client)
+
+        assert staging_recorder[0]["db_client"] is db_client
+
+
+class TestCircuitResolutionErrors:
+    def test_a_config_without_a_circuit_is_refused(self, circuit_config, tmp_path):
+        config = circuit_config()
+        del config.initialize.__dict__["circuit"]
+
+        with pytest.raises(OBIONEError, match="No circuit specified in config!"):
+            generate(config, tmp_path)
+
+    def test_an_unrecognised_circuit_type_is_refused(self, circuit_config, tmp_path):
+        """Only ``Circuit`` and the known ``*FromID`` wrappers can be resolved."""
+        config = circuit_config()
+        config.initialize.__dict__["circuit"] = object()
+
+        with pytest.raises(OBIONEError, match="Failed to resolve circuit!"):
+            generate(config, tmp_path)

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_entity_persistence.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_entity_persistence.py
@@ -1,0 +1,213 @@
+"""What the task sends to entitycore when a database client is supplied.
+
+Generation is usable offline: with no client it only writes files. With one, it additionally
+records the neuron count on the Simulation entity and uploads the generated artefacts as labelled
+assets. Both the set of labels and the neuron count are part of the contract.
+"""
+
+import entitysdk
+import pytest
+
+import obi_one as obi
+from obi_one.scientific.blocks.neuron_sets.id import (
+    BiophysicalPopulationIDNeuronSet,
+    VirtualPopulationIDNeuronSet,
+)
+from obi_one.scientific.tasks.generate_simulations.config.neuron.neuron_circuit import (
+    CircuitSimulationSingleConfig,
+)
+from obi_one.scientific.tasks.generate_simulations.task.task import GenerateSimulationTask
+
+from tests.obi_one.scientific.tasks.simulation_campaign_generation.conftest import (
+    BIOPHYSICAL_POPULATION,
+    VIRTUAL_POPULATION,
+    FakeDBClient,
+    build_config,
+    generate,
+)
+
+
+class TestWithoutADatabaseClient:
+    def test_generation_works_offline(self, circuit_config, tmp_path):
+        result = generate(circuit_config(), tmp_path)
+
+        assert (result.directory / "simulation_config.json").exists()
+
+    def test_nothing_is_uploaded(self, circuit_config, tmp_path, db_client):
+        generate(circuit_config(), tmp_path, db_client=None)
+
+        assert db_client.calls == []
+
+
+class TestAssetUploads:
+    def test_node_sets_and_config_are_uploaded(self, circuit_config, tmp_path, db_client):
+        generate(circuit_config(), tmp_path, db_client=db_client)
+
+        assert db_client.uploaded_labels() == ["custom_node_sets", "sonata_simulation_config"]
+
+    def test_uploads_point_at_the_generated_files(self, circuit_config, tmp_path, db_client):
+        result = generate(circuit_config(), tmp_path, db_client=db_client)
+
+        paths = {
+            call.kwargs["asset_label"]: call.kwargs["file_path"]
+            for call in db_client.calls_to("upload_file")
+        }
+        assert paths["custom_node_sets"] == result.directory / "node_sets.json"
+        assert paths["sonata_simulation_config"] == result.directory / "simulation_config.json"
+
+    def test_uploads_target_the_simulation_entity(self, circuit_config, tmp_path, db_client):
+        config = circuit_config()
+
+        generate(config, tmp_path, db_client=db_client)
+
+        for call in db_client.calls_to("upload_file"):
+            assert call.kwargs["entity_id"] == config.single_entity.id
+            assert call.kwargs["entity_type"] is entitysdk.models.Simulation
+
+    def test_json_assets_declare_a_json_content_type(self, circuit_config, tmp_path, db_client):
+        generate(circuit_config(), tmp_path, db_client=db_client)
+
+        for call in db_client.calls_to("upload_file"):
+            assert call.kwargs["file_content_type"] == "application/json"
+
+    def test_compartment_sets_are_uploaded_when_present(
+        self, morphology_circuit, tmp_path, db_client
+    ):
+        locations = obi.RandomMorphologyLocations(random_seed=0, number_of_locations=2)
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=morphology_circuit,
+            blocks={
+                "Locations": locations,
+                "Clamp": lambda: obi.ConstantCurrentClampSomaticStimulus(neuron_set=locations.ref),
+            },
+        )
+
+        generate(config, tmp_path, db_client=db_client)
+
+        assert "compartment_sets" in db_client.uploaded_labels()
+
+    def test_spike_replay_files_are_uploaded(self, circuit, tmp_path, db_client):
+        source = VirtualPopulationIDNeuronSet(
+            population=VIRTUAL_POPULATION,
+            neuron_ids=obi.NamedTuple(name="source", elements=[0, 1, 2]),
+        )
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "Source": source,
+                "Spikes": lambda: obi.PoissonSpikeStimulus(source_neuron_set=source.ref),
+            },
+        )
+
+        result = generate(config, tmp_path, db_client=db_client)
+
+        replay_calls = [
+            call
+            for call in db_client.calls_to("upload_file")
+            if call.kwargs["asset_label"] == "replay_spikes"
+        ]
+        assert len(replay_calls) == 1
+        assert replay_calls[0].kwargs["file_path"] == result.directory / "Spikes_spikes.h5"
+        assert replay_calls[0].kwargs["file_content_type"] == "application/x-hdf5"
+
+    def test_one_replay_upload_per_spike_stimulus(self, circuit, tmp_path, db_client):
+        source = VirtualPopulationIDNeuronSet(
+            population=VIRTUAL_POPULATION,
+            neuron_ids=obi.NamedTuple(name="source", elements=[0, 1, 2]),
+        )
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "Source": source,
+                "Poisson": lambda: obi.PoissonSpikeStimulus(source_neuron_set=source.ref),
+                "Synchronous": lambda: obi.FullySynchronousSpikeStimulus(
+                    source_neuron_set=source.ref
+                ),
+            },
+        )
+
+        generate(config, tmp_path, db_client=db_client)
+
+        assert db_client.uploaded_labels().count("replay_spikes") == 2
+
+    def test_a_config_without_spikes_uploads_no_replay_assets(
+        self, circuit_config, tmp_path, db_client
+    ):
+        generate(circuit_config(), tmp_path, db_client=db_client)
+
+        assert "replay_spikes" not in db_client.uploaded_labels()
+
+
+class TestNeuronCount:
+    def test_the_simulation_target_size_is_recorded(self, circuit, tmp_path, db_client):
+        target = BiophysicalPopulationIDNeuronSet(
+            population=BIOPHYSICAL_POPULATION,
+            neuron_ids=obi.NamedTuple(name="target", elements=[0, 1, 2, 3]),
+        )
+        config = build_config(
+            CircuitSimulationSingleConfig, circuit=circuit, blocks={"Target": target}
+        )
+        config.initialize.node_set = config.neuron_sets["Target"].ref
+
+        generate(config, tmp_path, db_client=db_client)
+
+        updates = db_client.calls_to("update_entity")
+        assert len(updates) == 1
+        assert updates[0].kwargs["attrs_or_entity"] == {"number_neurons": 4}
+
+    def test_the_default_target_counts_the_whole_population(
+        self, circuit_config, tmp_path, db_client
+    ):
+        generate(circuit_config(), tmp_path, db_client=db_client)
+
+        updates = db_client.calls_to("update_entity")
+        assert updates[0].kwargs["attrs_or_entity"] == {"number_neurons": 10}
+
+    def test_an_me_model_always_counts_one_neuron(self, me_model_config, tmp_path, db_client):
+        """An ME model config has no neuron_sets dictionary, so the count is fixed at one."""
+        generate(me_model_config(), tmp_path, db_client=db_client)
+
+        updates = db_client.calls_to("update_entity")
+        assert updates[0].kwargs["attrs_or_entity"] == {"number_neurons": 1}
+
+    def test_the_update_targets_the_simulation_entity(self, circuit_config, tmp_path, db_client):
+        config = circuit_config()
+
+        generate(config, tmp_path, db_client=db_client)
+
+        update = db_client.calls_to("update_entity")[0]
+        assert update.kwargs["entity_id"] == config.single_entity.id
+        assert update.kwargs["entity_type"] is entitysdk.models.Simulation
+
+
+class TestPersistenceOrdering:
+    def test_the_neuron_count_is_recorded_before_the_assets_are_uploaded(
+        self, circuit_config, tmp_path, db_client
+    ):
+        generate(circuit_config(), tmp_path, db_client=db_client)
+
+        methods = [call.method for call in db_client.calls]
+        assert methods[0] == "update_entity"
+        assert set(methods[1:]) == {"upload_file"}
+
+    def test_the_config_is_uploaded_last(self, circuit_config, tmp_path, db_client):
+        """The SONATA config is the completion marker, so it is uploaded after its inputs."""
+        generate(circuit_config(), tmp_path, db_client=db_client)
+
+        assert db_client.uploaded_labels()[-1] == "sonata_simulation_config"
+
+
+class TestSingleEntityRequirement:
+    def test_persisting_without_a_registered_entity_fails(self, circuit_config, tmp_path):
+        """``single_entity`` is populated by the scan before the task runs."""
+        config = circuit_config()
+        coordinate_root = tmp_path / "0"
+        coordinate_root.mkdir(parents=True)
+        config.scan_output_root = tmp_path
+        config.coordinate_output_root = coordinate_root
+
+        with pytest.raises(AttributeError):
+            GenerateSimulationTask(config=config).execute(db_client=FakeDBClient())

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_generation_pipeline.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_generation_pipeline.py
@@ -1,0 +1,253 @@
+"""End-to-end behaviour of ``GenerateSimulationTask.execute``.
+
+These tests pin the observable contract of a generation run: which files land in the coordinate
+output directory, and what the top-level shape of ``simulation_config.json`` is for each family of
+simulation config. They deliberately assert on whole dictionaries rather than individual keys, so
+that a refactor which drops or renames a section fails loudly.
+"""
+
+import json
+
+import pytest
+
+import obi_one as obi
+from obi_one.scientific.tasks.generate_simulations.config.neuron.neuron_circuit import (
+    CircuitSimulationSingleConfig,
+)
+from obi_one.scientific.tasks.generate_simulations.task.task import GenerateSimulationTask
+
+from tests.obi_one.scientific.tasks.simulation_campaign_generation.conftest import (
+    DEFAULT_BIOPHYSICAL_NODE_SET,
+    DEFAULT_POINT_NODE_SET,
+    build_config,
+    generate,
+)
+
+
+class TestGeneratedFiles:
+    def test_minimal_run_writes_config_and_node_sets_only(self, circuit_config, tmp_path):
+        """With no morphology locations and no spike stimuli, only two files are written."""
+        result = generate(circuit_config(), tmp_path)
+
+        assert sorted(p.name for p in result.directory.iterdir()) == [
+            "node_sets.json",
+            "simulation_config.json",
+        ]
+        assert result.sonata_config["node_sets_file"] == "node_sets.json"
+        assert "compartment_sets_file" not in result.sonata_config
+
+    def test_file_names_are_declared_as_class_variables(self):
+        """The task's file names are part of its public contract."""
+        assert GenerateSimulationTask.CONFIG_FILE_NAME == "simulation_config.json"
+        assert GenerateSimulationTask.NODE_SETS_FILE_NAME == "node_sets.json"
+        assert GenerateSimulationTask.COMPARTMENT_SETS_FILE_NAME == "compartment_sets.json"
+
+    def test_generated_config_is_valid_sonata(self, circuit_config, tmp_path):
+        """``write_simulation_config`` validates through libsonata before writing."""
+        result = generate(circuit_config(), tmp_path)
+
+        # If libsonata had rejected the config, no file would exist to read back.
+        assert result.sonata_config["version"] == pytest.approx(2.4)
+        assert json.loads((result.directory / "simulation_config.json").read_text())
+
+    def test_rerunning_into_the_same_directory_is_refused(self, circuit_config, tmp_path):
+        """node_sets.json is written with ``overwrite_if_exists=False``, guarding stale output."""
+        generate(circuit_config(), tmp_path)
+
+        with pytest.raises(ValueError, match=r"node_sets.json' already exists!"):
+            generate(circuit_config(), tmp_path)
+
+
+class TestBaseSonataConfig:
+    """The simulator-independent scaffolding every generated config starts from."""
+
+    def test_circuit_simulation_sections(self, circuit_config, tmp_path):
+        result = generate(
+            circuit_config(
+                initialize={"simulation_length": 250.0, "random_seed": 7, "v_init": -65.0}
+            ),
+            tmp_path,
+        )
+
+        assert result.sonata_config["version"] == pytest.approx(2.4)
+        assert result.sonata_config["target_simulator"] == "NEURON"
+        assert result.sonata_config["run"] == {"dt": 0.025, "random_seed": 7, "tstop": 250.0}
+        assert result.sonata_config["output"] == {
+            "output_dir": "output",
+            "spikes_file": "spikes.h5",
+        }
+
+    def test_circuit_conditions(self, circuit_config, tmp_path):
+        """A circuit simulation adds spike location, calcium and the synapse mechanisms."""
+        result = generate(
+            circuit_config(initialize={"extracellular_calcium_concentration": 1.3}), tmp_path
+        )
+
+        assert result.conditions == {
+            "v_init": -80.0,
+            "spike_location": "soma",
+            "extracellular_calcium": 1.3,
+            "mechanisms": {
+                "ProbAMPANMDA_EMS": {"init_depleted": True, "minis_single_vesicle": True},
+                "ProbGABAAB_EMS": {"init_depleted": True, "minis_single_vesicle": True},
+            },
+        }
+
+    def test_me_model_conditions_have_no_calcium_or_mechanisms(self, me_model_config, tmp_path):
+        """An ME model is a single cell: there are no synapses to configure."""
+        result = generate(me_model_config(), tmp_path)
+
+        assert result.conditions == {"v_init": -80.0, "spike_location": "soma"}
+
+    def test_brian2_conditions_have_no_spike_location(self, brian2_config, tmp_path):
+        """``spike_location`` is added by the NEURON base class, not the Brian2 one."""
+        result = generate(brian2_config(), tmp_path)
+
+        assert result.conditions == {"v_init": -80.0}
+        assert result.sonata_config["target_simulator"] == "Brian2"
+
+    def test_learning_engine_uses_its_own_timestep(self, learning_engine_config, tmp_path):
+        result = generate(learning_engine_config(), tmp_path)
+
+        assert result.sonata_config["target_simulator"] == "LearningEngine"
+        assert result.sonata_config["run"]["dt"] == pytest.approx(0.1)
+
+
+class TestConfigFamilies:
+    """Each simulation config family produces its own recognisable output."""
+
+    def test_circuit_simulation_full_config(self, circuit_config, circuit, tmp_path):
+        result = generate(circuit_config(), tmp_path)
+
+        assert result.sonata_config == {
+            "version": 2.4,
+            "target_simulator": "NEURON",
+            "run": {"dt": 0.025, "random_seed": 1, "tstop": 100.0},
+            "conditions": {
+                "v_init": -80.0,
+                "spike_location": "soma",
+                "extracellular_calcium": 1.1,
+                "mechanisms": {
+                    "ProbAMPANMDA_EMS": {"init_depleted": True, "minis_single_vesicle": True},
+                    "ProbGABAAB_EMS": {"init_depleted": True, "minis_single_vesicle": True},
+                },
+            },
+            "output": {"output_dir": "output", "spikes_file": "spikes.h5"},
+            "network": str(circuit.path),
+            "node_set": DEFAULT_BIOPHYSICAL_NODE_SET,
+            "inputs": {},
+            "reports": {},
+            "node_sets_file": "node_sets.json",
+        }
+
+    def test_me_model_full_config(self, me_model_config, me_model_circuit, tmp_path):
+        result = generate(me_model_config(), tmp_path)
+
+        assert result.sonata_config == {
+            "version": 2.4,
+            "target_simulator": "NEURON",
+            "run": {"dt": 0.025, "random_seed": 1, "tstop": 100.0},
+            "conditions": {"v_init": -80.0, "spike_location": "soma"},
+            "output": {"output_dir": "output", "spikes_file": "spikes.h5"},
+            "network": str(me_model_circuit.path),
+            "node_set": DEFAULT_BIOPHYSICAL_NODE_SET,
+            "inputs": {},
+            "reports": {},
+            "node_sets_file": "node_sets.json",
+        }
+
+    def test_me_model_with_synapses_matches_circuit_shape(
+        self, me_model_with_synapses_config, tmp_path
+    ):
+        """The with-synapses config derives from the circuit config, so it keeps the mechanisms."""
+        result = generate(me_model_with_synapses_config(), tmp_path)
+
+        assert result.conditions["extracellular_calcium"] == pytest.approx(1.1)
+        assert set(result.conditions["mechanisms"]) == {"ProbAMPANMDA_EMS", "ProbGABAAB_EMS"}
+        assert result.sonata_config["node_set"] == DEFAULT_BIOPHYSICAL_NODE_SET
+
+    def test_brian2_full_config(self, brian2_config, point_circuit, tmp_path):
+        result = generate(brian2_config(), tmp_path)
+
+        assert result.sonata_config == {
+            "version": 2.4,
+            "target_simulator": "Brian2",
+            "run": {"dt": 0.025, "random_seed": 1, "tstop": 100.0},
+            "conditions": {"v_init": -80.0},
+            "output": {"output_dir": "output", "spikes_file": "spikes.h5"},
+            "network": str(point_circuit.path),
+            "node_set": DEFAULT_POINT_NODE_SET,
+            "inputs": {},
+            "reports": {},
+            "node_sets_file": "node_sets.json",
+        }
+
+    def test_learning_engine_full_config(self, learning_engine_config, point_circuit, tmp_path):
+        result = generate(learning_engine_config(), tmp_path)
+
+        assert result.sonata_config == {
+            "version": 2.4,
+            "target_simulator": "LearningEngine",
+            "run": {"dt": 0.1, "random_seed": 1, "tstop": 100.0},
+            "conditions": {"v_init": -80.0},
+            "output": {"output_dir": "output", "spikes_file": "spikes.h5"},
+            "network": str(point_circuit.path),
+            "node_set": DEFAULT_POINT_NODE_SET,
+            "inputs": {},
+            "reports": {},
+            "node_sets_file": "node_sets.json",
+        }
+
+
+class TestStepOrdering:
+    """``execute`` depends on its steps running in a particular order.
+
+    These are the couplings a refactor is most likely to break, so they are asserted through
+    observable output rather than by spying on the private methods.
+    """
+
+    def test_default_neuron_set_is_injected_before_node_sets_are_written(
+        self, circuit_config, tmp_path
+    ):
+        """Resolving the simulation target adds a neuron set that must reach node_sets.json."""
+        config = circuit_config()
+        assert config.neuron_sets == {}
+
+        result = generate(config, tmp_path)
+
+        assert DEFAULT_BIOPHYSICAL_NODE_SET in config.neuron_sets
+        assert DEFAULT_BIOPHYSICAL_NODE_SET in result.node_sets
+
+    def test_locations_are_materialised_before_inputs_are_built(self, morphology_circuit, tmp_path):
+        """The stimulus only knows its compartment set because materialisation ran first."""
+        locations = obi.RandomMorphologyLocations(random_seed=0, number_of_locations=2)
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=morphology_circuit,
+            blocks={
+                "ClampLocations": locations,
+                "Clamp": lambda: obi.ConstantCurrentClampSomaticStimulus(neuron_set=locations.ref),
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.inputs["Clamp_0"]["compartment_set"] == "ClampLocations"
+        assert result.sonata_config["compartment_sets_file"] == "compartment_sets.json"
+
+    def test_the_simulation_target_is_resolved_before_the_blocks_that_default_to_it(
+        self, circuit, tmp_path
+    ):
+        """``initialize.node_set`` is filled in first, so an untargeted recording inherits the
+        same default rather than a second, differently-named one."""
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={"Voltage": obi.SomaVoltageRecording()},
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.sonata_config["node_set"] == DEFAULT_BIOPHYSICAL_NODE_SET
+        assert result.reports["Voltage"]["cells"] == DEFAULT_BIOPHYSICAL_NODE_SET
+        assert len(config.neuron_sets) == 1

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_manipulations.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_manipulations.py
@@ -1,0 +1,372 @@
+"""How manipulation blocks reach the generated SONATA config.
+
+Synaptic manipulations become ``connection_overrides``; neuronal manipulations split between
+``conditions.modifications`` (RANGE variables) and ``conditions.mechanisms`` (GLOBAL variables).
+The split, the merge into pre-existing mechanisms, and the list ordering are all the task's
+responsibility rather than the blocks'.
+"""
+
+import inspect
+import typing
+
+import pytest
+
+import obi_one as obi
+from obi_one.scientific.blocks.neuron_sets.id import BiophysicalPopulationIDNeuronSet
+from obi_one.scientific.blocks.neuronal_manipulations.neuronal_manipulations import (
+    ByNeuronMechanismVariableNeuronalManipulation,
+    ByNeuronModification,
+    BySectionListMechanismVariableNeuronalManipulation,
+    BySectionListModification,
+)
+from obi_one.scientific.tasks.generate_simulations.config.neuron.neuron_circuit import (
+    CircuitSimulationSingleConfig,
+)
+from obi_one.scientific.unions_and_references.manipulations import SynapticManipulationsUnion
+from obi_one.scientific.unions_and_references.neuronal_manipulations import (
+    NeuronalManipulationReference,
+    NeuronalManipulationUnion,
+)
+
+from tests.obi_one.scientific.tasks.simulation_campaign_generation.conftest import (
+    BIOPHYSICAL_POPULATION,
+    DEFAULT_BIOPHYSICAL_NODE_SET,
+    build_config,
+    generate,
+)
+
+SYNAPTIC_MANIPULATIONS = {
+    "SynapticMgManipulation": obi.SynapticMgManipulation(magnesium_value=2.4),
+    "ScaleAcetylcholineUSESynapticManipulation": obi.ScaleAcetylcholineUSESynapticManipulation(
+        use_scaling=0.7
+    ),
+    "ConnectSynapticManipulation": obi.ConnectSynapticManipulation(),
+    "DisconnectSynapticManipulation": obi.DisconnectSynapticManipulation(),
+}
+
+
+def _union_member_names(union) -> set[str]:
+    inner = typing.get_args(union)[0]
+    if inspect.isclass(inner):
+        return {inner.__name__}
+    return {cls.__name__ for cls in typing.get_args(inner) if inspect.isclass(cls)}
+
+
+class TestUnionCoverage:
+    def test_every_synaptic_manipulation_is_exercised(self):
+        assert _union_member_names(SynapticManipulationsUnion) == set(SYNAPTIC_MANIPULATIONS)
+
+    def test_every_neuronal_manipulation_is_exercised(self):
+        assert _union_member_names(NeuronalManipulationUnion) == {
+            "BySectionListMechanismVariableNeuronalManipulation",
+            "ByNeuronMechanismVariableNeuronalManipulation",
+        }
+
+
+class TestSynapticManipulations:
+    def test_no_manipulations_means_no_connection_overrides_key(self, circuit_config, tmp_path):
+        result = generate(circuit_config(), tmp_path)
+
+        assert "connection_overrides" not in result.sonata_config
+
+    def test_magnesium_manipulation(self, circuit, tmp_path):
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={"Magnesium": obi.SynapticMgManipulation(magnesium_value=2.4)},
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.sonata_config["connection_overrides"] == [
+            {
+                "name": "Magnesium",
+                "source": DEFAULT_BIOPHYSICAL_NODE_SET,
+                "target": DEFAULT_BIOPHYSICAL_NODE_SET,
+                "modoverride": "GluSynapse",
+                "synapse_configure": "mg = 2.4",
+            }
+        ]
+
+    def test_acetylcholine_use_scaling(self, circuit, tmp_path):
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "Acetylcholine": obi.ScaleAcetylcholineUSESynapticManipulation(use_scaling=0.5)
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.sonata_config["connection_overrides"] == [
+            {
+                "name": "Acetylcholine",
+                "source": DEFAULT_BIOPHYSICAL_NODE_SET,
+                "target": DEFAULT_BIOPHYSICAL_NODE_SET,
+                "synapse_configure": "%s.Use *= 0.5",
+            }
+        ]
+
+    def test_connect_and_disconnect_emit_weighted_overrides(self, circuit, tmp_path):
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "Disconnect": obi.DisconnectSynapticManipulation(),
+                "Connect": obi.ConnectSynapticManipulation(),
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        overrides = result.sonata_config["connection_overrides"]
+        weights = {override["name"]: override.get("weight") for override in overrides}
+        assert weights["Disconnect"] == pytest.approx(0.0)
+        assert weights["Connect"] == pytest.approx(1.0)
+
+    def test_pre_and_post_synaptic_targets_are_honoured(self, circuit, tmp_path):
+        presynaptic = BiophysicalPopulationIDNeuronSet(
+            population=BIOPHYSICAL_POPULATION,
+            neuron_ids=obi.NamedTuple(name="pre", elements=[0, 1]),
+        )
+        postsynaptic = BiophysicalPopulationIDNeuronSet(
+            population=BIOPHYSICAL_POPULATION,
+            neuron_ids=obi.NamedTuple(name="post", elements=[2, 3]),
+        )
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "Pre": presynaptic,
+                "Post": postsynaptic,
+                "Magnesium": lambda: obi.SynapticMgManipulation(
+                    magnesium_value=2.0,
+                    presynaptic_neuron_set=presynaptic.ref,
+                    postsynaptic_neuron_set=postsynaptic.ref,
+                ),
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        override = result.sonata_config["connection_overrides"][0]
+        assert override["source"] == "Pre"
+        assert override["target"] == "Post"
+
+    def test_manipulations_keep_their_dictionary_order(self, circuit, tmp_path):
+        """SONATA applies connection overrides in order, so the config order must survive."""
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "Acetylcholine": obi.ScaleAcetylcholineUSESynapticManipulation(use_scaling=0.5),
+                "Magnesium": obi.SynapticMgManipulation(magnesium_value=2.0),
+                "Disconnect": obi.DisconnectSynapticManipulation(),
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        names = [override["name"] for override in result.sonata_config["connection_overrides"]]
+        assert names == ["Acetylcholine", "Magnesium", "Disconnect"]
+
+
+class TestNeuronalManipulations:
+    """Neuronal manipulations live on the ME model config."""
+
+    @staticmethod
+    def _config(me_model_config, manipulations):
+        return me_model_config(blocks=manipulations)
+
+    def test_no_manipulations_leaves_conditions_untouched(self, me_model_config, tmp_path):
+        result = generate(me_model_config(), tmp_path)
+
+        assert "modifications" not in result.conditions
+        assert "mechanisms" not in result.conditions
+
+    def test_neuronal_manipulations_can_be_added_through_the_reference_api(self, me_model_config):
+        """``NeuronalManipulationReference`` is registered, so ``ScanConfig.add`` routes a
+        neuronal manipulation into the right block dictionary."""
+        config = me_model_config()
+        manipulation = ByNeuronMechanismVariableNeuronalManipulation(
+            modification=ByNeuronModification(variable_name="cm", new_value=1.0)
+        )
+
+        config.add(manipulation, name="Capacitance")
+
+        assert config.neuronal_manipulations == {"Capacitance": manipulation}
+        assert isinstance(manipulation.ref, NeuronalManipulationReference)
+        assert manipulation.ref.block_dict_name == "neuronal_manipulations"
+
+    def test_range_variables_become_condition_modifications(self, me_model_config, tmp_path):
+        config = self._config(
+            me_model_config,
+            {
+                "Capacitance": BySectionListMechanismVariableNeuronalManipulation(
+                    modification=BySectionListModification(
+                        variable_name="cm",
+                        section_list_modifications={"somatic": 1.5},
+                    )
+                )
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.conditions["modifications"] == [
+            {
+                "name": "modify_cm_somatic",
+                "node_set": DEFAULT_BIOPHYSICAL_NODE_SET,
+                "type": "section_list",
+                "section_configure": "somatic.cm = 1.5",
+            }
+        ]
+        assert "mechanisms" not in result.conditions
+
+    def test_a_section_list_modification_expands_per_section_list(self, me_model_config, tmp_path):
+        config = self._config(
+            me_model_config,
+            {
+                "Capacitance": BySectionListMechanismVariableNeuronalManipulation(
+                    modification=BySectionListModification(
+                        variable_name="cm",
+                        section_list_modifications={"somatic": 1.0, "axonal": 2.0},
+                    )
+                )
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        names = [entry["name"] for entry in result.conditions["modifications"]]
+        assert names == ["modify_cm_somatic", "modify_cm_axonal"]
+
+    def test_global_variables_become_condition_mechanisms(self, me_model_config, tmp_path):
+        config = self._config(
+            me_model_config,
+            {
+                "ChannelGlobal": ByNeuronMechanismVariableNeuronalManipulation(
+                    modification=ByNeuronModification(
+                        channel_name="StochKv3",
+                        variable_name="vmin_StochKv3",
+                        variable_type="GLOBAL",
+                        new_value=0.5,
+                    )
+                )
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.conditions["mechanisms"] == {"StochKv3": {"vmin_StochKv3": 0.5}}
+        assert "modifications" not in result.conditions
+
+    def test_global_variables_for_one_channel_are_merged(self, me_model_config, tmp_path):
+        config = self._config(
+            me_model_config,
+            {
+                "First": ByNeuronMechanismVariableNeuronalManipulation(
+                    modification=ByNeuronModification(
+                        channel_name="StochKv3",
+                        variable_name="vmin_StochKv3",
+                        variable_type="GLOBAL",
+                        new_value=0.5,
+                    )
+                ),
+                "Second": ByNeuronMechanismVariableNeuronalManipulation(
+                    modification=ByNeuronModification(
+                        channel_name="StochKv3",
+                        variable_name="vmax_StochKv3",
+                        variable_type="GLOBAL",
+                        new_value=1.5,
+                    )
+                ),
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.conditions["mechanisms"] == {
+            "StochKv3": {"vmin_StochKv3": 0.5, "vmax_StochKv3": 1.5}
+        }
+
+    def test_by_neuron_range_variables_configure_all_sections(self, me_model_config, tmp_path):
+        config = self._config(
+            me_model_config,
+            {
+                "Resistance": ByNeuronMechanismVariableNeuronalManipulation(
+                    modification=ByNeuronModification(
+                        variable_name="Ra",
+                        variable_type="RANGE",
+                        new_value=120.0,
+                    )
+                )
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.conditions["modifications"] == [
+            {
+                "name": "modify_Ra_all",
+                "node_set": DEFAULT_BIOPHYSICAL_NODE_SET,
+                "type": "configure_all_sections",
+                "section_configure": "%s.Ra = 120.0",
+            }
+        ]
+
+    def test_range_and_global_manipulations_coexist(self, me_model_config, tmp_path):
+        config = self._config(
+            me_model_config,
+            {
+                "Range": ByNeuronMechanismVariableNeuronalManipulation(
+                    modification=ByNeuronModification(
+                        variable_name="Ra", variable_type="RANGE", new_value=100.0
+                    )
+                ),
+                "Global": ByNeuronMechanismVariableNeuronalManipulation(
+                    modification=ByNeuronModification(
+                        channel_name="StochKv3",
+                        variable_name="vmin_StochKv3",
+                        variable_type="GLOBAL",
+                        new_value=0.5,
+                    )
+                ),
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert len(result.conditions["modifications"]) == 1
+        assert result.conditions["mechanisms"] == {"StochKv3": {"vmin_StochKv3": 0.5}}
+
+    def test_a_manipulation_without_a_new_value_contributes_nothing(
+        self, me_model_config, tmp_path
+    ):
+        config = self._config(
+            me_model_config,
+            {
+                "Unset": ByNeuronMechanismVariableNeuronalManipulation(
+                    modification=ByNeuronModification(
+                        channel_name="StochKv3",
+                        variable_name="vmin_StochKv3",
+                        variable_type="GLOBAL",
+                        new_value=None,
+                    )
+                )
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert "modifications" not in result.conditions
+        assert "mechanisms" not in result.conditions
+
+    def test_a_circuit_config_keeps_its_synapse_mechanisms(
+        self, me_model_with_synapses_config, tmp_path
+    ):
+        """A circuit-derived config already has ``conditions.mechanisms`` from the base config."""
+        result = generate(me_model_with_synapses_config(), tmp_path)
+
+        assert set(result.conditions["mechanisms"]) == {"ProbAMPANMDA_EMS", "ProbGABAAB_EMS"}

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_manipulations.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_manipulations.py
@@ -6,9 +6,6 @@ The split, the merge into pre-existing mechanisms, and the list ordering are all
 responsibility rather than the blocks'.
 """
 
-import inspect
-import typing
-
 import pytest
 
 import obi_one as obi
@@ -33,6 +30,7 @@ from tests.obi_one.scientific.tasks.simulation_campaign_generation.conftest impo
     DEFAULT_BIOPHYSICAL_NODE_SET,
     build_config,
     generate,
+    union_member_names,
 )
 
 SYNAPTIC_MANIPULATIONS = {
@@ -45,19 +43,12 @@ SYNAPTIC_MANIPULATIONS = {
 }
 
 
-def _union_member_names(union) -> set[str]:
-    inner = typing.get_args(union)[0]
-    if inspect.isclass(inner):
-        return {inner.__name__}
-    return {cls.__name__ for cls in typing.get_args(inner) if inspect.isclass(cls)}
-
-
 class TestUnionCoverage:
     def test_every_synaptic_manipulation_is_exercised(self):
-        assert _union_member_names(SynapticManipulationsUnion) == set(SYNAPTIC_MANIPULATIONS)
+        assert union_member_names(SynapticManipulationsUnion) == set(SYNAPTIC_MANIPULATIONS)
 
     def test_every_neuronal_manipulation_is_exercised(self):
-        assert _union_member_names(NeuronalManipulationUnion) == {
+        assert union_member_names(NeuronalManipulationUnion) == {
             "BySectionListMechanismVariableNeuronalManipulation",
             "ByNeuronMechanismVariableNeuronalManipulation",
         }

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_morphology_locations.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_morphology_locations.py
@@ -6,9 +6,6 @@ materialises the locations against the circuit's morphologies, writes them to
 name instead of carrying a node set.
 """
 
-import inspect
-import typing
-
 import pytest
 
 import obi_one as obi
@@ -26,6 +23,7 @@ from tests.obi_one.scientific.tasks.simulation_campaign_generation.conftest impo
     DEFAULT_BIOPHYSICAL_NODE_SET,
     build_config,
     generate,
+    union_member_names,
 )
 
 MORPHOLOGY_POPULATION = "S1nonbarrel_neurons"
@@ -46,13 +44,6 @@ MORPHOLOGY_LOCATIONS = {
 }
 
 
-def _union_member_names(union) -> set[str]:
-    inner = typing.get_args(union)[0]
-    if inspect.isclass(inner):
-        return {inner.__name__}
-    return {cls.__name__ for cls in typing.get_args(inner) if inspect.isclass(cls)}
-
-
 def _locations_config(circuit, locations, *, neuron_set=None, name="Locations"):
     blocks: dict = {}
     if neuron_set is not None:
@@ -66,7 +57,7 @@ def _locations_config(circuit, locations, *, neuron_set=None, name="Locations"):
 
 class TestUnionCoverage:
     def test_every_selectable_morphology_location_block_is_exercised(self):
-        assert _union_member_names(MorphologyLocationUnion) == set(MORPHOLOGY_LOCATIONS)
+        assert union_member_names(MorphologyLocationUnion) == set(MORPHOLOGY_LOCATIONS)
 
 
 class TestCompartmentSetGeneration:

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_morphology_locations.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_morphology_locations.py
@@ -1,0 +1,279 @@
+"""How morphology location blocks become SONATA compartment sets.
+
+A stimulus can target a ``MorphologyLocations`` block instead of a neuron set. The task then
+materialises the locations against the circuit's morphologies, writes them to
+``compartment_sets.json``, and rewrites the stimulus input to reference the compartment set by
+name instead of carrying a node set.
+"""
+
+import inspect
+import typing
+
+import pytest
+
+import obi_one as obi
+from obi_one.core.exception import OBIONEError
+from obi_one.scientific.blocks.neuron_sets.id import BiophysicalPopulationIDNeuronSet
+from obi_one.scientific.tasks.generate_simulations.config.neuron.neuron_circuit import (
+    CircuitSimulationSingleConfig,
+)
+from obi_one.scientific.tasks.generate_simulations.task.task import GenerateSimulationTask
+from obi_one.scientific.unions_and_references.morphology_locations import (
+    MorphologyLocationUnion,
+)
+
+from tests.obi_one.scientific.tasks.simulation_campaign_generation.conftest import (
+    DEFAULT_BIOPHYSICAL_NODE_SET,
+    build_config,
+    generate,
+)
+
+MORPHOLOGY_POPULATION = "S1nonbarrel_neurons"
+
+MORPHOLOGY_LOCATIONS = {
+    "RandomMorphologyLocations": obi.RandomMorphologyLocations(
+        random_seed=0, number_of_locations=3
+    ),
+    "ClusteredMorphologyLocations": obi.ClusteredMorphologyLocations(
+        random_seed=0, number_of_locations=4, n_clusters=2
+    ),
+    "PathDistanceMorphologyLocations": obi.PathDistanceMorphologyLocations(
+        random_seed=0, number_of_locations=3
+    ),
+    "ClusteredPathDistanceMorphologyLocations": obi.ClusteredPathDistanceMorphologyLocations(
+        random_seed=0, number_of_locations=4, n_clusters=2
+    ),
+}
+
+
+def _union_member_names(union) -> set[str]:
+    inner = typing.get_args(union)[0]
+    if inspect.isclass(inner):
+        return {inner.__name__}
+    return {cls.__name__ for cls in typing.get_args(inner) if inspect.isclass(cls)}
+
+
+def _locations_config(circuit, locations, *, neuron_set=None, name="Locations"):
+    blocks: dict = {}
+    if neuron_set is not None:
+        blocks["Cell"] = neuron_set
+    blocks[name] = locations
+    blocks["Clamp"] = lambda: obi.ConstantCurrentClampSomaticStimulus(
+        neuron_set=locations.ref, amplitude=0.2, duration=50.0
+    )
+    return build_config(CircuitSimulationSingleConfig, circuit=circuit, blocks=blocks)
+
+
+class TestUnionCoverage:
+    def test_every_selectable_morphology_location_block_is_exercised(self):
+        assert _union_member_names(MorphologyLocationUnion) == set(MORPHOLOGY_LOCATIONS)
+
+
+class TestCompartmentSetGeneration:
+    @pytest.mark.parametrize("name", sorted(MORPHOLOGY_LOCATIONS))
+    def test_each_location_block_materialises(self, name, morphology_circuit, tmp_path):
+        locations = MORPHOLOGY_LOCATIONS[name].model_copy(deep=True)
+        config = _locations_config(morphology_circuit, locations)
+
+        result = generate(config, tmp_path)
+
+        assert set(result.compartment_sets) == {"Locations"}
+        assert result.compartment_sets["Locations"]["population"] == MORPHOLOGY_POPULATION
+        assert len(result.compartment_sets["Locations"]["compartment_set"]) > 0
+
+    def test_compartment_set_file_is_written_and_referenced(self, morphology_circuit, tmp_path):
+        config = _locations_config(
+            morphology_circuit,
+            obi.RandomMorphologyLocations(random_seed=0, number_of_locations=2),
+        )
+
+        result = generate(config, tmp_path)
+
+        assert (result.directory / "compartment_sets.json").exists()
+        assert result.sonata_config["compartment_sets_file"] == "compartment_sets.json"
+
+    def test_rows_are_node_id_section_id_offset_triples(self, morphology_circuit, tmp_path):
+        config = _locations_config(
+            morphology_circuit,
+            obi.RandomMorphologyLocations(random_seed=0, number_of_locations=5),
+        )
+
+        result = generate(config, tmp_path)
+
+        for node_id, section_id, offset in result.compartment_sets["Locations"]["compartment_set"]:
+            assert isinstance(node_id, int)
+            assert isinstance(section_id, int)
+            assert 0.0 <= offset <= 1.0
+
+    def test_rows_are_sorted_and_deduplicated(self, morphology_circuit, tmp_path):
+        """``to_sonata_dict`` emits canonical SONATA order, not generation order."""
+        config = _locations_config(
+            morphology_circuit,
+            obi.RandomMorphologyLocations(random_seed=0, number_of_locations=8),
+        )
+
+        result = generate(config, tmp_path)
+
+        rows = [tuple(row) for row in result.compartment_sets["Locations"]["compartment_set"]]
+        assert rows == sorted(rows)
+        assert len(rows) == len(set(rows))
+
+    def test_no_locations_means_no_compartment_sets_file(self, circuit_config, tmp_path):
+        result = generate(circuit_config(), tmp_path)
+
+        assert result.compartment_sets is None
+        assert "compartment_sets_file" not in result.sonata_config
+
+    def test_an_unreferenced_location_block_is_not_materialised(self, morphology_circuit, tmp_path):
+        """Only locations a stimulus actually targets become compartment sets."""
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=morphology_circuit,
+            blocks={"Unused": obi.RandomMorphologyLocations(random_seed=0, number_of_locations=2)},
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.compartment_sets is None
+
+
+class TestStimulusRewriting:
+    def test_the_stimulus_targets_the_compartment_set(self, morphology_circuit, tmp_path):
+        config = _locations_config(
+            morphology_circuit,
+            obi.RandomMorphologyLocations(random_seed=0, number_of_locations=2),
+        )
+
+        result = generate(config, tmp_path)
+
+        entry = result.inputs["Clamp_0"]
+        assert entry["compartment_set"] == "Locations"
+        assert "node_set" not in entry
+        assert "locations" not in entry
+
+    def test_two_stimuli_sharing_a_location_block_share_one_compartment_set(
+        self, morphology_circuit, tmp_path
+    ):
+        locations = obi.RandomMorphologyLocations(random_seed=0, number_of_locations=2)
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=morphology_circuit,
+            blocks={
+                "Locations": locations,
+                "First": lambda: obi.ConstantCurrentClampSomaticStimulus(
+                    neuron_set=locations.ref, amplitude=0.1
+                ),
+                "Second": lambda: obi.ConstantCurrentClampSomaticStimulus(
+                    neuron_set=locations.ref, amplitude=0.2
+                ),
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert set(result.compartment_sets) == {"Locations"}
+        assert result.inputs["First_0"]["compartment_set"] == "Locations"
+        assert result.inputs["Second_0"]["compartment_set"] == "Locations"
+
+    def test_a_location_targeting_stimulus_coexists_with_a_neuron_set_one(
+        self, morphology_circuit, tmp_path
+    ):
+        locations = obi.RandomMorphologyLocations(random_seed=0, number_of_locations=2)
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=morphology_circuit,
+            blocks={
+                "Locations": locations,
+                "OnLocations": lambda: obi.ConstantCurrentClampSomaticStimulus(
+                    neuron_set=locations.ref
+                ),
+                "OnSoma": obi.ConstantCurrentClampSomaticStimulus(),
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.inputs["OnLocations_0"]["compartment_set"] == "Locations"
+        assert result.inputs["OnSoma_0"]["node_set"] == DEFAULT_BIOPHYSICAL_NODE_SET
+
+
+class TestLocationTargeting:
+    def test_locations_without_a_neuron_set_use_the_default(self, morphology_circuit, tmp_path):
+        locations = obi.RandomMorphologyLocations(random_seed=0, number_of_locations=2)
+        assert locations.neuron_set is None
+        config = _locations_config(morphology_circuit, locations)
+
+        generate(config, tmp_path)
+
+        assert config.morphology_locations["Locations"].neuron_set.block_name == (
+            DEFAULT_BIOPHYSICAL_NODE_SET
+        )
+
+    def test_an_explicit_neuron_set_restricts_the_materialised_cells(
+        self, morphology_circuit, tmp_path
+    ):
+        cell = BiophysicalPopulationIDNeuronSet(
+            population=MORPHOLOGY_POPULATION,
+            neuron_ids=obi.NamedTuple(name="one_cell", elements=[0]),
+        )
+        built: dict = {}
+
+        def _locations():
+            built["locations"] = obi.RandomMorphologyLocations(
+                random_seed=0, number_of_locations=3, neuron_set=cell.ref
+            )
+            return built["locations"]
+
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=morphology_circuit,
+            blocks={
+                "Cell": cell,
+                "Locations": _locations,
+                "Clamp": lambda: obi.ConstantCurrentClampSomaticStimulus(
+                    neuron_set=built["locations"].ref
+                ),
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        node_ids = {row[0] for row in result.compartment_sets["Locations"]["compartment_set"]}
+        assert node_ids == {0}
+
+    def test_section_types_restrict_where_locations_are_placed(self, morphology_circuit, tmp_path):
+        """Section types 3 and 4 are basal and apical dendrite; the soma (1) is excluded."""
+        config = _locations_config(
+            morphology_circuit,
+            obi.RandomMorphologyLocations(random_seed=0, number_of_locations=4, section_types=(3,)),
+        )
+
+        result = generate(config, tmp_path)
+
+        assert len(result.compartment_sets["Locations"]["compartment_set"]) > 0
+
+
+class TestCompartmentSetErrors:
+    def test_materialising_before_the_circuit_is_resolved_is_refused(self, circuit_config):
+        task = GenerateSimulationTask(config=circuit_config())
+
+        with pytest.raises(OBIONEError, match="Circuit must be resolved before materializing"):
+            task._materialize_location_targets()
+
+    def test_a_renamed_compartment_set_is_refused(self, morphology_circuit, tmp_path):
+        config = _locations_config(
+            morphology_circuit,
+            obi.RandomMorphologyLocations(random_seed=0, number_of_locations=2),
+        )
+        coordinate_root = tmp_path / "0"
+        coordinate_root.mkdir(parents=True)
+        config.scan_output_root = tmp_path
+        config.coordinate_output_root = coordinate_root
+
+        task = GenerateSimulationTask(config=config)
+        task.execute()
+        renamed = next(iter(task._materialized_compartment_sets.values()))
+        task._materialized_compartment_sets = {"Mismatched": renamed}
+
+        with pytest.raises(OBIONEError, match="Materialized compartment set name mismatch"):
+            task._write_materialized_compartment_sets_file()

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_neuron_sets.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_neuron_sets.py
@@ -1,0 +1,681 @@
+"""How neuron set blocks reach the generated ``node_sets.json``.
+
+Two things are covered here. First, every neuron set type accepted by a simulation config
+resolves into a node set definition under the key it was registered with. Second, the rules the
+task applies when a neuron set reference is left unset -- which default gets injected, and when
+that is an error.
+"""
+
+import inspect
+import typing
+
+import pytest
+
+import obi_one as obi
+from obi_one.core.exception import OBIONEError
+from obi_one.scientific.blocks.neuron_sets.combined import SetOperation
+from obi_one.scientific.blocks.neuron_sets.deprecated import AllNeurons
+from obi_one.scientific.blocks.neuron_sets.id import (
+    BiophysicalPopulationIDNeuronSet,
+    PointPopulationIDNeuronSet,
+    VirtualPopulationIDNeuronSet,
+)
+from obi_one.scientific.blocks.neuron_sets.population import (
+    BiophysicalPopulationNeuronSet,
+    PointPopulationNeuronSet,
+    VirtualPopulationNeuronSet,
+)
+from obi_one.scientific.blocks.neuron_sets.predefined import (
+    BiophysicalPopulationPredefinedNeuronSet,
+    PointPopulationPredefinedNeuronSet,
+    VirtualPopulationPredefinedNeuronSet,
+)
+from obi_one.scientific.blocks.neuron_sets.property import (
+    BiophysicalPopulationPropertyNeuronSet,
+    NeuronPropertyFilter,
+    PointPopulationPropertyNeuronSet,
+    VirtualPopulationPropertyNeuronSet,
+)
+from obi_one.scientific.blocks.neuron_sets.specific import (
+    AllBiophysicalNeurons,
+    AllPointNeurons,
+    AllVirtualNeurons,
+)
+from obi_one.scientific.tasks.generate_simulations.config.brian2.brian2_circuit import (
+    Brian2CircuitSimulationSingleConfig,
+)
+from obi_one.scientific.tasks.generate_simulations.config.learning_engine.le_circuit import (
+    LearningEngineCircuitSimulationSingleConfig,
+)
+from obi_one.scientific.tasks.generate_simulations.config.neuron.neuron_circuit import (
+    CircuitSimulationSingleConfig,
+)
+from obi_one.scientific.tasks.generate_simulations.task.task import GenerateSimulationTask
+from obi_one.scientific.unions_and_references.combined_neuron_sets import (
+    NEURONSimulationNeuronSetUnion,
+)
+from obi_one.scientific.unions_and_references.neuron_sets import (
+    BiophysicalNeuronSetReference,
+    PointNeuronSetReference,
+    VirtualNeuronSetReference,
+)
+
+from tests.obi_one.scientific.tasks.simulation_campaign_generation.conftest import (
+    BIOPHYSICAL_POPULATION,
+    DEFAULT_BIOPHYSICAL_NODE_SET,
+    DEFAULT_POINT_NODE_SET,
+    DEFAULT_VIRTUAL_NODE_SET,
+    POINT_POPULATION,
+    VIRTUAL_POPULATION,
+    build_config,
+    generate,
+)
+
+
+def _union_member_names(union) -> set[str]:
+    """The class names a discriminated block union accepts."""
+    inner = typing.get_args(union)[0]
+    return {cls.__name__ for cls in typing.get_args(inner) if inspect.isclass(cls)}
+
+
+# One constructible instance per neuron set type in NEURONSimulationNeuronSetUnion. Combined sets
+# are exercised separately because they need references to other sets, and the deprecated sets
+# have their own test because they refuse to resolve at all.
+BIOPHYSICAL_NEURON_SETS = {
+    "AllBiophysicalNeurons": AllBiophysicalNeurons(),
+    "BiophysicalPopulationNeuronSet": BiophysicalPopulationNeuronSet(
+        population=BIOPHYSICAL_POPULATION,
+    ),
+    "BiophysicalPopulationIDNeuronSet": BiophysicalPopulationIDNeuronSet(
+        population=BIOPHYSICAL_POPULATION,
+        neuron_ids=obi.NamedTuple(name="ids", elements=[0, 1]),
+    ),
+    "BiophysicalPopulationPredefinedNeuronSet": BiophysicalPopulationPredefinedNeuronSet(
+        population=BIOPHYSICAL_POPULATION,
+        node_set="Excitatory",
+    ),
+    "BiophysicalPopulationPropertyNeuronSet": BiophysicalPopulationPropertyNeuronSet(
+        population=BIOPHYSICAL_POPULATION,
+        property_filter=NeuronPropertyFilter(filter_dict={"synapse_class": ["EXC"]}),
+    ),
+}
+
+VIRTUAL_NEURON_SETS = {
+    "VirtualPopulationNeuronSet": VirtualPopulationNeuronSet(population=VIRTUAL_POPULATION),
+    "VirtualPopulationIDNeuronSet": VirtualPopulationIDNeuronSet(
+        population=VIRTUAL_POPULATION,
+        neuron_ids=obi.NamedTuple(name="ids", elements=[0, 1, 2]),
+    ),
+    "VirtualPopulationPredefinedNeuronSet": VirtualPopulationPredefinedNeuronSet(
+        population=VIRTUAL_POPULATION,
+        node_set="proj_Thalamocortical_VPM_Source",
+    ),
+    "VirtualPopulationPropertyNeuronSet": VirtualPopulationPropertyNeuronSet(
+        population=VIRTUAL_POPULATION,
+        property_filter=NeuronPropertyFilter(filter_dict={"model_type": ["virtual"]}),
+    ),
+}
+
+POINT_NEURON_SETS = {
+    "AllPointNeurons": AllPointNeurons(),
+    "PointPopulationNeuronSet": PointPopulationNeuronSet(population=POINT_POPULATION),
+    "PointPopulationIDNeuronSet": PointPopulationIDNeuronSet(
+        population=POINT_POPULATION,
+        neuron_ids=obi.NamedTuple(name="ids", elements=[0, 1]),
+    ),
+    "PointPopulationPredefinedNeuronSet": PointPopulationPredefinedNeuronSet(
+        population=POINT_POPULATION,
+        node_set="sugar",
+    ),
+    "PointPopulationPropertyNeuronSet": PointPopulationPropertyNeuronSet(
+        population=POINT_POPULATION,
+        property_filter=NeuronPropertyFilter(filter_dict={"model_type": ["brian2_point"]}),
+    ),
+}
+
+# Kept for backwards compatibility with stored configs; every resolution method raises.
+DEPRECATED_NEURON_SETS = {
+    "AllNeurons": AllNeurons(),
+    "ExcitatoryNeurons": obi.ExcitatoryNeurons(),
+    "InhibitoryNeurons": obi.InhibitoryNeurons(),
+    "IDNeuronSet": obi.IDNeuronSet(neuron_ids=obi.NamedTuple(name="ids", elements=[0, 1, 2])),
+    "PredefinedNeuronSet": obi.PredefinedNeuronSet(node_set="Excitatory"),
+    "nbS1VPMInputs": obi.nbS1VPMInputs(),
+    "nbS1POmInputs": obi.nbS1POmInputs(),
+    "rCA1CA3Inputs": obi.rCA1CA3Inputs(),
+}
+
+COMBINED_NEURON_SETS = {
+    "BiophysicalCombinedNeuronSet",
+    "VirtualCombinedNeuronSet",
+    "PointCombinedNeuronSet",
+    "NonVirtualCombinedNeuronSet",
+}
+
+
+class TestUnionCoverage:
+    """Guards against a new neuron set type slipping in untested."""
+
+    def test_every_neuron_simulation_neuron_set_is_exercised(self):
+        covered = (
+            set(BIOPHYSICAL_NEURON_SETS)
+            | set(VIRTUAL_NEURON_SETS)
+            | set(POINT_NEURON_SETS)
+            | set(DEPRECATED_NEURON_SETS)
+            | COMBINED_NEURON_SETS
+        )
+
+        assert _union_member_names(NEURONSimulationNeuronSetUnion) - covered == set()
+
+    def test_all_virtual_neurons_is_not_selectable(self, circuit_config):
+        """``AllVirtualNeurons`` only exists as the injected default, not as a user choice."""
+        with pytest.raises(KeyError, match="AllVirtualNeurons"):
+            circuit_config().add(AllVirtualNeurons(), name="Virtual")
+
+
+class TestNeuronSetsReachNodeSetsFile:
+    @pytest.mark.parametrize("name", sorted(BIOPHYSICAL_NEURON_SETS))
+    def test_biophysical_neuron_set_is_written(self, name, circuit, tmp_path):
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={name: BIOPHYSICAL_NEURON_SETS[name].model_copy(deep=True)},
+        )
+
+        result = generate(config, tmp_path)
+
+        assert name in result.node_sets
+
+    @pytest.mark.parametrize("name", sorted(VIRTUAL_NEURON_SETS))
+    def test_virtual_neuron_set_is_written(self, name, circuit, tmp_path):
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={name: VIRTUAL_NEURON_SETS[name].model_copy(deep=True)},
+        )
+
+        result = generate(config, tmp_path)
+
+        assert name in result.node_sets
+
+    @pytest.mark.parametrize("name", sorted(POINT_NEURON_SETS))
+    def test_point_neuron_set_is_written(self, name, point_circuit, tmp_path):
+        config = build_config(
+            Brian2CircuitSimulationSingleConfig,
+            circuit=point_circuit,
+            blocks={name: POINT_NEURON_SETS[name].model_copy(deep=True)},
+        )
+
+        result = generate(config, tmp_path)
+
+        assert name in result.node_sets
+
+    @pytest.mark.parametrize("name", sorted(DEPRECATED_NEURON_SETS))
+    def test_deprecated_neuron_set_refuses_to_resolve(self, name, circuit, tmp_path):
+        """The deprecated sets stay loadable for old configs but cannot be generated from."""
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={name: DEPRECATED_NEURON_SETS[name].model_copy(deep=True)},
+        )
+
+        with pytest.raises(NotImplementedError, match=f"{name} is deprecated"):
+            generate(config, tmp_path)
+
+    def test_node_set_is_named_after_the_dictionary_key_not_the_block(self, circuit, tmp_path):
+        """A predefined set is re-published under its key, so behaviour matches a subsampled set."""
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "MyExcitatory": BiophysicalPopulationPredefinedNeuronSet(
+                    population=BIOPHYSICAL_POPULATION, node_set="Excitatory"
+                )
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert "MyExcitatory" in result.node_sets
+        assert result.node_sets["MyExcitatory"] != {}
+
+    def test_id_neuron_set_resolves_to_explicit_node_ids(self, circuit, tmp_path):
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "Three": BiophysicalPopulationIDNeuronSet(
+                    population=BIOPHYSICAL_POPULATION,
+                    neuron_ids=obi.NamedTuple(name="ids", elements=[0, 1, 2]),
+                )
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.node_sets["Three"] == {
+            "population": BIOPHYSICAL_POPULATION,
+            "node_id": [0, 1, 2],
+        }
+
+    def test_sampling_reduces_the_resolved_ids(self, circuit, tmp_path):
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "Half": BiophysicalPopulationIDNeuronSet(
+                    population=BIOPHYSICAL_POPULATION,
+                    neuron_ids=obi.NamedTuple(name="ids", elements=list(range(10))),
+                    sample_percentage=50.0,
+                    sample_seed=1,
+                )
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert len(result.node_sets["Half"]["node_id"]) == 5
+
+    def test_several_neuron_sets_coexist(self, circuit, tmp_path):
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "Excitatory subset": BiophysicalPopulationPredefinedNeuronSet(
+                    population=BIOPHYSICAL_POPULATION, node_set="Excitatory"
+                ),
+                "VPM inputs": VirtualPopulationNeuronSet(population=VIRTUAL_POPULATION),
+                "Everything biophysical": AllBiophysicalNeurons(),
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert {"Excitatory subset", "VPM inputs", "Everything biophysical"} <= set(
+            result.node_sets
+        )
+
+    def test_key_must_match_the_block_name(self, circuit, tmp_path):
+        """The dictionary key is authoritative; a drifting block name is refused.
+
+        Constructing the task revalidates the config, which resets every block name to its key --
+        so the rename has to happen after the task exists for the guard to be reachable.
+        """
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={"Correct": AllBiophysicalNeurons()},
+        )
+        coordinate_root = tmp_path / "0"
+        coordinate_root.mkdir(parents=True)
+        config.scan_output_root = tmp_path
+        config.coordinate_output_root = coordinate_root
+
+        task = GenerateSimulationTask(config=config)
+        task.config.neuron_sets["Correct"].set_block_name("Renamed")
+
+        with pytest.raises(OBIONEError, match="Neuron set name mismatch!"):
+            task.execute()
+
+
+class TestCombinedNeuronSets:
+    def test_union_of_two_id_sets(self, circuit, tmp_path):
+        first = BiophysicalPopulationIDNeuronSet(
+            population=BIOPHYSICAL_POPULATION,
+            neuron_ids=obi.NamedTuple(name="first", elements=[0, 1]),
+        )
+        second = BiophysicalPopulationIDNeuronSet(
+            population=BIOPHYSICAL_POPULATION,
+            neuron_ids=obi.NamedTuple(name="second", elements=[2, 3]),
+        )
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "First": first,
+                "Second": second,
+                "Combined": lambda: obi.BiophysicalCombinedNeuronSet(
+                    base_neuron_set=first.ref,
+                    combined_with=((second.ref, SetOperation.UNION),),
+                ),
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.node_sets["Combined"]["node_id"] == [0, 1, 2, 3]
+
+    def test_intersection_and_difference(self, circuit, tmp_path):
+        first = BiophysicalPopulationIDNeuronSet(
+            population=BIOPHYSICAL_POPULATION,
+            neuron_ids=obi.NamedTuple(name="first", elements=[0, 1, 2]),
+        )
+        second = BiophysicalPopulationIDNeuronSet(
+            population=BIOPHYSICAL_POPULATION,
+            neuron_ids=obi.NamedTuple(name="second", elements=[1, 2, 3]),
+        )
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "First": first,
+                "Second": second,
+                "Intersection": lambda: obi.BiophysicalCombinedNeuronSet(
+                    base_neuron_set=first.ref,
+                    combined_with=((second.ref, SetOperation.INTERSECT),),
+                ),
+                "Difference": lambda: obi.BiophysicalCombinedNeuronSet(
+                    base_neuron_set=first.ref,
+                    combined_with=((second.ref, SetOperation.DIFF),),
+                ),
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.node_sets["Intersection"]["node_id"] == [1, 2]
+        assert result.node_sets["Difference"]["node_id"] == [0]
+
+    def test_unset_base_and_operand_fall_back_to_the_matching_default(self, circuit, tmp_path):
+        """An empty combined set is filled with the default for its own population type."""
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "Combined": obi.BiophysicalCombinedNeuronSet(
+                    base_neuron_set=None,
+                    combined_with=((None, SetOperation.UNION),),
+                )
+            },
+        )
+
+        generate(config, tmp_path)
+
+        combined = config.neuron_sets["Combined"]
+        assert combined.base_neuron_set.block_name == DEFAULT_BIOPHYSICAL_NODE_SET
+        assert combined.combined_with[0][0].block_name == DEFAULT_BIOPHYSICAL_NODE_SET
+
+    def test_virtual_combined_set_falls_back_to_the_virtual_default(self, circuit, tmp_path):
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "Combined": obi.VirtualCombinedNeuronSet(
+                    base_neuron_set=None,
+                    combined_with=(),
+                )
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert config.neuron_sets["Combined"].base_neuron_set.block_name == (
+            DEFAULT_VIRTUAL_NODE_SET
+        )
+        assert DEFAULT_VIRTUAL_NODE_SET in result.node_sets
+
+    def test_point_combined_set_falls_back_to_the_point_default(self, point_circuit, tmp_path):
+        """A NEURON config running a point circuit picks up the point default, not the
+        biophysical one."""
+        target = PointPopulationNeuronSet(population=POINT_POPULATION)
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=point_circuit,
+            blocks={
+                "Target": target,
+                "Combined": obi.PointCombinedNeuronSet(base_neuron_set=None, combined_with=()),
+            },
+        )
+        config.initialize.node_set = config.neuron_sets["Target"].ref
+
+        result = generate(config, tmp_path)
+
+        assert config.neuron_sets["Combined"].base_neuron_set.block_name == DEFAULT_POINT_NODE_SET
+        assert DEFAULT_POINT_NODE_SET in result.node_sets
+
+    def test_brian2_point_combined_set_falls_back_to_the_point_default(
+        self, point_circuit, tmp_path
+    ):
+        """Brian2's own default is already all point neurons, so the two coincide here."""
+        config = build_config(
+            Brian2CircuitSimulationSingleConfig,
+            circuit=point_circuit,
+            blocks={"Combined": obi.PointCombinedNeuronSet(base_neuron_set=None, combined_with=())},
+        )
+
+        result = generate(config, tmp_path)
+
+        assert config.neuron_sets["Combined"].base_neuron_set.block_name == DEFAULT_POINT_NODE_SET
+        assert DEFAULT_POINT_NODE_SET in result.node_sets
+
+    def test_learning_engine_point_combined_set_falls_back_to_the_point_default(
+        self, point_circuit, tmp_path
+    ):
+        config = build_config(
+            LearningEngineCircuitSimulationSingleConfig,
+            circuit=point_circuit,
+            blocks={"Combined": obi.PointCombinedNeuronSet(base_neuron_set=None, combined_with=())},
+        )
+
+        result = generate(config, tmp_path)
+
+        assert config.neuron_sets["Combined"].base_neuron_set.block_name == DEFAULT_POINT_NODE_SET
+        assert DEFAULT_POINT_NODE_SET in result.node_sets
+
+    def test_explicit_references_are_left_alone(self, circuit, tmp_path):
+        explicit = BiophysicalPopulationIDNeuronSet(
+            population=BIOPHYSICAL_POPULATION,
+            neuron_ids=obi.NamedTuple(name="ids", elements=[4]),
+        )
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "Explicit": explicit,
+                "Combined": lambda: obi.BiophysicalCombinedNeuronSet(
+                    base_neuron_set=explicit.ref, combined_with=()
+                ),
+            },
+        )
+
+        generate(config, tmp_path)
+
+        assert config.neuron_sets["Combined"].base_neuron_set.block_name == "Explicit"
+
+
+class TestDefaultNeuronSetInjection:
+    def test_default_is_created_on_demand_and_added_to_the_config(self, circuit_config, tmp_path):
+        config = circuit_config()
+
+        result = generate(config, tmp_path)
+
+        assert isinstance(config.neuron_sets[DEFAULT_BIOPHYSICAL_NODE_SET], AllBiophysicalNeurons)
+        assert result.node_sets[DEFAULT_BIOPHYSICAL_NODE_SET] == {
+            "population": BIOPHYSICAL_POPULATION,
+            "node_id": list(range(10)),
+        }
+
+    def test_untargeted_stimulus_and_recording_get_the_default(self, circuit, tmp_path):
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "Clamp": obi.ConstantCurrentClampSomaticStimulus(),
+                "Voltage": obi.SomaVoltageRecording(),
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert config.stimuli["Clamp"].neuron_set.block_name == DEFAULT_BIOPHYSICAL_NODE_SET
+        assert config.recordings["Voltage"].neuron_set.block_name == DEFAULT_BIOPHYSICAL_NODE_SET
+        assert result.inputs["Clamp_0"]["node_set"] == DEFAULT_BIOPHYSICAL_NODE_SET
+        assert result.reports["Voltage"]["cells"] == DEFAULT_BIOPHYSICAL_NODE_SET
+
+    def test_explicit_targets_are_preserved(self, circuit, tmp_path):
+        target = BiophysicalPopulationIDNeuronSet(
+            population=BIOPHYSICAL_POPULATION,
+            neuron_ids=obi.NamedTuple(name="ids", elements=[0, 1]),
+        )
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "Target": target,
+                "Clamp": lambda: obi.ConstantCurrentClampSomaticStimulus(neuron_set=target.ref),
+                "Voltage": lambda: obi.SomaVoltageRecording(neuron_set=target.ref),
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.inputs["Clamp_0"]["node_set"] == "Target"
+        assert result.reports["Voltage"]["cells"] == "Target"
+
+    def test_simulation_target_defaults_when_node_set_is_unset(self, circuit_config, tmp_path):
+        config = circuit_config()
+        assert config.initialize.node_set is None
+
+        result = generate(config, tmp_path)
+
+        assert config.initialize.node_set.block_name == DEFAULT_BIOPHYSICAL_NODE_SET
+        assert result.sonata_config["node_set"] == DEFAULT_BIOPHYSICAL_NODE_SET
+
+    def test_explicit_simulation_target_is_used(self, circuit, tmp_path):
+        target = BiophysicalPopulationIDNeuronSet(
+            population=BIOPHYSICAL_POPULATION,
+            neuron_ids=obi.NamedTuple(name="ids", elements=[0, 1]),
+        )
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={"Target": target},
+        )
+        config.initialize.node_set = config.neuron_sets["Target"].ref
+
+        result = generate(config, tmp_path)
+
+        assert result.sonata_config["node_set"] == "Target"
+
+    def test_me_model_without_a_neuron_sets_dictionary_uses_the_default_name(
+        self, me_model_config, tmp_path
+    ):
+        """An ME model config has no ``neuron_sets`` field, so the default is created inline."""
+        config = me_model_config()
+        assert not hasattr(config, "neuron_sets")
+
+        result = generate(config, tmp_path)
+
+        assert result.sonata_config["node_set"] == DEFAULT_BIOPHYSICAL_NODE_SET
+        assert DEFAULT_BIOPHYSICAL_NODE_SET in result.node_sets
+
+
+class TestDefaultNeuronSetErrors:
+    def test_virtual_simulation_target_is_rejected(self, circuit, tmp_path):
+        """The simulation itself cannot run a virtual population."""
+        virtual = VirtualPopulationIDNeuronSet(
+            population=VIRTUAL_POPULATION,
+            neuron_ids=obi.NamedTuple(name="ids", elements=[0, 1]),
+        )
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={"VirtualTarget": virtual},
+        )
+        config.initialize.node_set = config.neuron_sets["VirtualTarget"].ref
+
+        with pytest.raises(OBIONEError, match="'VirtualTarget' is virtual"):
+            generate(config, tmp_path)
+
+    def test_virtual_target_error_lists_the_usable_populations(self, circuit, tmp_path):
+        virtual = VirtualPopulationIDNeuronSet(
+            population=VIRTUAL_POPULATION,
+            neuron_ids=obi.NamedTuple(name="ids", elements=[0]),
+        )
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={"VirtualTarget": virtual},
+        )
+        config.initialize.node_set = config.neuron_sets["VirtualTarget"].ref
+
+        with pytest.raises(OBIONEError, match=f"'{BIOPHYSICAL_POPULATION}'"):
+            generate(config, tmp_path)
+
+    def test_reusing_the_default_name_for_another_type_is_rejected(self, circuit, tmp_path):
+        """The default name is reserved: a user set under it must be the default type."""
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                DEFAULT_BIOPHYSICAL_NODE_SET: obi.PredefinedNeuronSet(node_set="Excitatory"),
+                "Clamp": obi.ConstantCurrentClampSomaticStimulus(),
+            },
+        )
+
+        with pytest.raises(OBIONEError, match="already exists in neuron_sets but is not an"):
+            generate(config, tmp_path)
+
+    def test_reusing_the_virtual_default_name_for_another_type_is_rejected(self, circuit, tmp_path):
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                DEFAULT_VIRTUAL_NODE_SET: VirtualPopulationIDNeuronSet(
+                    population=VIRTUAL_POPULATION,
+                    neuron_ids=obi.NamedTuple(name="ids", elements=[0]),
+                ),
+                "Combined": obi.VirtualCombinedNeuronSet(base_neuron_set=None, combined_with=()),
+            },
+        )
+
+        with pytest.raises(OBIONEError, match="Default virtual neuron set name"):
+            generate(config, tmp_path)
+
+    def test_reusing_the_point_default_name_for_another_type_is_rejected(self, circuit, tmp_path):
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                DEFAULT_POINT_NODE_SET: PointPopulationIDNeuronSet(
+                    population=POINT_POPULATION,
+                    neuron_ids=obi.NamedTuple(name="ids", elements=[0]),
+                ),
+                "Combined": obi.PointCombinedNeuronSet(base_neuron_set=None, combined_with=()),
+            },
+        )
+
+        with pytest.raises(OBIONEError, match="Default point neuron set name"):
+            generate(config, tmp_path)
+
+
+class TestDefaultReferenceTypes:
+    """The reference each config family hands out for its default neuron set."""
+
+    def test_circuit_default_is_biophysical(self, circuit_config):
+        reference = circuit_config().default_neuron_set_reference
+
+        assert isinstance(reference, BiophysicalNeuronSetReference)
+        assert reference.block_name == DEFAULT_BIOPHYSICAL_NODE_SET
+        assert isinstance(reference.block, AllBiophysicalNeurons)
+
+    def test_circuit_virtual_and_point_defaults(self, circuit_config):
+        config = circuit_config()
+
+        assert isinstance(config.default_virtual_neuron_set_reference, VirtualNeuronSetReference)
+        assert isinstance(config.default_point_neuron_set_reference, PointNeuronSetReference)
+        assert isinstance(config.default_virtual_neuron_set_reference.block, AllVirtualNeurons)
+        assert isinstance(config.default_point_neuron_set_reference.block, AllPointNeurons)
+
+    def test_brian2_default_is_point(self, brian2_config):
+        reference = brian2_config().default_neuron_set_reference
+
+        assert isinstance(reference, PointNeuronSetReference)
+        assert reference.block_name == DEFAULT_POINT_NODE_SET
+        assert isinstance(reference.block, AllPointNeurons)
+
+    def test_learning_engine_default_is_point(self, learning_engine_config):
+        reference = learning_engine_config().default_neuron_set_reference
+
+        assert isinstance(reference, PointNeuronSetReference)
+        assert reference.block_name == DEFAULT_POINT_NODE_SET

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_neuron_sets.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_neuron_sets.py
@@ -6,9 +6,6 @@ task applies when a neuron set reference is left unset -- which default gets inj
 that is an error.
 """
 
-import inspect
-import typing
-
 import pytest
 
 import obi_one as obi
@@ -69,14 +66,8 @@ from tests.obi_one.scientific.tasks.simulation_campaign_generation.conftest impo
     VIRTUAL_POPULATION,
     build_config,
     generate,
+    union_member_names,
 )
-
-
-def _union_member_names(union) -> set[str]:
-    """The class names a discriminated block union accepts."""
-    inner = typing.get_args(union)[0]
-    return {cls.__name__ for cls in typing.get_args(inner) if inspect.isclass(cls)}
-
 
 # One constructible instance per neuron set type in NEURONSimulationNeuronSetUnion. Combined sets
 # are exercised separately because they need references to other sets, and the deprecated sets
@@ -165,7 +156,7 @@ class TestUnionCoverage:
             | COMBINED_NEURON_SETS
         )
 
-        assert _union_member_names(NEURONSimulationNeuronSetUnion) - covered == set()
+        assert union_member_names(NEURONSimulationNeuronSetUnion) - covered == set()
 
     def test_all_virtual_neurons_is_not_selectable(self, circuit_config):
         """``AllVirtualNeurons`` only exists as the injected default, not as a user choice."""

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_recordings.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_recordings.py
@@ -1,0 +1,192 @@
+"""How recording blocks become the ``reports`` section of the generated SONATA config."""
+
+import inspect
+import typing
+
+import pytest
+
+import obi_one as obi
+from obi_one.core.exception import OBIONEError
+from obi_one.scientific.blocks.neuron_sets.id import (
+    BiophysicalPopulationIDNeuronSet,
+    VirtualPopulationIDNeuronSet,
+)
+from obi_one.scientific.tasks.generate_simulations.config.neuron.neuron_circuit import (
+    CircuitSimulationSingleConfig,
+)
+from obi_one.scientific.unions_and_references.recordings import (
+    IonChannelModelRecordingUnion,
+    RecordingUnion,
+)
+
+from tests.obi_one.scientific.tasks.simulation_campaign_generation.conftest import (
+    BIOPHYSICAL_POPULATION,
+    DEFAULT_BIOPHYSICAL_NODE_SET,
+    VIRTUAL_POPULATION,
+    build_config,
+    generate,
+)
+
+SOMA_REPORT_SHAPE = {
+    "sections": "soma",
+    "type": "compartment",
+    "compartments": "center",
+    "variable_name": "v",
+    "unit": "mV",
+}
+
+
+def _union_member_names(union) -> set[str]:
+    inner = typing.get_args(union)[0]
+    if inspect.isclass(inner):
+        return {inner.__name__}
+    return {cls.__name__ for cls in typing.get_args(inner) if inspect.isclass(cls)}
+
+
+class TestUnionCoverage:
+    def test_every_recording_in_the_circuit_union_is_exercised(self):
+        assert _union_member_names(RecordingUnion) == {
+            "SomaVoltageRecording",
+            "TimeWindowSomaVoltageRecording",
+        }
+
+    def test_ion_channel_configs_add_a_variable_recording(self):
+        """``IonChannelVariableRecording`` is reachable only from the database-backed config."""
+        assert _union_member_names(IonChannelModelRecordingUnion) - _union_member_names(
+            RecordingUnion
+        ) == {"IonChannelVariableRecording"}
+
+
+class TestSomaVoltageRecording:
+    def test_report_shape(self, circuit, tmp_path):
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={"Voltage": obi.SomaVoltageRecording()},
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.reports["Voltage"] == {
+            "cells": DEFAULT_BIOPHYSICAL_NODE_SET,
+            **SOMA_REPORT_SHAPE,
+            "dt": 0.1,
+            "start_time": 0.0,
+            "end_time": 100.0,
+        }
+
+    def test_end_time_follows_the_simulation_length(self, circuit, tmp_path):
+        """A plain soma recording spans the whole simulation."""
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={"Voltage": obi.SomaVoltageRecording()},
+            initialize={"simulation_length": 400.0},
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.reports["Voltage"]["end_time"] == pytest.approx(400.0)
+
+    def test_custom_timestep(self, circuit, tmp_path):
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={"Voltage": obi.SomaVoltageRecording(dt=0.5)},
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.reports["Voltage"]["dt"] == pytest.approx(0.5)
+
+    def test_explicit_neuron_set_is_recorded_from(self, circuit, tmp_path):
+        target = BiophysicalPopulationIDNeuronSet(
+            population=BIOPHYSICAL_POPULATION,
+            neuron_ids=obi.NamedTuple(name="target", elements=[0, 1]),
+        )
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "Target": target,
+                "Voltage": lambda: obi.SomaVoltageRecording(neuron_set=target.ref),
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.reports["Voltage"]["cells"] == "Target"
+
+
+class TestTimeWindowSomaVoltageRecording:
+    def test_window_bounds_are_used_verbatim(self, circuit, tmp_path):
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={"Window": obi.TimeWindowSomaVoltageRecording(start_time=20.0, end_time=60.0)},
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.reports["Window"]["start_time"] == pytest.approx(20.0)
+        assert result.reports["Window"]["end_time"] == pytest.approx(60.0)
+
+    def test_window_does_not_extend_to_the_simulation_length(self, circuit, tmp_path):
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={"Window": obi.TimeWindowSomaVoltageRecording(start_time=0.0, end_time=10.0)},
+            initialize={"simulation_length": 500.0},
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.reports["Window"]["end_time"] == pytest.approx(10.0)
+
+
+class TestReportsSection:
+    def test_several_recordings_produce_independent_reports(self, circuit, tmp_path):
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "Whole run": obi.SomaVoltageRecording(),
+                "First window": obi.TimeWindowSomaVoltageRecording(start_time=0.0, end_time=10.0),
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert set(result.reports) == {"Whole run", "First window"}
+
+    def test_no_recordings_yields_an_empty_reports_section(self, circuit_config, tmp_path):
+        result = generate(circuit_config(), tmp_path)
+
+        assert result.reports == {}
+
+    def test_a_config_without_a_recordings_field_still_gets_an_empty_section(
+        self, brian2_config, tmp_path
+    ):
+        """Brian2 configs expose no recordings, but the SONATA key is still emitted."""
+        config = brian2_config()
+        assert not hasattr(config, "recordings")
+
+        result = generate(config, tmp_path)
+
+        assert result.reports == {}
+
+    def test_recording_from_a_virtual_neuron_set_is_rejected(self, circuit, tmp_path):
+        """There is nothing to record on a virtual population."""
+        virtual = VirtualPopulationIDNeuronSet(
+            population=VIRTUAL_POPULATION,
+            neuron_ids=obi.NamedTuple(name="virtual", elements=[0, 1]),
+        )
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={"Virtual": virtual, "Voltage": obi.SomaVoltageRecording()},
+        )
+        config.recordings["Voltage"].neuron_set = config.neuron_sets["Virtual"].ref
+
+        with pytest.raises(OBIONEError, match="should be non-virtual"):
+            generate(config, tmp_path)

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_recordings.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_recordings.py
@@ -1,8 +1,5 @@
 """How recording blocks become the ``reports`` section of the generated SONATA config."""
 
-import inspect
-import typing
-
 import pytest
 
 import obi_one as obi
@@ -25,6 +22,7 @@ from tests.obi_one.scientific.tasks.simulation_campaign_generation.conftest impo
     VIRTUAL_POPULATION,
     build_config,
     generate,
+    union_member_names,
 )
 
 SOMA_REPORT_SHAPE = {
@@ -36,23 +34,16 @@ SOMA_REPORT_SHAPE = {
 }
 
 
-def _union_member_names(union) -> set[str]:
-    inner = typing.get_args(union)[0]
-    if inspect.isclass(inner):
-        return {inner.__name__}
-    return {cls.__name__ for cls in typing.get_args(inner) if inspect.isclass(cls)}
-
-
 class TestUnionCoverage:
     def test_every_recording_in_the_circuit_union_is_exercised(self):
-        assert _union_member_names(RecordingUnion) == {
+        assert union_member_names(RecordingUnion) == {
             "SomaVoltageRecording",
             "TimeWindowSomaVoltageRecording",
         }
 
     def test_ion_channel_configs_add_a_variable_recording(self):
         """``IonChannelVariableRecording`` is reachable only from the database-backed config."""
-        assert _union_member_names(IonChannelModelRecordingUnion) - _union_member_names(
+        assert union_member_names(IonChannelModelRecordingUnion) - union_member_names(
             RecordingUnion
         ) == {"IonChannelVariableRecording"}
 

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_stimuli.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_stimuli.py
@@ -6,9 +6,6 @@ cover every stimulus type reachable from a simulation config, plus the timestamp
 targeting rules that apply across them.
 """
 
-import inspect
-import typing
-
 import h5py
 import numpy as np
 import pytest
@@ -44,16 +41,8 @@ from tests.obi_one.scientific.tasks.simulation_campaign_generation.conftest impo
     VIRTUAL_POPULATION,
     build_config,
     generate,
+    union_member_names,
 )
-
-
-def _union_member_names(union) -> set[str]:
-    inner = typing.get_args(union)[0]
-    if inspect.isclass(inner):
-        # A single-member "union" annotates the class directly.
-        return {inner.__name__}
-    return {cls.__name__ for cls in typing.get_args(inner) if inspect.isclass(cls)}
-
 
 # Every continuous stimulus in CircuitStimulusUnion, with the SONATA module and input type it is
 # expected to emit. A refactor that reroutes a stimulus through the wrong branch shows up here.
@@ -108,19 +97,19 @@ class TestUnionCoverage:
     def test_every_circuit_stimulus_is_exercised(self):
         covered = set(CONTINUOUS_STIMULI) | set(SPIKE_STIMULI)
 
-        assert _union_member_names(CircuitStimulusUnion) - covered == set()
+        assert union_member_names(CircuitStimulusUnion) - covered == set()
 
     def test_me_model_and_learning_engine_stimuli_are_a_subset_of_the_circuit_ones(self):
         """Narrower unions reuse the same blocks, so the circuit coverage carries over."""
-        assert _union_member_names(MEModelStimulusUnion) <= set(CONTINUOUS_STIMULI)
-        assert _union_member_names(LearningEngineCircuitStimulusUnion) <= set(CONTINUOUS_STIMULI)
+        assert union_member_names(MEModelStimulusUnion) <= set(CONTINUOUS_STIMULI)
+        assert union_member_names(LearningEngineCircuitStimulusUnion) <= set(CONTINUOUS_STIMULI)
 
     def test_brian2_accepts_only_the_direct_poisson_stimulus(self):
-        assert _union_member_names(Brian2CircuitStimulusUnion) == {"Brian2DirectPoissonStimulus"}
+        assert union_member_names(Brian2CircuitStimulusUnion) == {"Brian2DirectPoissonStimulus"}
 
     def test_ion_channel_only_adds_the_voltage_clamps(self):
         """The SE clamps are reachable only from the ion channel config, which needs a database."""
-        assert _union_member_names(IonChannelModelStimulusUnion) - set(CONTINUOUS_STIMULI) == {
+        assert union_member_names(IonChannelModelStimulusUnion) - set(CONTINUOUS_STIMULI) == {
             "SEClampSomaticStimulus",
             "MultiLevelSEClampSomaticStimulus",
         }

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_stimuli.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_stimuli.py
@@ -1,0 +1,456 @@
+"""How stimulus blocks become the ``inputs`` section of the generated SONATA config.
+
+The task dispatches on three different stimulus shapes -- spike stimuli, the Brian2 direct
+Poisson stimulus, and everything else -- each with its own ``config()`` signature. These tests
+cover every stimulus type reachable from a simulation config, plus the timestamp expansion and
+targeting rules that apply across them.
+"""
+
+import inspect
+import typing
+
+import h5py
+import numpy as np
+import pytest
+
+import obi_one as obi
+from obi_one.core.exception import OBIONEError
+from obi_one.scientific.blocks.neuron_sets.id import (
+    BiophysicalPopulationIDNeuronSet,
+    PointPopulationIDNeuronSet,
+    VirtualPopulationIDNeuronSet,
+)
+from obi_one.scientific.blocks.neuron_sets.population import VirtualPopulationNeuronSet
+from obi_one.scientific.blocks.stimuli.brian2_poisson import Brian2DirectPoissonStimulus
+from obi_one.scientific.tasks.generate_simulations.config.brian2.brian2_circuit import (
+    Brian2CircuitSimulationSingleConfig,
+)
+from obi_one.scientific.tasks.generate_simulations.config.neuron.neuron_circuit import (
+    CircuitSimulationSingleConfig,
+)
+from obi_one.scientific.unions_and_references.stimuli import (
+    Brian2CircuitStimulusUnion,
+    CircuitStimulusUnion,
+    IonChannelModelStimulusUnion,
+    LearningEngineCircuitStimulusUnion,
+    MEModelStimulusUnion,
+)
+
+from tests.obi_one.scientific.tasks.simulation_campaign_generation.conftest import (
+    BIOPHYSICAL_POPULATION,
+    DEFAULT_BIOPHYSICAL_NODE_SET,
+    DEFAULT_BRIAN2_STIMULUS_NODE_SET,
+    POINT_POPULATION,
+    VIRTUAL_POPULATION,
+    build_config,
+    generate,
+)
+
+
+def _union_member_names(union) -> set[str]:
+    inner = typing.get_args(union)[0]
+    if inspect.isclass(inner):
+        # A single-member "union" annotates the class directly.
+        return {inner.__name__}
+    return {cls.__name__ for cls in typing.get_args(inner) if inspect.isclass(cls)}
+
+
+# Every continuous stimulus in CircuitStimulusUnion, with the SONATA module and input type it is
+# expected to emit. A refactor that reroutes a stimulus through the wrong branch shows up here.
+CONTINUOUS_STIMULI = {
+    "ConstantCurrentClampSomaticStimulus": ("linear", "current_clamp"),
+    "HyperpolarizingCurrentClampSomaticStimulus": ("hyperpolarizing", "current_clamp"),
+    "LinearCurrentClampSomaticStimulus": ("linear", "current_clamp"),
+    "MultiPulseCurrentClampSomaticStimulus": ("pulse", "current_clamp"),
+    "NormallyDistributedCurrentClampSomaticStimulus": ("noise", "current_clamp"),
+    "SinusoidalCurrentClampSomaticStimulus": ("sinusoidal", "current_clamp"),
+    "RelativeConstantCurrentClampSomaticStimulus": ("relative_linear", "current_clamp"),
+    "RelativeLinearCurrentClampSomaticStimulus": ("relative_linear", "current_clamp"),
+    "RelativeNormallyDistributedCurrentClampSomaticStimulus": ("noise", "current_clamp"),
+    "SubthresholdCurrentClampSomaticStimulus": ("subthreshold", "current_clamp"),
+    "OrnsteinUhlenbeckCurrentSomaticStimulus": ("ornstein_uhlenbeck", "current_clamp"),
+    "OrnsteinUhlenbeckConductanceSomaticStimulus": ("ornstein_uhlenbeck", "conductance"),
+    "RelativeOrnsteinUhlenbeckCurrentSomaticStimulus": (
+        "relative_ornstein_uhlenbeck",
+        "current_clamp",
+    ),
+    "RelativeOrnsteinUhlenbeckConductanceSomaticStimulus": (
+        "relative_ornstein_uhlenbeck",
+        "conductance",
+    ),
+    "SpatiallyUniformElectricFieldStimulus": (
+        "spatially_uniform_e_field",
+        "extracellular_stimulation",
+    ),
+    "TemporallyCosineSpatiallyUniformElectricFieldStimulus": (
+        "spatially_uniform_e_field",
+        "extracellular_stimulation",
+    ),
+}
+
+# Spike stimuli all emit a synapse_replay input backed by a generated HDF5 file.
+SPIKE_STIMULI = [
+    "PoissonSpikeStimulus",
+    "FullySynchronousSpikeStimulus",
+    "SinusoidalPoissonSpikeStimulus",
+    "InterSpikeIntervalDistributionSpikeStimulus",
+    "SpikeTimeDistributionSpikeStimulus",
+]
+
+# The two distribution-driven spike stimuli need a distribution block to point at.
+NEEDS_DISTRIBUTION = {
+    "InterSpikeIntervalDistributionSpikeStimulus",
+    "SpikeTimeDistributionSpikeStimulus",
+}
+
+
+class TestUnionCoverage:
+    def test_every_circuit_stimulus_is_exercised(self):
+        covered = set(CONTINUOUS_STIMULI) | set(SPIKE_STIMULI)
+
+        assert _union_member_names(CircuitStimulusUnion) - covered == set()
+
+    def test_me_model_and_learning_engine_stimuli_are_a_subset_of_the_circuit_ones(self):
+        """Narrower unions reuse the same blocks, so the circuit coverage carries over."""
+        assert _union_member_names(MEModelStimulusUnion) <= set(CONTINUOUS_STIMULI)
+        assert _union_member_names(LearningEngineCircuitStimulusUnion) <= set(CONTINUOUS_STIMULI)
+
+    def test_brian2_accepts_only_the_direct_poisson_stimulus(self):
+        assert _union_member_names(Brian2CircuitStimulusUnion) == {"Brian2DirectPoissonStimulus"}
+
+    def test_ion_channel_only_adds_the_voltage_clamps(self):
+        """The SE clamps are reachable only from the ion channel config, which needs a database."""
+        assert _union_member_names(IonChannelModelStimulusUnion) - set(CONTINUOUS_STIMULI) == {
+            "SEClampSomaticStimulus",
+            "MultiLevelSEClampSomaticStimulus",
+        }
+
+
+class TestContinuousStimuli:
+    @pytest.mark.parametrize(("name", "expected"), sorted(CONTINUOUS_STIMULI.items()))
+    def test_module_and_input_type(self, name, expected, circuit, tmp_path):
+        module, input_type = expected
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={"Stim": getattr(obi, name)()},
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.inputs["Stim_0"]["module"] == module
+        assert result.inputs["Stim_0"]["input_type"] == input_type
+
+    @pytest.mark.parametrize("name", sorted(CONTINUOUS_STIMULI))
+    def test_common_fields_are_always_present(self, name, circuit, tmp_path):
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={"Stim": getattr(obi, name)()},
+        )
+
+        result = generate(config, tmp_path)
+
+        entry = result.inputs["Stim_0"]
+        assert entry["delay"] == pytest.approx(0.0)
+        assert entry["node_set"] == DEFAULT_BIOPHYSICAL_NODE_SET
+        assert entry["duration"] > 0.0
+
+    def test_amplitude_reaches_the_generated_input(self, circuit, tmp_path):
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "Clamp": obi.ConstantCurrentClampSomaticStimulus(amplitude=0.42, duration=25.0)
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.inputs["Clamp_0"]["amp_start"] == pytest.approx(0.42)
+        assert result.inputs["Clamp_0"]["duration"] == pytest.approx(25.0)
+
+    def test_electric_field_emits_a_fields_list(self, circuit, tmp_path):
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={"Field": obi.SpatiallyUniformElectricFieldStimulus(E_x=1.0, E_y=2.0, E_z=3.0)},
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.inputs["Field_0"]["fields"] == [
+            {"Ex": 1.0, "Ey": 2.0, "Ez": 3.0, "frequency": 0.0, "phase": 0.0}
+        ]
+
+    def test_several_stimuli_produce_independent_entries(self, circuit, tmp_path):
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "Depolarising": obi.ConstantCurrentClampSomaticStimulus(amplitude=0.5),
+                "Hyperpolarising": obi.HyperpolarizingCurrentClampSomaticStimulus(),
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert set(result.inputs) == {"Depolarising_0", "Hyperpolarising_0"}
+
+
+class TestTimestampExpansion:
+    def test_a_stimulus_without_timestamps_starts_at_zero(self, circuit, tmp_path):
+        """The task supplies a default ``SingleTimestamp(start_time=0.0)``."""
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={"Clamp": obi.ConstantCurrentClampSomaticStimulus()},
+        )
+
+        result = generate(config, tmp_path)
+
+        assert set(result.inputs) == {"Clamp_0"}
+        assert result.inputs["Clamp_0"]["delay"] == pytest.approx(0.0)
+
+    def test_a_single_timestamp_produces_one_entry(self, circuit, tmp_path):
+        timestamps = obi.SingleTimestamp(start_time=30.0)
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "Start": timestamps,
+                "Clamp": lambda: obi.ConstantCurrentClampSomaticStimulus(timestamps=timestamps.ref),
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert set(result.inputs) == {"Clamp_0"}
+        assert result.inputs["Clamp_0"]["delay"] == pytest.approx(30.0)
+
+    def test_regular_timestamps_produce_one_entry_per_repetition(self, circuit, tmp_path):
+        timestamps = obi.RegularTimestamps(start_time=0.0, number_of_repetitions=3, interval=20.0)
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "Repeats": timestamps,
+                "Clamp": lambda: obi.ConstantCurrentClampSomaticStimulus(
+                    timestamps=timestamps.ref, duration=5.0
+                ),
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert set(result.inputs) == {"Clamp_0", "Clamp_1", "Clamp_2"}
+        assert [result.inputs[f"Clamp_{i}"]["delay"] for i in range(3)] == [0.0, 20.0, 40.0]
+
+    def test_timestamp_offset_shifts_every_entry(self, circuit, tmp_path):
+        timestamps = obi.RegularTimestamps(start_time=0.0, number_of_repetitions=2, interval=20.0)
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "Repeats": timestamps,
+                "Clamp": lambda: obi.ConstantCurrentClampSomaticStimulus(
+                    timestamps=timestamps.ref, timestamp_offset=5.0, duration=5.0
+                ),
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert [result.inputs[f"Clamp_{i}"]["delay"] for i in range(2)] == [5.0, 25.0]
+
+
+class TestSpikeStimuli:
+    @staticmethod
+    def _spike_config(circuit, name, *, source=None, target=None):
+        source_set = source or VirtualPopulationIDNeuronSet(
+            population=VIRTUAL_POPULATION,
+            neuron_ids=obi.NamedTuple(name="source", elements=list(range(20))),
+        )
+        blocks: dict = {"Source": source_set}
+        if target is not None:
+            blocks["Target"] = target
+
+        stimulus_class = getattr(obi, name)
+        distribution = obi.ExponentialDistribution(scale=50.0)
+        if name in NEEDS_DISTRIBUTION:
+            blocks["Distribution"] = distribution
+
+        def _stimulus():
+            kwargs = {"source_neuron_set": source_set.ref}
+            if target is not None:
+                kwargs["targeted_neuron_set"] = target.ref
+            if name in NEEDS_DISTRIBUTION:
+                kwargs["distribution"] = distribution.ref
+            return stimulus_class(**kwargs)
+
+        blocks["Spikes"] = _stimulus
+        return build_config(CircuitSimulationSingleConfig, circuit=circuit, blocks=blocks)
+
+    @pytest.mark.parametrize("name", SPIKE_STIMULI)
+    def test_spike_stimulus_emits_a_synapse_replay_input(self, name, circuit, tmp_path):
+        config = self._spike_config(circuit, name)
+
+        result = generate(config, tmp_path)
+
+        assert result.inputs["Spikes"] == {
+            "delay": 0.0,
+            "duration": 100.0,
+            "node_set": DEFAULT_BIOPHYSICAL_NODE_SET,
+            "module": "synapse_replay",
+            "input_type": "spikes",
+            "spike_file": "Spikes_spikes.h5",
+        }
+
+    @pytest.mark.parametrize("name", SPIKE_STIMULI)
+    def test_spike_file_is_written_next_to_the_config(self, name, circuit, tmp_path):
+        config = self._spike_config(circuit, name)
+
+        result = generate(config, tmp_path)
+
+        spike_file = result.directory / "Spikes_spikes.h5"
+        assert spike_file.exists()
+        with h5py.File(spike_file, "r") as handle:
+            node_ids = np.array(handle[f"spikes/{VIRTUAL_POPULATION}/node_ids"])
+            timestamps = np.array(handle[f"spikes/{VIRTUAL_POPULATION}/timestamps"])
+        assert len(node_ids) == len(timestamps)
+        assert np.all(np.isin(node_ids, np.arange(20)))
+
+    def test_spike_input_key_is_not_suffixed_by_timestamp(self, circuit, tmp_path):
+        """Unlike continuous stimuli, all repetitions go into one replay file and one entry."""
+        timestamps = obi.RegularTimestamps(start_time=0.0, number_of_repetitions=3, interval=20.0)
+        source = VirtualPopulationIDNeuronSet(
+            population=VIRTUAL_POPULATION,
+            neuron_ids=obi.NamedTuple(name="source", elements=[0, 1, 2]),
+        )
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "Repeats": timestamps,
+                "Source": source,
+                "Spikes": lambda: obi.PoissonSpikeStimulus(
+                    timestamps=timestamps.ref, source_neuron_set=source.ref, duration=10.0
+                ),
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert set(result.inputs) == {"Spikes"}
+
+    def test_spike_duration_covers_the_whole_simulation(self, circuit, tmp_path):
+        config = self._spike_config(circuit, "PoissonSpikeStimulus")
+        config.initialize.simulation_length = 750.0
+
+        result = generate(config, tmp_path)
+
+        assert result.inputs["Spikes"]["duration"] == pytest.approx(750.0)
+
+    def test_explicit_target_is_used_as_the_node_set(self, circuit, tmp_path):
+        target = BiophysicalPopulationIDNeuronSet(
+            population=BIOPHYSICAL_POPULATION,
+            neuron_ids=obi.NamedTuple(name="target", elements=[0, 1]),
+        )
+        config = self._spike_config(circuit, "PoissonSpikeStimulus", target=target)
+
+        result = generate(config, tmp_path)
+
+        assert result.inputs["Spikes"]["node_set"] == "Target"
+
+    def test_a_virtual_target_is_rejected(self, circuit, tmp_path):
+        """Spikes are replayed onto real synapses, so the target cannot itself be virtual."""
+        source = VirtualPopulationNeuronSet(population=VIRTUAL_POPULATION)
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "Source": source,
+                "Spikes": lambda: obi.PoissonSpikeStimulus(source_neuron_set=source.ref),
+            },
+        )
+        # Point the target at the virtual source, which the stimulus must refuse.
+        config.stimuli["Spikes"].targeted_neuron_set = config.neuron_sets["Source"].ref
+
+        with pytest.raises(OBIONEError):
+            generate(config, tmp_path)
+
+
+class TestBrian2DirectPoissonStimulus:
+    def test_untargeted_stimulus_drives_the_sugar_node_set(self, brian2_config, tmp_path):
+        config = brian2_config(blocks={"DirectPoisson": Brian2DirectPoissonStimulus()})
+
+        result = generate(config, tmp_path)
+
+        assert result.inputs["DirectPoisson"]["node_set"] == DEFAULT_BRIAN2_STIMULUS_NODE_SET
+        assert result.inputs["DirectPoisson"]["input_type"] == "spikes"
+        assert result.inputs["DirectPoisson"]["module"] == "poisson"
+
+    def test_targeted_stimulus_uses_its_own_neuron_set(self, point_circuit, tmp_path):
+        target = PointPopulationIDNeuronSet(
+            population=POINT_POPULATION,
+            neuron_ids=obi.NamedTuple(name="target", elements=[2]),
+        )
+        config = build_config(
+            Brian2CircuitSimulationSingleConfig,
+            circuit=point_circuit,
+            blocks={
+                "Target": target,
+                "DirectPoisson": lambda: Brian2DirectPoissonStimulus(neuron_set=target.ref),
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.inputs["DirectPoisson"]["node_set"] == "Target"
+
+    def test_frequency_weight_and_duration_reach_the_input(self, brian2_config, tmp_path):
+        """``frequency`` is published under the SONATA name ``rate``."""
+        config = brian2_config(
+            blocks={
+                "DirectPoisson": Brian2DirectPoissonStimulus(
+                    frequency=25.0, weight=0.3, duration=60.0
+                )
+            }
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.inputs["DirectPoisson"] == {
+            "input_type": "spikes",
+            "module": "poisson",
+            "node_set": DEFAULT_BRIAN2_STIMULUS_NODE_SET,
+            "rate": 25.0,
+            "weight": 0.3,
+            "delay": 0.0,
+            "duration": 60.0,
+        }
+
+    def test_a_circuit_without_a_point_population_is_refused(self, circuit, tmp_path):
+        """Resolving the `sugar` default needs exactly one point population to name."""
+        config = build_config(
+            Brian2CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={"DirectPoisson": Brian2DirectPoissonStimulus()},
+        )
+
+        with pytest.raises(OBIONEError, match="needs exactly one point node population"):
+            generate(config, tmp_path)
+
+    def test_the_stimulus_default_is_a_strict_subset_of_the_simulation_default(
+        self, brian2_config, tmp_path
+    ):
+        """The two Brian2 defaults are separate: `sugar` for stimuli, all point neurons for the
+        simulation. Collapsing them would push the stimulus over its 100-neuron ceiling on a real
+        circuit."""
+        config = brian2_config(blocks={"DirectPoisson": Brian2DirectPoissonStimulus()})
+
+        result = generate(config, tmp_path)
+
+        stimulus_ids = result.node_sets[DEFAULT_BRIAN2_STIMULUS_NODE_SET]["node_id"]
+        simulation_ids = result.node_sets[result.sonata_config["node_set"]]["node_id"]
+        assert set(stimulus_ids) < set(simulation_ids)

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_timestamps_and_distributions.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_timestamps_and_distributions.py
@@ -1,0 +1,179 @@
+"""Timestamps and distribution blocks, exercised through the stimuli that consume them.
+
+Neither block type emits SONATA of its own: timestamps expand a stimulus into repeated inputs,
+and distributions shape the spike trains a distribution-driven stimulus writes. Both are covered
+here by generating a simulation and inspecting what came out.
+"""
+
+import inspect
+import typing
+
+import h5py
+import numpy as np
+import pytest
+
+import obi_one as obi
+from obi_one.scientific.blocks.neuron_sets.id import VirtualPopulationIDNeuronSet
+from obi_one.scientific.tasks.generate_simulations.config.neuron.neuron_circuit import (
+    CircuitSimulationSingleConfig,
+)
+from obi_one.scientific.unions_and_references.distributions import AllDistributionsUnion
+from obi_one.scientific.unions_and_references.timestamps import TimestampsUnion
+
+from tests.obi_one.scientific.tasks.simulation_campaign_generation.conftest import (
+    VIRTUAL_POPULATION,
+    build_config,
+    generate,
+)
+
+TIMESTAMPS = {
+    "SingleTimestamp": obi.SingleTimestamp(start_time=0.0),
+    "RegularTimestamps": obi.RegularTimestamps(
+        start_time=0.0, number_of_repetitions=2, interval=25.0
+    ),
+}
+
+# Distributions that produce non-negative samples, so they can stand in for an inter-spike
+# interval. The integer-valued ones are included because the union accepts them.
+DISTRIBUTIONS = {
+    "FloatConstantDistribution": obi.FloatConstantDistribution(value=10.0),
+    "FloatUniformDistribution": obi.FloatUniformDistribution(low=5.0, high=15.0),
+    "ExponentialDistribution": obi.ExponentialDistribution(scale=10.0),
+    "GammaDistribution": obi.GammaDistribution(shape=2.0, scale=5.0),
+    "NormalDistribution": obi.NormalDistribution(mean=10.0, standard_deviation=1.0, min=0.1),
+    "LogNormalDistribution": obi.LogNormalDistribution(mean=2.0, sigma=0.5),
+    "PoissonDistribution": obi.PoissonDistribution(rate=10.0, min=1.0),
+    "IntConstantDistribution": obi.IntConstantDistribution(value=10),
+    "IntUniformDistribution": obi.IntUniformDistribution(low=5, high=15),
+    "IntDiscreteDistribution": obi.IntDiscreteDistribution(
+        values=[5, 10, 20], probabilities=[0.3, 0.4, 0.3]
+    ),
+}
+
+
+def _union_member_names(union) -> set[str]:
+    inner = typing.get_args(union)[0]
+    if inspect.isclass(inner):
+        return {inner.__name__}
+    return {cls.__name__ for cls in typing.get_args(inner) if inspect.isclass(cls)}
+
+
+def _distribution_driven_config(circuit, distribution):
+    source = VirtualPopulationIDNeuronSet(
+        population=VIRTUAL_POPULATION,
+        neuron_ids=obi.NamedTuple(name="source", elements=[0, 1, 2]),
+    )
+    return build_config(
+        CircuitSimulationSingleConfig,
+        circuit=circuit,
+        blocks={
+            "Source": source,
+            "Distribution": distribution,
+            "Spikes": lambda: obi.InterSpikeIntervalDistributionSpikeStimulus(
+                source_neuron_set=source.ref,
+                distribution=obi.AllDistributionsReference(
+                    block_dict_name="distributions", block_name="Distribution"
+                ),
+                duration=100.0,
+            ),
+        },
+    )
+
+
+class TestUnionCoverage:
+    def test_every_timestamps_block_is_exercised(self):
+        assert _union_member_names(TimestampsUnion) == set(TIMESTAMPS)
+
+    def test_every_distribution_is_exercised(self):
+        assert _union_member_names(AllDistributionsUnion) == set(DISTRIBUTIONS)
+
+
+class TestTimestamps:
+    @pytest.mark.parametrize("name", sorted(TIMESTAMPS))
+    def test_a_stimulus_can_be_driven_by_each_timestamps_block(self, name, circuit, tmp_path):
+        timestamps = TIMESTAMPS[name].model_copy(deep=True)
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "When": timestamps,
+                "Clamp": lambda: obi.ConstantCurrentClampSomaticStimulus(
+                    timestamps=timestamps.ref, duration=5.0
+                ),
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert len(result.inputs) == len(timestamps.timestamps())
+
+    def test_regular_timestamps_are_evenly_spaced(self, circuit, tmp_path):
+        timestamps = obi.RegularTimestamps(start_time=10.0, number_of_repetitions=4, interval=15.0)
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "When": timestamps,
+                "Clamp": lambda: obi.ConstantCurrentClampSomaticStimulus(
+                    timestamps=timestamps.ref, duration=5.0
+                ),
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        delays = [result.inputs[f"Clamp_{i}"]["delay"] for i in range(4)]
+        assert delays == [10.0, 25.0, 40.0, 55.0]
+
+    def test_an_unused_timestamps_block_changes_nothing(self, circuit, tmp_path):
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "Unused": obi.RegularTimestamps(
+                    start_time=0.0, number_of_repetitions=5, interval=10.0
+                ),
+                "Clamp": obi.ConstantCurrentClampSomaticStimulus(),
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert set(result.inputs) == {"Clamp_0"}
+
+
+class TestDistributions:
+    @pytest.mark.parametrize("name", sorted(DISTRIBUTIONS))
+    def test_each_distribution_can_drive_a_spike_stimulus(self, name, circuit, tmp_path):
+        config = _distribution_driven_config(circuit, DISTRIBUTIONS[name].model_copy(deep=True))
+
+        result = generate(config, tmp_path)
+
+        spike_file = result.directory / "Spikes_spikes.h5"
+        assert spike_file.exists()
+        with h5py.File(spike_file, "r") as handle:
+            timestamps = np.array(handle[f"spikes/{VIRTUAL_POPULATION}/timestamps"])
+        assert np.all(timestamps >= 0.0)
+
+    def test_a_constant_interval_produces_regularly_spaced_spikes(self, circuit, tmp_path):
+        """A constant inter-spike interval is the one case with a predictable spike train."""
+        config = _distribution_driven_config(circuit, obi.FloatConstantDistribution(value=10.0))
+
+        result = generate(config, tmp_path)
+
+        with h5py.File(result.directory / "Spikes_spikes.h5", "r") as handle:
+            node_ids = np.array(handle[f"spikes/{VIRTUAL_POPULATION}/node_ids"])
+            timestamps = np.array(handle[f"spikes/{VIRTUAL_POPULATION}/timestamps"])
+
+        for node_id in np.unique(node_ids):
+            spikes = np.sort(timestamps[node_ids == node_id])
+            intervals = np.diff(spikes)
+            assert np.allclose(intervals, 10.0)
+
+    def test_an_unused_distribution_changes_nothing(self, circuit_config, tmp_path):
+        config = circuit_config(blocks={"Unused": obi.ExponentialDistribution(scale=10.0)})
+
+        result = generate(config, tmp_path)
+
+        assert result.inputs == {}
+        assert "Unused" not in result.node_sets

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_timestamps_and_distributions.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_timestamps_and_distributions.py
@@ -5,9 +5,6 @@ and distributions shape the spike trains a distribution-driven stimulus writes. 
 here by generating a simulation and inspecting what came out.
 """
 
-import inspect
-import typing
-
 import h5py
 import numpy as np
 import pytest
@@ -24,6 +21,7 @@ from tests.obi_one.scientific.tasks.simulation_campaign_generation.conftest impo
     VIRTUAL_POPULATION,
     build_config,
     generate,
+    union_member_names,
 )
 
 TIMESTAMPS = {
@@ -51,13 +49,6 @@ DISTRIBUTIONS = {
 }
 
 
-def _union_member_names(union) -> set[str]:
-    inner = typing.get_args(union)[0]
-    if inspect.isclass(inner):
-        return {inner.__name__}
-    return {cls.__name__ for cls in typing.get_args(inner) if inspect.isclass(cls)}
-
-
 def _distribution_driven_config(circuit, distribution):
     source = VirtualPopulationIDNeuronSet(
         population=VIRTUAL_POPULATION,
@@ -82,10 +73,10 @@ def _distribution_driven_config(circuit, distribution):
 
 class TestUnionCoverage:
     def test_every_timestamps_block_is_exercised(self):
-        assert _union_member_names(TimestampsUnion) == set(TIMESTAMPS)
+        assert union_member_names(TimestampsUnion) == set(TIMESTAMPS)
 
     def test_every_distribution_is_exercised(self):
-        assert _union_member_names(AllDistributionsUnion) == set(DISTRIBUTIONS)
+        assert union_member_names(AllDistributionsUnion) == set(DISTRIBUTIONS)
 
 
 class TestTimestamps:

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_unset_block_references.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_unset_block_references.py
@@ -1,0 +1,593 @@
+"""Blocks whose every block-reference field is left unset.
+
+Reference fields are all optional and all default to ``None``, so "the user added a block and
+targeted nothing" is the most common config there is. Resolving those ``None``s is spread across
+several places -- the task fills some in on the block itself before generating, while others stay
+``None`` and are resolved to a bare node set *name* inside the block's own ``config()``. These
+tests pin what an unset reference currently produces, so that consolidating the two mechanisms
+can be checked against real output rather than by reading.
+
+The parametrised sweeps build their cases from the block unions themselves, so a newly added
+block type is covered here without anyone editing this file.
+"""
+
+import pytest
+
+import obi_one as obi
+from obi_one.scientific.blocks.neuron_sets.population import PointPopulationNeuronSet
+from obi_one.scientific.blocks.neuronal_manipulations.neuronal_manipulations import (
+    ByNeuronMechanismVariableNeuronalManipulation,
+    ByNeuronModification,
+    BySectionListMechanismVariableNeuronalManipulation,
+    BySectionListModification,
+)
+from obi_one.scientific.blocks.stimuli.brian2_poisson import Brian2DirectPoissonStimulus
+from obi_one.scientific.blocks.stimuli.spike.base import SpikeStimulus
+from obi_one.scientific.tasks.generate_simulations.config.neuron.neuron_circuit import (
+    CircuitSimulationSingleConfig,
+)
+from obi_one.scientific.unions_and_references.combined_neuron_sets import (
+    NEURONSimulationNeuronSetUnion,
+)
+from obi_one.scientific.unions_and_references.manipulations import SynapticManipulationsUnion
+from obi_one.scientific.unions_and_references.morphology_locations import (
+    MorphologyLocationUnion,
+)
+from obi_one.scientific.unions_and_references.neuronal_manipulations import (
+    NeuronalManipulationUnion,
+)
+from obi_one.scientific.unions_and_references.recordings import RecordingUnion
+from obi_one.scientific.unions_and_references.stimuli import CircuitStimulusUnion
+
+from tests.obi_one.scientific.tasks.simulation_campaign_generation.conftest import (
+    DEFAULT_BIOPHYSICAL_NODE_SET,
+    DEFAULT_BRIAN2_STIMULUS_NODE_SET,
+    DEFAULT_POINT_NODE_SET,
+    DEFAULT_VIRTUAL_NODE_SET,
+    POINT_POPULATION,
+    build_config,
+    generate,
+    reference_field_names,
+    union_member_names,
+)
+
+# Every block in these unions is constructible with no arguments, so "all references unset" is
+# just the default construction.
+CIRCUIT_STIMULI = sorted(union_member_names(CircuitStimulusUnion))
+RECORDINGS = sorted(union_member_names(RecordingUnion))
+SYNAPTIC_MANIPULATIONS = sorted(union_member_names(SynapticManipulationsUnion))
+MORPHOLOGY_LOCATIONS = sorted(union_member_names(MorphologyLocationUnion))
+COMBINED_NEURON_SETS = sorted(
+    name for name in union_member_names(NEURONSimulationNeuronSetUnion) if "Combined" in name
+)
+
+# Neuronal manipulations take a required `modification`, so each needs a factory rather than
+# bare construction. Their `neuron_set` is still left unset, which is what these cases are for.
+NEURONAL_MANIPULATIONS = {
+    "ByNeuronMechanismVariableNeuronalManipulation": lambda: (
+        ByNeuronMechanismVariableNeuronalManipulation(
+            modification=ByNeuronModification(
+                variable_name="Ra", variable_type="RANGE", new_value=100.0
+            )
+        )
+    ),
+    "BySectionListMechanismVariableNeuronalManipulation": lambda: (
+        BySectionListMechanismVariableNeuronalManipulation(
+            modification=BySectionListModification(
+                variable_name="cm", section_list_modifications={"somatic": 1.5}
+            )
+        )
+    ),
+}
+
+# Which default a combined set with an unset base falls back to, by its own population type.
+EXPECTED_COMBINED_DEFAULTS = {
+    "BiophysicalCombinedNeuronSet": DEFAULT_BIOPHYSICAL_NODE_SET,
+    "NonVirtualCombinedNeuronSet": DEFAULT_BIOPHYSICAL_NODE_SET,
+    "VirtualCombinedNeuronSet": DEFAULT_VIRTUAL_NODE_SET,
+    "PointCombinedNeuronSet": DEFAULT_POINT_NODE_SET,
+}
+
+
+def _block(name: str):
+    """Construct a block by class name with every field, references included, left at default."""
+    return getattr(obi, name)()
+
+
+def _input_entry(result, name: str) -> dict:
+    """The generated input for a stimulus, whichever key convention it used.
+
+    Continuous stimuli emit one entry per timestamp (``Clamp_0``); spike stimuli emit a single
+    entry under the bare block name.
+    """
+    if name in result.inputs:
+        return result.inputs[name]
+    return result.inputs[f"{name}_0"]
+
+
+class TestReferenceFieldsAreAllOptional:
+    """The precondition for everything else in this module."""
+
+    @pytest.mark.parametrize(
+        "name",
+        CIRCUIT_STIMULI + RECORDINGS + SYNAPTIC_MANIPULATIONS + MORPHOLOGY_LOCATIONS,
+    )
+    def test_every_reference_field_defaults_to_none(self, name):
+        block_class = getattr(obi, name)
+        fields = reference_field_names(block_class)
+
+        assert fields, f"{name} was expected to have at least one reference field"
+        for field in fields:
+            assert block_class.model_fields[field].default is None
+
+    def test_a_block_constructed_with_no_arguments_has_no_targets(self):
+        stimulus = obi.ConstantCurrentClampSomaticStimulus()
+
+        assert stimulus.neuron_set is None
+        assert stimulus.timestamps is None
+
+
+class TestUnsetReferencesResolveToTheDefault:
+    """Whatever the mechanism, an unset reference must end up naming the default neuron set."""
+
+    @pytest.mark.parametrize("name", CIRCUIT_STIMULI)
+    def test_stimulus_targets_the_default_neuron_set(self, name, circuit, tmp_path):
+        config = build_config(
+            CircuitSimulationSingleConfig, circuit=circuit, blocks={"Stim": _block(name)}
+        )
+
+        result = generate(config, tmp_path)
+
+        assert _input_entry(result, "Stim")["node_set"] == DEFAULT_BIOPHYSICAL_NODE_SET
+
+    @pytest.mark.parametrize("name", RECORDINGS)
+    def test_recording_records_the_default_neuron_set(self, name, circuit, tmp_path):
+        config = build_config(
+            CircuitSimulationSingleConfig, circuit=circuit, blocks={"Rec": _block(name)}
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.reports["Rec"]["cells"] == DEFAULT_BIOPHYSICAL_NODE_SET
+
+    @pytest.mark.parametrize("name", SYNAPTIC_MANIPULATIONS)
+    def test_synaptic_manipulation_spans_the_default_on_both_sides(self, name, circuit, tmp_path):
+        config = build_config(
+            CircuitSimulationSingleConfig, circuit=circuit, blocks={"Manip": _block(name)}
+        )
+
+        result = generate(config, tmp_path)
+
+        override = result.sonata_config["connection_overrides"][0]
+        assert override["source"] == DEFAULT_BIOPHYSICAL_NODE_SET
+        assert override["target"] == DEFAULT_BIOPHYSICAL_NODE_SET
+
+    @pytest.mark.parametrize("name", COMBINED_NEURON_SETS)
+    def test_combined_neuron_set_base_is_filled_with_its_population_default(
+        self, name, circuit, point_circuit, tmp_path
+    ):
+        """Each combined set picks up the default for its own population type.
+
+        A point combined set needs a circuit with a point population to resolve against, and a
+        simulation target that is itself a point set, so it gets the drosophila circuit.
+        """
+        is_point = name == "PointCombinedNeuronSet"
+        blocks: dict = {"Combined": _block(name)}
+        if is_point:
+            target = PointPopulationNeuronSet(population=POINT_POPULATION)
+            blocks = {"Target": target, **blocks}
+
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=point_circuit if is_point else circuit,
+            blocks=blocks,
+        )
+        if is_point:
+            config.initialize.node_set = config.neuron_sets["Target"].ref
+
+        result = generate(config, tmp_path)
+
+        base = config.neuron_sets["Combined"].base_neuron_set
+        assert base is not None
+        assert base.block_name == (
+            DEFAULT_POINT_NODE_SET if is_point else EXPECTED_COMBINED_DEFAULTS[name]
+        )
+        assert base.block_name in result.node_sets
+
+    @pytest.mark.parametrize("name", MORPHOLOGY_LOCATIONS)
+    def test_morphology_locations_target_the_default_neuron_set(
+        self, name, morphology_circuit, tmp_path
+    ):
+        locations = _block(name)
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=morphology_circuit,
+            blocks={
+                "Locations": locations,
+                "Clamp": lambda: obi.ConstantCurrentClampSomaticStimulus(neuron_set=locations.ref),
+            },
+        )
+
+        generate(config, tmp_path)
+
+        assert config.morphology_locations["Locations"].neuron_set.block_name == (
+            DEFAULT_BIOPHYSICAL_NODE_SET
+        )
+
+    def test_neuronal_manipulation_applies_to_the_default_neuron_set(
+        self, me_model_config, tmp_path
+    ):
+        config = me_model_config(
+            blocks={
+                "Manip": ByNeuronMechanismVariableNeuronalManipulation(
+                    modification=ByNeuronModification(
+                        variable_name="Ra", variable_type="RANGE", new_value=100.0
+                    )
+                )
+            }
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.conditions["modifications"][0]["node_set"] == DEFAULT_BIOPHYSICAL_NODE_SET
+
+    def test_unset_simulation_target_resolves_to_the_default(self, circuit_config, tmp_path):
+        config = circuit_config()
+        assert config.initialize.node_set is None
+
+        result = generate(config, tmp_path)
+
+        assert result.sonata_config["node_set"] == DEFAULT_BIOPHYSICAL_NODE_SET
+
+
+class TestNoDanglingNodeSetReferences:
+    """The invariant that matters: a name the config points at must exist in node_sets.json.
+
+    The default neuron set is created as a side effect of resolving an unset reference. If that
+    side effect is ever lost -- or happens after the node sets file is written -- the generated
+    config silently references a node set that is not there, and the simulator fails at run time
+    rather than here.
+    """
+
+    @pytest.mark.parametrize("name", CIRCUIT_STIMULI)
+    def test_a_single_untargeted_stimulus_leaves_nothing_dangling(self, name, circuit, tmp_path):
+        config = build_config(
+            CircuitSimulationSingleConfig, circuit=circuit, blocks={"Stim": _block(name)}
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.dangling_node_sets() == set()
+
+    def test_a_config_whose_only_block_is_a_manipulation(self, circuit, tmp_path):
+        """Nothing else creates the default here, so only the manipulation can have done it."""
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={"Manip": obi.SynapticMgManipulation()},
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.referenced_node_sets() == {DEFAULT_BIOPHYSICAL_NODE_SET}
+        assert result.dangling_node_sets() == set()
+
+    def test_every_block_family_untargeted_at_once(self, circuit, tmp_path):
+        """One block of each kind, none of them targeting anything."""
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "Clamp": obi.ConstantCurrentClampSomaticStimulus(),
+                "Spikes": obi.PoissonSpikeStimulus(),
+                "Voltage": obi.SomaVoltageRecording(),
+                "Window": obi.TimeWindowSomaVoltageRecording(start_time=0.0, end_time=10.0),
+                "Magnesium": obi.SynapticMgManipulation(),
+                "Acetylcholine": obi.ScaleAcetylcholineUSESynapticManipulation(),
+                "Combined": obi.BiophysicalCombinedNeuronSet(),
+            },
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.dangling_node_sets() == set()
+
+    def test_untargeted_me_model_blocks_leave_nothing_dangling(self, me_model_config, tmp_path):
+        config = me_model_config(
+            blocks={
+                "Clamp": obi.ConstantCurrentClampSomaticStimulus(),
+                "Voltage": obi.SomaVoltageRecording(),
+            }
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.dangling_node_sets() == set()
+
+    def test_untargeted_brian2_stimulus_leaves_nothing_dangling(self, brian2_config, tmp_path):
+        """Brian2 resolves two different defaults, and both node sets have to be written."""
+        config = brian2_config(blocks={"DirectPoisson": Brian2DirectPoissonStimulus()})
+
+        result = generate(config, tmp_path)
+
+        assert result.referenced_node_sets() == {
+            DEFAULT_POINT_NODE_SET,
+            DEFAULT_BRIAN2_STIMULUS_NODE_SET,
+        }
+        assert result.dangling_node_sets() == set()
+
+    def test_untargeted_learning_engine_stimulus_leaves_nothing_dangling(
+        self, learning_engine_config, tmp_path
+    ):
+        config = learning_engine_config(blocks={"Clamp": obi.ConstantCurrentClampSomaticStimulus()})
+
+        result = generate(config, tmp_path)
+
+        assert result.dangling_node_sets() == set()
+
+    def test_the_default_is_created_exactly_once(self, circuit, tmp_path):
+        """Several untargeted blocks share one injected default rather than each adding one."""
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "First": obi.ConstantCurrentClampSomaticStimulus(),
+                "Second": obi.HyperpolarizingCurrentClampSomaticStimulus(),
+                "Voltage": obi.SomaVoltageRecording(),
+            },
+        )
+
+        generate(config, tmp_path)
+
+        assert list(config.neuron_sets) == [DEFAULT_BIOPHYSICAL_NODE_SET]
+
+
+class TestWhichReferencesAreFilledInPlace:
+    """Characterisation of the current split between the two resolution mechanisms.
+
+    Stimuli, recordings, morphology locations and combined neuron sets have their unset
+    references replaced with a real reference on the block before generation. Timestamps,
+    distributions and both kinds of manipulation are left ``None`` and resolved to a node set
+    name inside the block's own ``config()``. The generated SONATA is the same either way, which
+    is exactly why the divergence is easy to miss -- these assertions make it visible.
+    """
+
+    def test_stimulus_and_recording_targets_are_filled_on_the_block(self, circuit, tmp_path):
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "Clamp": obi.ConstantCurrentClampSomaticStimulus(),
+                "Voltage": obi.SomaVoltageRecording(),
+            },
+        )
+
+        generate(config, tmp_path)
+
+        assert config.stimuli["Clamp"].neuron_set is not None
+        assert config.recordings["Voltage"].neuron_set is not None
+
+    def test_spike_stimulus_source_and_target_are_both_filled(self, circuit, tmp_path):
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={"Spikes": obi.PoissonSpikeStimulus()},
+        )
+
+        generate(config, tmp_path)
+
+        stimulus = config.stimuli["Spikes"]
+        assert stimulus.source_neuron_set.block_name == DEFAULT_BIOPHYSICAL_NODE_SET
+        assert stimulus.targeted_neuron_set.block_name == DEFAULT_BIOPHYSICAL_NODE_SET
+
+    def test_timestamps_are_left_unset_on_the_block(self, circuit, tmp_path):
+        """The default timestamps never reach the config; they are applied during generation."""
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={"Clamp": obi.ConstantCurrentClampSomaticStimulus()},
+        )
+
+        result = generate(config, tmp_path)
+
+        assert config.stimuli["Clamp"].timestamps is None
+        assert result.inputs["Clamp_0"]["delay"] == pytest.approx(0.0)
+
+    def test_manipulation_targets_are_left_unset_on_the_block(self, circuit, tmp_path):
+        """Unlike stimuli, a manipulation keeps its ``None`` and is resolved by name later."""
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={"Magnesium": obi.SynapticMgManipulation()},
+        )
+
+        result = generate(config, tmp_path)
+
+        manipulation = config.synaptic_manipulations["Magnesium"]
+        assert manipulation.presynaptic_neuron_set is None
+        assert manipulation.postsynaptic_neuron_set is None
+        assert result.sonata_config["connection_overrides"][0]["source"] == (
+            DEFAULT_BIOPHYSICAL_NODE_SET
+        )
+
+    def test_neuronal_manipulation_target_is_left_unset_on_the_block(
+        self, me_model_config, tmp_path
+    ):
+        config = me_model_config(
+            blocks={
+                "Manip": ByNeuronMechanismVariableNeuronalManipulation(
+                    modification=ByNeuronModification(
+                        variable_name="Ra", variable_type="RANGE", new_value=100.0
+                    )
+                )
+            }
+        )
+
+        result = generate(config, tmp_path)
+
+        assert config.neuronal_manipulations["Manip"].neuron_set is None
+        assert result.conditions["modifications"][0]["node_set"] == DEFAULT_BIOPHYSICAL_NODE_SET
+
+
+class TestConfigWithoutANeuronSetsDictionary:
+    """The ME model config has no ``neuron_sets`` field, so nothing is filled in on its blocks.
+
+    It reaches the same SONATA output through the blocks' own default-node-set fallback. That is
+    the second mechanism producing the first mechanism's result, on a different config family.
+    """
+
+    def test_references_stay_unset_on_the_blocks(self, me_model_config, tmp_path):
+        config = me_model_config(
+            blocks={
+                "Clamp": obi.ConstantCurrentClampSomaticStimulus(),
+                "Voltage": obi.SomaVoltageRecording(),
+            }
+        )
+        assert not hasattr(config, "neuron_sets")
+
+        generate(config, tmp_path)
+
+        assert config.stimuli["Clamp"].neuron_set is None
+        assert config.recordings["Voltage"].neuron_set is None
+
+    def test_the_output_still_names_the_default(self, me_model_config, tmp_path):
+        config = me_model_config(
+            blocks={
+                "Clamp": obi.ConstantCurrentClampSomaticStimulus(),
+                "Voltage": obi.SomaVoltageRecording(),
+            }
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.inputs["Clamp_0"]["node_set"] == DEFAULT_BIOPHYSICAL_NODE_SET
+        assert result.reports["Voltage"]["cells"] == DEFAULT_BIOPHYSICAL_NODE_SET
+
+    def test_the_default_node_set_is_still_written(self, me_model_config, tmp_path):
+        result = generate(me_model_config(), tmp_path)
+
+        assert DEFAULT_BIOPHYSICAL_NODE_SET in result.node_sets
+
+
+class TestUnsetTimestampsAndDistributions:
+    """The two reference kinds that do not name a neuron set."""
+
+    @pytest.mark.parametrize("name", CIRCUIT_STIMULI)
+    def test_an_unset_timestamps_reference_starts_the_stimulus_at_zero(
+        self, name, circuit, tmp_path
+    ):
+        config = build_config(
+            CircuitSimulationSingleConfig, circuit=circuit, blocks={"Stim": _block(name)}
+        )
+
+        result = generate(config, tmp_path)
+
+        assert _input_entry(result, "Stim")["delay"] == pytest.approx(0.0)
+
+    def test_a_continuous_stimulus_without_timestamps_emits_exactly_one_input(
+        self, circuit, tmp_path
+    ):
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={"Clamp": obi.ConstantCurrentClampSomaticStimulus()},
+        )
+
+        result = generate(config, tmp_path)
+
+        assert set(result.inputs) == {"Clamp_0"}
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "InterSpikeIntervalDistributionSpikeStimulus",
+            "SpikeTimeDistributionSpikeStimulus",
+        ],
+    )
+    def test_a_distribution_driven_stimulus_generates_without_a_distribution(
+        self, name, circuit, tmp_path
+    ):
+        """These stimuli fall back to their own distribution rather than failing."""
+        config = build_config(
+            CircuitSimulationSingleConfig, circuit=circuit, blocks={"Stim": _block(name)}
+        )
+
+        result = generate(config, tmp_path)
+
+        assert config.stimuli["Stim"].distribution is None
+        assert result.inputs["Stim"]["spike_file"] == "Stim_spikes.h5"
+        assert (result.directory / "Stim_spikes.h5").exists()
+
+
+class TestUnsetReferencesAcrossEveryBlockAtOnce:
+    def test_a_config_of_entirely_untargeted_blocks_generates_valid_sonata(self, circuit, tmp_path):
+        """The end state this module is really about: nothing anywhere points at anything."""
+        blocks = {name: _block(name) for name in CIRCUIT_STIMULI}
+        blocks |= {name: _block(name) for name in RECORDINGS}
+        blocks |= {name: _block(name) for name in SYNAPTIC_MANIPULATIONS}
+
+        config = build_config(CircuitSimulationSingleConfig, circuit=circuit, blocks=blocks)
+
+        result = generate(config, tmp_path)
+
+        assert result.dangling_node_sets() == set()
+        assert result.referenced_node_sets() == {DEFAULT_BIOPHYSICAL_NODE_SET}
+        assert len(result.inputs) == len(CIRCUIT_STIMULI)
+        assert len(result.reports) == len(RECORDINGS)
+        assert len(result.sonata_config["connection_overrides"]) == len(SYNAPTIC_MANIPULATIONS)
+
+    def test_spike_stimuli_are_the_only_ones_that_can_target_a_virtual_source(
+        self, circuit, tmp_path
+    ):
+        """An unset spike source defaults to the biophysical set, not a virtual population.
+
+        The source is allowed to be virtual, so the default could plausibly have been the virtual
+        one; it is not, and replay spikes are generated from the biophysical cells instead.
+        """
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={"Spikes": obi.PoissonSpikeStimulus()},
+        )
+
+        result = generate(config, tmp_path)
+
+        assert isinstance(config.stimuli["Spikes"], SpikeStimulus)
+        assert config.stimuli["Spikes"].source_neuron_set.block_name == (
+            DEFAULT_BIOPHYSICAL_NODE_SET
+        )
+        assert (result.directory / "Spikes_spikes.h5").exists()
+
+
+class TestUntargetedNeuronalManipulations:
+    """Neuronal manipulations need a ``modification``, so they cannot use the sweeps above."""
+
+    @pytest.mark.parametrize("name", sorted(union_member_names(NeuronalManipulationUnion)))
+    def test_the_target_is_optional_and_unset_by_default(self, name):
+        block_class = NEURONAL_MANIPULATIONS[name]().__class__
+
+        assert "neuron_set" in reference_field_names(block_class)
+        assert block_class.model_fields["neuron_set"].default is None
+
+    @pytest.mark.parametrize("name", sorted(NEURONAL_MANIPULATIONS))
+    def test_an_untargeted_manipulation_applies_to_the_default(
+        self, name, me_model_config, tmp_path
+    ):
+        config = me_model_config(blocks={"Manip": NEURONAL_MANIPULATIONS[name]()})
+
+        result = generate(config, tmp_path)
+
+        assert config.neuronal_manipulations["Manip"].neuron_set is None
+        modifications = result.conditions["modifications"]
+        assert modifications
+        for modification in modifications:
+            assert modification["node_set"] == DEFAULT_BIOPHYSICAL_NODE_SET
+
+    def test_an_untargeted_manipulation_leaves_nothing_dangling(self, me_model_config, tmp_path):
+        config = me_model_config(
+            blocks={name: factory() for name, factory in NEURONAL_MANIPULATIONS.items()}
+        )
+
+        result = generate(config, tmp_path)
+
+        assert result.dangling_node_sets() == set()

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_unset_block_references.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_unset_block_references.py
@@ -14,6 +14,7 @@ block type is covered here without anyone editing this file.
 import pytest
 
 import obi_one as obi
+from obi_one.scientific.blocks.neuron_sets.deprecated import AllNeurons
 from obi_one.scientific.blocks.neuron_sets.population import PointPopulationNeuronSet
 from obi_one.scientific.blocks.neuronal_manipulations.neuronal_manipulations import (
     ByNeuronMechanismVariableNeuronalManipulation,
@@ -48,6 +49,7 @@ from tests.obi_one.scientific.tasks.simulation_campaign_generation.conftest impo
     build_config,
     generate,
     reference_field_names,
+    reference_types_in,
     union_member_names,
 )
 
@@ -60,6 +62,48 @@ MORPHOLOGY_LOCATIONS = sorted(union_member_names(MorphologyLocationUnion))
 COMBINED_NEURON_SETS = sorted(
     name for name in union_member_names(NEURONSimulationNeuronSetUnion) if "Combined" in name
 )
+
+ALL_BLOCK_UNIONS = (
+    CircuitStimulusUnion,
+    RecordingUnion,
+    SynapticManipulationsUnion,
+    NeuronalManipulationUnion,
+    MorphologyLocationUnion,
+    NEURONSimulationNeuronSetUnion,
+)
+
+BLOCK_CLASSES = {
+    name: cls
+    for union in ALL_BLOCK_UNIONS
+    for name in union_member_names(union)
+    for cls in [
+        getattr(obi, name, None)
+        or {
+            "ByNeuronMechanismVariableNeuronalManipulation": (
+                ByNeuronMechanismVariableNeuronalManipulation
+            ),
+            "BySectionListMechanismVariableNeuronalManipulation": (
+                BySectionListMechanismVariableNeuronalManipulation
+            ),
+            "AllNeurons": AllNeurons,
+        }[name]
+    ]
+}
+
+# Every reference-holding field a simulation-generation block can have, each with a case below.
+# Seven name neuron sets, one names timestamps, one names a distribution.
+COVERED_REFERENCE_FIELDS = {
+    "neuron_set",
+    "source_neuron_set",
+    "targeted_neuron_set",
+    "presynaptic_neuron_set",
+    "postsynaptic_neuron_set",
+    "base_neuron_set",
+    "combined_with",
+    "initialize.node_set",
+    "timestamps",
+    "distribution",
+}
 
 # Neuronal manipulations take a required `modification`, so each needs a factory rather than
 # bare construction. Their `neuron_set` is still left unset, which is what these cases are for.
@@ -105,8 +149,43 @@ def _input_entry(result, name: str) -> dict:
     return result.inputs[f"{name}_0"]
 
 
-class TestReferenceFieldsAreAllOptional:
-    """The precondition for everything else in this module."""
+class TestEveryReferenceFieldIsExercised:
+    """Proves the sweeps below reach every reference field, not just the neuron set ones.
+
+    Simulation-generation blocks carry three kinds of reference: neuron sets (seven differently
+    named fields), timestamps and distributions. It is easy to cover the neuron set fields and
+    assume the rest came along, so the covered set is asserted against what introspection finds.
+    A new reference field on any block fails this test until it is added to the list and given a
+    case below.
+    """
+
+    def test_the_covered_fields_are_all_the_fields_there_are(self):
+        found = {
+            field
+            for union in ALL_BLOCK_UNIONS
+            for name in union_member_names(union)
+            for field in reference_field_names(BLOCK_CLASSES[name])
+        }
+        found |= {
+            f"initialize.{field}"
+            for field in reference_field_names(CircuitSimulationSingleConfig.Initialize)
+        }
+
+        assert found == COVERED_REFERENCE_FIELDS
+
+    def test_the_three_reference_kinds_are_all_represented(self):
+        kinds = {
+            reference.__name__
+            for union in ALL_BLOCK_UNIONS
+            for name in union_member_names(union)
+            for field_info in BLOCK_CLASSES[name].model_fields.values()
+            for reference in reference_types_in(field_info.annotation)
+        }
+
+        assert "TimestampsReference" in kinds
+        assert "AllDistributionsReference" in kinds
+        assert "MorphologyLocationsReference" in kinds
+        assert any(name.endswith("NeuronSetReference") for name in kinds)
 
     @pytest.mark.parametrize(
         "name",
@@ -119,6 +198,14 @@ class TestReferenceFieldsAreAllOptional:
         assert fields, f"{name} was expected to have at least one reference field"
         for field in fields:
             assert block_class.model_fields[field].default is None
+
+    @pytest.mark.parametrize("name", COMBINED_NEURON_SETS)
+    def test_a_combined_neuron_set_starts_with_no_operands(self, name):
+        """``combined_with`` is the one reference field that defaults to empty rather than None."""
+        block_class = getattr(obi, name)
+
+        assert block_class.model_fields["base_neuron_set"].default is None
+        assert block_class.model_fields["combined_with"].default == ()
 
     def test_a_block_constructed_with_no_arguments_has_no_targets(self):
         stimulus = obi.ConstantCurrentClampSomaticStimulus()
@@ -193,6 +280,37 @@ class TestUnsetReferencesResolveToTheDefault:
             DEFAULT_POINT_NODE_SET if is_point else EXPECTED_COMBINED_DEFAULTS[name]
         )
         assert base.block_name in result.node_sets
+
+    @pytest.mark.parametrize("name", COMBINED_NEURON_SETS)
+    def test_combined_neuron_set_operands_are_filled_too(
+        self, name, circuit, point_circuit, tmp_path
+    ):
+        """``combined_with`` entries are ``(reference, operation)`` pairs whose reference can
+        also be unset, and each one is filled with the same population default as the base."""
+        is_point = name == "PointCombinedNeuronSet"
+        combined = getattr(obi, name)(
+            base_neuron_set=None, combined_with=((None, "union"), (None, "union"))
+        )
+        blocks: dict = {"Combined": combined}
+        if is_point:
+            blocks = {"Target": PointPopulationNeuronSet(population=POINT_POPULATION), **blocks}
+
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=point_circuit if is_point else circuit,
+            blocks=blocks,
+        )
+        if is_point:
+            config.initialize.node_set = config.neuron_sets["Target"].ref
+
+        generate(config, tmp_path)
+
+        expected = EXPECTED_COMBINED_DEFAULTS[name]
+        operands = config.neuron_sets["Combined"].combined_with
+        assert len(operands) == 2
+        for reference, _operation in operands:
+            assert reference is not None
+            assert reference.block_name == expected
 
     @pytest.mark.parametrize("name", MORPHOLOGY_LOCATIONS)
     def test_morphology_locations_target_the_default_neuron_set(
@@ -496,6 +614,24 @@ class TestUnsetTimestampsAndDistributions:
         result = generate(config, tmp_path)
 
         assert set(result.inputs) == {"Clamp_0"}
+
+    @pytest.mark.parametrize(
+        "name", ["ConnectSynapticManipulation", "DisconnectSynapticManipulation"]
+    )
+    def test_a_delayed_manipulation_without_timestamps_applies_at_zero(
+        self, name, circuit, tmp_path
+    ):
+        """These two are the only manipulations carrying a timestamps reference."""
+        config = build_config(
+            CircuitSimulationSingleConfig, circuit=circuit, blocks={"Manip": _block(name)}
+        )
+
+        result = generate(config, tmp_path)
+
+        assert config.synaptic_manipulations["Manip"].timestamps is None
+        overrides = result.sonata_config["connection_overrides"]
+        assert len(overrides) == 1
+        assert overrides[0]["delay"] == pytest.approx(0.0)
 
     @pytest.mark.parametrize(
         "name",


### PR DESCRIPTION
Tests for `GenerateSimulationTask`, plus two bugs they turned up.

**Tests** — 365 tests in `tests/obi_one/scientific/tasks/simulation_campaign_generation/`

- Drive the task directly (no scan, no DB): build a SingleConfig, execute, assert on the files written
- Cover every block type: neuron sets, stimuli, recordings, timestamps, distributions, morphology locations, synaptic + neuronal manipulations
- Sweep every block with its reference fields left unset (`None`), which is the most common config and where the default-resolution logic is spread across several places
- Assert no generated config names a node set that is missing from `node_sets.json`
- Parametrised sweeps build their cases from the block unions, so a new block type is covered without editing the tests
- Also: circuit resolution/staging, compartment sets, entitycore asset uploads, whole-config snapshots per config family (Circuit, MEModel, MEModel+synapses, Brian2, LearningEngine)

**Fixes**

- Point/virtual neuron set defaults moved from `NeuronSimulationScanConfig` up to `BaseSimulationScanConfig`. Brian2 and LearningEngine configs accept `PointCombinedNeuronSet` but had no `default_point_neuron_set_reference`, so leaving its base unset raised `AttributeError` instead of picking up the point default.
- Registered `NeuronalManipulationReference` in the block reference registry. It was declared in `reference_types` on `MEModelSimulationScanConfig.neuronal_manipulations` but never registered, so `ScanConfig.add()` could not add a neuronal manipulation at all.