### PR TITLE
Resolve the SingleConfig class from TASK_MAP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ The core uses a **block-based compositional pattern**:
 
 - **`OBIBaseModel`** (`base.py`) - Pydantic base model with discriminator-based type field for polymorphic serialization. All domain models inherit from this.
 - **`Block`** (`block.py`) - Composable, parameterizable component. Any field set to a list becomes a dimension in a parameter scan.
-- **`ScanConfig`** (`scan_config.py`) - Abstract configuration composed of Blocks. Defines a modeling use case (e.g., `CircuitSimulationScanConfig`). Has class variables `name`, `description`, `single_coord_class_name`.
+- **`ScanConfig`** (`scan_config.py`) - Abstract configuration composed of Blocks. Defines a modeling use case (e.g., `CircuitSimulationScanConfig`). Has class variables `name` and `description`. The SingleConfig it expands into comes from its `TaskRegistration` in `config_task_map.TASK_MAP`, via the `single_config_class` property.
 - **`SingleConfigMixin`** (`single.py`) - Enforces that all parameters are single values (no lists). Used for execution-ready configs after scan expansion.
 - **`Task`** (`task.py`) - Abstract execution unit with an `execute()` method.
 - **`ScanGenerationTask`** (`scan_generation.py`) - Expands a ScanConfig into SingleConfigs via Cartesian product of multi-value parameters, then runs each.

--- a/docs/index.md
+++ b/docs/index.md
@@ -107,7 +107,7 @@ The package is split into **core/** and **scientific/** code.
 
 - **ScanConfig**: Defines configurations for specific modeling use cases. A Form is composed of one or multiple Blocks, which define the parameterization of a use case. Currently Forms can have both single Blocks and dictionaries of Blocks. Each Form has its own Initialize Block for specifying the base parameters of the use case.
 - **Block**: Defines a component of a ScanConfig. Blocks support the specification of parameters which should be scanned over in the multi-dimensional parameter scan. When using the Form (in a Jupyter Notebook for example), any parameter which is specified as a list is used as a dimension of a multi-dimensional parameter scan when passed to a Scan object.
-- **SingleConfig**: A single configuration instance within a scan.
+- **SingleConfig**: A single configuration instance within a scan. Which SingleConfig a given ScanConfig expands into is declared once in `config_task_map.TASK_MAP`, as the `scan_config_cls`/`single_config_cls` pair of that task's `TaskRegistration`. A ScanConfig reads it back through its `single_config_class` property, so the pairing does not have to be repeated on the config classes themselves.
 - **Task**: Defines executable tasks that operate on configurations.
 - **ScanGenerationTask**: Takes a single ScanConfig as input, an output path and a string for specifying how output files should be stored. The `scan.execute()` function can then be called which generates the multi-dimensional scan.
 

--- a/obi_one/core/registry.py
+++ b/obi_one/core/registry.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from entitysdk.types import AssetLabel, TaskActivityType, TaskConfigType
 
+    from obi_one.core.base import OBIBaseModel
     from obi_one.types import TaskType
 
 
@@ -32,8 +33,8 @@ class TaskRegistration:
     """
 
     task_cls: type
-    single_config_cls: type
-    scan_config_cls: type | None = None
+    single_config_cls: type[OBIBaseModel]
+    scan_config_cls: type[OBIBaseModel] | None = None
     asset_label: AssetLabel | None = None
     campaign_task_config_type: TaskConfigType | None = None
     campaign_generation_task_activity_type: TaskActivityType | None = None

--- a/obi_one/core/scan_config.py
+++ b/obi_one/core/scan_config.py
@@ -43,7 +43,6 @@ class ScanConfig(OBIBaseModel, extra="forbid"):
 
     name: ClassVar[str] = "Add a name class' name variable"
     description: ClassVar[str] = """Add a description to the class' description variable"""
-    single_coord_class_name: ClassVar[str] = ""
 
     _block_mapping: dict = None  # ty:ignore[invalid-assignment]
 
@@ -267,17 +266,28 @@ class ScanConfig(OBIBaseModel, extra="forbid"):
 
         return self
 
+    @property
+    def single_config_class(self) -> type[OBIBaseModel]:
+        """The SingleConfig class this ScanConfig expands into, from TASK_MAP."""
+        registration = task_registry.get_registration_for_scan_config(type(self))
+        if registration is None:
+            msg = (
+                f"'{type(self).__name__}' has no entry in TASK_MAP, so the SingleConfig "
+                "class it expands into cannot be resolved."
+            )
+            raise OBIONEError(msg)
+        return registration.single_config_cls
+
     def cast_to_single_coord(self) -> OBIBaseModel:
         """Cast the form to a single coordinate object."""
-        module = __import__(self.__module__)
-        class_to_cast_to = getattr(module, self.single_coord_class_name)
+        class_to_cast_to = self.single_config_class
         single_coord = class_to_cast_to.model_construct(**self.__dict__)
-        single_coord.type = self.single_coord_class_name
+        single_coord.type = class_to_cast_to.__name__
         return single_coord
 
     @property
     def single_coord_scan_default_subpath(self) -> str:
-        return self.single_coord_class_name + "/"
+        return self.single_config_class.__name__ + "/"
 
     def add(self, block: Block, name: str = "") -> None:
         block_dict_name = self.block_mapping[block.__class__.__name__]["block_dict_name"]

--- a/obi_one/scientific/mappings_and_registry/config_task_map.py
+++ b/obi_one/scientific/mappings_and_registry/config_task_map.py
@@ -2,6 +2,7 @@ from entitysdk.types import AssetLabel, TaskActivityType, TaskConfigType
 
 from obi_one.core.registry import TaskRegistration, task_registry
 from obi_one.scientific.tasks.basic_connectivity_plots import (
+    BasicConnectivityPlotsScanConfig,
     BasicConnectivityPlotsSingleConfig,
     BasicConnectivityPlotsTask,
 )
@@ -11,6 +12,7 @@ from obi_one.scientific.tasks.circuit_extraction import (
     CircuitExtractionTask,
 )
 from obi_one.scientific.tasks.connectivity_matrix_extraction import (
+    ConnectivityMatrixExtractionScanConfig,
     ConnectivityMatrixExtractionSingleConfig,
     ConnectivityMatrixExtractionTask,
 )
@@ -32,35 +34,44 @@ from obi_one.scientific.tasks.emodel_building.task1_efeature_extraction.task imp
     EModelEFeatureExtractionTask,
 )
 from obi_one.scientific.tasks.ephys_extraction import (
+    ElectrophysiologyMetricsScanConfig,
     ElectrophysiologyMetricsSingleConfig,
     ElectrophysiologyMetricsTask,
 )
 from obi_one.scientific.tasks.folder_compression import (
+    FolderCompressionScanConfig,
     FolderCompressionSingleConfig,
     FolderCompressionTask,
 )
 from obi_one.scientific.tasks.generate_simulations.config.brian2.brian2_circuit import (
+    Brian2CircuitSimulationScanConfig,
     Brian2CircuitSimulationSingleConfig,
 )
 from obi_one.scientific.tasks.generate_simulations.config.learning_engine.le_circuit import (
+    LearningEngineCircuitSimulationScanConfig,
     LearningEngineCircuitSimulationSingleConfig,
 )
 from obi_one.scientific.tasks.generate_simulations.config.neuron.neuron_circuit import (
+    CircuitSimulationScanConfig,
     CircuitSimulationSingleConfig,
 )
 from obi_one.scientific.tasks.generate_simulations.config.neuron.neuron_ion_channel_models import (
+    IonChannelModelSimulationScanConfig,
     IonChannelModelSimulationSingleConfig,
 )
 from obi_one.scientific.tasks.generate_simulations.config.neuron.neuron_me_model import (
+    MEModelSimulationScanConfig,
     MEModelSimulationSingleConfig,
 )
 from obi_one.scientific.tasks.generate_simulations.config.neuron.neuron_me_model_with_synapses import (  # ruff: ignore[line-too-long]
+    MEModelWithSynapsesCircuitSimulationScanConfig,
     MEModelWithSynapsesCircuitSimulationSingleConfig,
 )
 from obi_one.scientific.tasks.generate_simulations.task.task import (
     GenerateSimulationTask,
 )
 from obi_one.scientific.tasks.ion_channel_modeling import (
+    IonChannelFittingScanConfig,
     IonChannelFittingSingleConfig,
     IonChannelFittingTask,
 )
@@ -69,18 +80,22 @@ from obi_one.scientific.tasks.mesh_lod_generation.config import (
 )
 from obi_one.scientific.tasks.mesh_lod_generation.task import MeshLODGenerationTask
 from obi_one.scientific.tasks.morphology_containerization import (
+    MorphologyContainerizationScanConfig,
     MorphologyContainerizationSingleConfig,
     MorphologyContainerizationTask,
 )
 from obi_one.scientific.tasks.morphology_decontainerization import (
+    MorphologyDecontainerizationScanConfig,
     MorphologyDecontainerizationSingleConfig,
     MorphologyDecontainerizationTask,
 )
 from obi_one.scientific.tasks.morphology_locations import (
+    MorphologyLocationsScanConfig,
     MorphologyLocationsSingleConfig,
     MorphologyLocationsTask,
 )
 from obi_one.scientific.tasks.morphology_metrics import (
+    MorphologyMetricsScanConfig,
     MorphologyMetricsSingleConfig,
     MorphologyMetricsTask,
 )
@@ -126,6 +141,7 @@ TASK_MAP: dict[TaskType, TaskRegistration] = {
     TaskType.circuit_simulation: TaskRegistration(
         task_cls=GenerateSimulationTask,
         single_config_cls=CircuitSimulationSingleConfig,
+        scan_config_cls=CircuitSimulationScanConfig,
         asset_label=None,
     ),
     TaskType.circuit_synaptic_physiology_assignment: TaskRegistration(
@@ -220,71 +236,85 @@ TASK_MAP: dict[TaskType, TaskRegistration] = {
     TaskType.basic_connectivity_plots: TaskRegistration(
         task_cls=BasicConnectivityPlotsTask,
         single_config_cls=BasicConnectivityPlotsSingleConfig,
+        scan_config_cls=BasicConnectivityPlotsScanConfig,
         asset_label=None,
     ),
     TaskType.brian2_circuit_simulation: TaskRegistration(
         task_cls=GenerateSimulationTask,
         single_config_cls=Brian2CircuitSimulationSingleConfig,
+        scan_config_cls=Brian2CircuitSimulationScanConfig,
         asset_label=None,
     ),
     TaskType.connectivity_matrix_extraction: TaskRegistration(
         task_cls=ConnectivityMatrixExtractionTask,
         single_config_cls=ConnectivityMatrixExtractionSingleConfig,
+        scan_config_cls=ConnectivityMatrixExtractionScanConfig,
         asset_label=None,
     ),
     TaskType.electrophysiology_metrics: TaskRegistration(
         task_cls=ElectrophysiologyMetricsTask,
         single_config_cls=ElectrophysiologyMetricsSingleConfig,
+        scan_config_cls=ElectrophysiologyMetricsScanConfig,
         asset_label=None,
     ),
     TaskType.folder_compression: TaskRegistration(
         task_cls=FolderCompressionTask,
         single_config_cls=FolderCompressionSingleConfig,
+        scan_config_cls=FolderCompressionScanConfig,
         asset_label=None,
     ),
     TaskType.ion_channel_fitting: TaskRegistration(
         task_cls=IonChannelFittingTask,
         single_config_cls=IonChannelFittingSingleConfig,
+        scan_config_cls=IonChannelFittingScanConfig,
         asset_label=None,
     ),
     TaskType.ion_channel_model_simulation: TaskRegistration(
         task_cls=GenerateSimulationTask,
         single_config_cls=IonChannelModelSimulationSingleConfig,
+        scan_config_cls=IonChannelModelSimulationScanConfig,
         asset_label=None,
     ),
     TaskType.me_model_simulation: TaskRegistration(
         task_cls=GenerateSimulationTask,
         single_config_cls=MEModelSimulationSingleConfig,
+        scan_config_cls=MEModelSimulationScanConfig,
         asset_label=None,
     ),
     TaskType.learning_engine_circuit_simulation: TaskRegistration(
         task_cls=GenerateSimulationTask,
         single_config_cls=LearningEngineCircuitSimulationSingleConfig,
+        scan_config_cls=LearningEngineCircuitSimulationScanConfig,
         asset_label=None,
     ),
     TaskType.me_model_with_synapses_circuit_simulation: TaskRegistration(
         task_cls=GenerateSimulationTask,
         single_config_cls=MEModelWithSynapsesCircuitSimulationSingleConfig,
+        scan_config_cls=MEModelWithSynapsesCircuitSimulationScanConfig,
         asset_label=None,
     ),
     TaskType.morphology_containerization: TaskRegistration(
         task_cls=MorphologyContainerizationTask,
         single_config_cls=MorphologyContainerizationSingleConfig,
+        scan_config_cls=MorphologyContainerizationScanConfig,
         asset_label=None,
     ),
     TaskType.morphology_decontainerization: TaskRegistration(
         task_cls=MorphologyDecontainerizationTask,
         single_config_cls=MorphologyDecontainerizationSingleConfig,
+        scan_config_cls=MorphologyDecontainerizationScanConfig,
         asset_label=None,
     ),
     TaskType.morphology_locations: TaskRegistration(
         task_cls=MorphologyLocationsTask,
         single_config_cls=MorphologyLocationsSingleConfig,
+        scan_config_cls=MorphologyLocationsScanConfig,
         asset_label=None,
     ),
     TaskType.morphology_metrics: TaskRegistration(
         task_cls=MorphologyMetricsTask,
         single_config_cls=MorphologyMetricsSingleConfig,
+        scan_config_cls=MorphologyMetricsScanConfig,
         asset_label=None,
     ),
     TaskType.circuit_simulation_neurodamus_machine: TaskRegistration(

--- a/obi_one/scientific/tasks/basic_connectivity_plots.py
+++ b/obi_one/scientific/tasks/basic_connectivity_plots.py
@@ -69,7 +69,6 @@ class BasicConnectivityPlotsScanConfig(ScanConfig):
         color legend) for small connectomes (<= 20 nodes).
     """
 
-    single_coord_class_name: ClassVar[str] = "BasicConnectivityPlotsSingleConfig"
     name: ClassVar[str] = "Basic Connectivity Plots"
     description: ClassVar[str] = (
         "Generates basic connectivity plots and stats from a ConnectivityMatrix object."

--- a/obi_one/scientific/tasks/circuit_extraction/task.py
+++ b/obi_one/scientific/tasks/circuit_extraction/task.py
@@ -67,7 +67,6 @@ class BlockGroup(StrEnum):
 class CircuitExtractionScanConfig(InfoScanConfig):
     """ScanConfig for extracting sub-circuits from larger circuits."""
 
-    single_coord_class_name: ClassVar[str] = "CircuitExtractionSingleConfig"
     name: ClassVar[str] = "Circuit Extraction"
     description: ClassVar[str] = (
         "Extracts a sub-circuit from a SONATA circuit as defined by a neuron set. The output"

--- a/obi_one/scientific/tasks/connectivity_matrix_extraction.py
+++ b/obi_one/scientific/tasks/connectivity_matrix_extraction.py
@@ -29,7 +29,6 @@ class ConnectivityMatrixExtractionScanConfig(ScanConfig):
     table (dataframe) of selected node attributes.
     """
 
-    single_coord_class_name: ClassVar[str] = "ConnectivityMatrixExtractionSingleConfig"
     name: ClassVar[str] = "Connectivity Matrix Extraction"
     description: ClassVar[str] = (
         "Extracts a connectivity matrix of a given edge population of a SONATA circuit in"

--- a/obi_one/scientific/tasks/create_recording_array/create_recording_array.py
+++ b/obi_one/scientific/tasks/create_recording_array/create_recording_array.py
@@ -40,7 +40,6 @@ class BlockGroup(StrEnum):
 class CreateExtracellularRecordingArrayScanConfig(InfoScanConfig):
     """Description."""
 
-    single_coord_class_name: ClassVar[str] = "CreateExtracellularRecordingArraySingleConfig"
     name: ClassVar[str] = "Create Extracellular Recording Array"
     description: ClassVar[str] = "Description."
 

--- a/obi_one/scientific/tasks/em_synapse_mapping/config.py
+++ b/obi_one/scientific/tasks/em_synapse_mapping/config.py
@@ -71,7 +71,6 @@ class AdvancedEMSynapseMappingOptions(Block):
 class EMSynapseMappingScanConfig(InfoScanConfig):
     """Map location of afferent synapses from EM onto one or more spiny morphologies."""
 
-    single_coord_class_name: ClassVar[str] = "EMSynapseMappingSingleConfig"
     name: ClassVar[str] = "Map synapse locations"
     description: ClassVar[str] = "EM synapse mapping campaign"
 

--- a/obi_one/scientific/tasks/emodel_building/task1_efeature_extraction/config.py
+++ b/obi_one/scientific/tasks/emodel_building/task1_efeature_extraction/config.py
@@ -51,7 +51,6 @@ class EModelEFeatureExtractionScanConfig(InfoScanConfig):
     stage. No model assets are needed at this point.
     """
 
-    single_coord_class_name: ClassVar[str] = "EModelEFeatureExtractionSingleConfig"
     name: ClassVar[str] = "EModel EFeature Extraction"
     description: ClassVar[str] = (
         "Extract experimental e-features from ephys traces via BluePyEModel."

--- a/obi_one/scientific/tasks/ephys_extraction.py
+++ b/obi_one/scientific/tasks/ephys_extraction.py
@@ -23,7 +23,6 @@ from obi_one.scientific.library.ephys_extraction import (
 class ElectrophysiologyMetricsScanConfig(ScanConfig):
     """ScanConfig for extracting electrophysiological metrics from a trace."""
 
-    single_coord_class_name: ClassVar[str] = "ElectrophysiologyMetricsSingleConfig"
     name: ClassVar[str] = "Electrophysiology Metrics"
     description: ClassVar[str] = "Calculates ephys metrics for a given trace."
 

--- a/obi_one/scientific/tasks/folder_compression.py
+++ b/obi_one/scientific/tasks/folder_compression.py
@@ -24,7 +24,6 @@ class FolderCompressionScanConfig(ScanConfig):
     The following compression formats are available: gzip (.gz; default), bzip2 (.bz2), LZMA (.xz)
     """
 
-    single_coord_class_name: ClassVar[str] = "FolderCompressionSingleConfig"
     name: ClassVar[str] = "Folder Compression"
     description: ClassVar[str] = "Compresses a folder using the specified compression format."
 

--- a/obi_one/scientific/tasks/generate_simulations/config/base.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/base.py
@@ -69,7 +69,6 @@ class BlockGroup(StrEnum):
 class BaseSimulationScanConfig(InfoScanConfig, abc.ABC):
     """Abstract base class for simulation scan configurations."""
 
-    single_coord_class_name: ClassVar[str]
     name: ClassVar[str] = "Simulation Campaign"
     description: ClassVar[str] = "SONATA simulation campaign"
 

--- a/obi_one/scientific/tasks/generate_simulations/config/brian2/brian2_circuit.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/brian2/brian2_circuit.py
@@ -45,7 +45,6 @@ class Brian2CircuitSimulationScanConfig(Brian2SimulationScanConfig):
     ``simulation_config.json`` will have ``target_simulator: "Brian2"``.
     """
 
-    single_coord_class_name: ClassVar[str] = "Brian2CircuitSimulationSingleConfig"
     name: ClassVar[str] = "Brian2 Simulation Campaign"
     description: ClassVar[str] = "Brian2-targeted SONATA simulation campaign"
 

--- a/obi_one/scientific/tasks/generate_simulations/config/learning_engine/le_circuit.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/learning_engine/le_circuit.py
@@ -38,8 +38,6 @@ CircuitDiscriminator = Annotated[Circuit | CircuitFromID, Field(discriminator="t
 class LearningEngineCircuitSimulationScanConfig(LearningEngineSimulationScanConfig):
     """LearningEngineCircuitSimulationScanConfig."""
 
-    single_coord_class_name: ClassVar[str] = "LearningEngineCircuitSimulationSingleConfig"
-
     json_schema_extra_additions: ClassVar[dict] = {
         SchemaKey.UI_ENABLED: True,
         SchemaKey.GROUP_ORDER: [

--- a/obi_one/scientific/tasks/generate_simulations/config/neuron/neuron_circuit.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/neuron/neuron_circuit.py
@@ -53,8 +53,6 @@ CircuitDiscriminator = Annotated[Circuit | CircuitFromID, Field(discriminator="t
 class CircuitSimulationScanConfig(NeuronSimulationScanConfig):
     """CircuitSimulationScanConfig."""
 
-    single_coord_class_name: ClassVar[str] = "CircuitSimulationSingleConfig"
-
     json_schema_extra_additions: ClassVar[dict] = {
         SchemaKey.UI_ENABLED: True,
         SchemaKey.GROUP_ORDER: [

--- a/obi_one/scientific/tasks/generate_simulations/config/neuron/neuron_ion_channel_models.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/neuron/neuron_ion_channel_models.py
@@ -42,7 +42,6 @@ L = logging.getLogger(__name__)
 class IonChannelModelSimulationScanConfig(BaseSimulationScanConfig):
     """Form for simulating ion channel model(s)."""
 
-    single_coord_class_name: ClassVar[str] = "IonChannelModelSimulationSingleConfig"
     name: ClassVar[str] = "Ion Channel Model Simulation Campaign"
     description: ClassVar[str] = "Ion Channel Model SONATA simulation campaign"
 

--- a/obi_one/scientific/tasks/generate_simulations/config/neuron/neuron_me_model.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/neuron/neuron_me_model.py
@@ -39,7 +39,6 @@ MEModelDiscriminator = Annotated[MEModelCircuit | MEModelFromID, Field(discrimin
 class MEModelSimulationScanConfig(NeuronSimulationScanConfig):
     """MEModelSimulationScanConfig."""
 
-    single_coord_class_name: ClassVar[str] = "MEModelSimulationSingleConfig"
     name: ClassVar[str] = "Simulation Campaign"
     description: ClassVar[str] = "SONATA simulation campaign"
 

--- a/obi_one/scientific/tasks/generate_simulations/config/neuron/neuron_me_model_with_synapses.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/neuron/neuron_me_model_with_synapses.py
@@ -32,7 +32,6 @@ MEModelWithSynapsesCircuitDiscriminator = Annotated[
 class MEModelWithSynapsesCircuitSimulationScanConfig(CircuitSimulationScanConfig):
     """MEModelWithSynapsesCircuitSimulationScanConfig."""
 
-    single_coord_class_name: ClassVar[str] = "MEModelWithSynapsesCircuitSimulationSingleConfig"
     name: ClassVar[str] = "Simulation Campaign"
     description: ClassVar[str] = "SONATA simulation campaign"
     json_schema_extra_additions: ClassVar[dict] = {

--- a/obi_one/scientific/tasks/ion_channel_modeling.py
+++ b/obi_one/scientific/tasks/ion_channel_modeling.py
@@ -92,7 +92,6 @@ class BlockGroup(StrEnum):
 class IonChannelFittingScanConfig(ScanConfig):
     """Form for modeling an ion channel model from a set of ion channel traces."""
 
-    single_coord_class_name: ClassVar[str] = "IonChannelFittingSingleConfig"
     name: ClassVar[str] = "IonChannelFittingScanConfig"
     description: ClassVar[str] = "Models ion channel model from a set of ion channel traces."
 

--- a/obi_one/scientific/tasks/morphology_containerization.py
+++ b/obi_one/scientific/tasks/morphology_containerization.py
@@ -38,7 +38,6 @@ class MorphologyContainerizationScanConfig(ScanConfig):
                to the output location where all operations take place.
     """
 
-    single_coord_class_name: ClassVar[str] = "MorphologyContainerizationSingleConfig"
     name: ClassVar[str] = "Morphology Containerization"
     description: ClassVar[str] = (
         "Creates a circuit with containerized morphologies instead of individual morphology files"

--- a/obi_one/scientific/tasks/morphology_decontainerization.py
+++ b/obi_one/scientific/tasks/morphology_decontainerization.py
@@ -36,7 +36,6 @@ class MorphologyDecontainerizationScanConfig(ScanConfig):
                to the output location where all operations take place.
     """
 
-    single_coord_class_name: ClassVar[str] = "MorphologyDecontainerizationSingleConfig"
     name: ClassVar[str] = "Morphology Decontainerization"
     description: ClassVar[str] = (
         "Creates a circuit with individual morphology files instead of containerized morphologies"

--- a/obi_one/scientific/tasks/morphology_locations.py
+++ b/obi_one/scientific/tasks/morphology_locations.py
@@ -34,7 +34,6 @@ L = logging.getLogger(__name__)
 class MorphologyLocationsScanConfig(ScanConfig):
     """ScanConfig for generating locations on a morphology skeleton."""
 
-    single_coord_class_name: ClassVar[str] = "MorphologyLocationsSingleConfig"
     name: ClassVar[str] = "Point locations on neurite skeletons"
     description: ClassVar[str] = (
         "Generates optionally clustered locations on neurites of a morphology skeleton"

--- a/obi_one/scientific/tasks/morphology_metrics.py
+++ b/obi_one/scientific/tasks/morphology_metrics.py
@@ -18,7 +18,6 @@ L = logging.getLogger(__name__)
 
 
 class MorphologyMetricsScanConfig(ScanConfig):
-    single_coord_class_name: ClassVar[str] = "MorphologyMetricsSingleConfig"
     name: ClassVar[str] = "Morphology Metrics"
     description: ClassVar[str] = "Calculates morphology metrics for a given morphologies."
 

--- a/obi_one/scientific/tasks/schema_example.py
+++ b/obi_one/scientific/tasks/schema_example.py
@@ -44,7 +44,6 @@ class EntityDependentBlockExample(Block):
 class SchemaExampleScanConfig(ScanConfig):
     """ScanConfig for extracting sub-circuits from larger circuits."""
 
-    single_coord_class_name: ClassVar[str] = ""
     name: ClassVar[str] = "Schema Example"
     description: ClassVar[str] = "Useful for testing and generating example schema."
 

--- a/obi_one/scientific/tasks/skeletonization/config.py
+++ b/obi_one/scientific/tasks/skeletonization/config.py
@@ -27,7 +27,6 @@ class BlockGroup(StrEnum):
 class SkeletonizationScanConfig(InfoScanConfig, abc.ABC):
     """Abstract base class for skeletonization scan configurations."""
 
-    single_coord_class_name: ClassVar[str] = "SkeletonizationSingleConfig"
     name: ClassVar[str] = "Skeletonization Campaign"
     description: ClassVar[str] = "Skeletonization campaign"
 

--- a/obi_one/scientific/tasks/synapse_parameterization/config.py
+++ b/obi_one/scientific/tasks/synapse_parameterization/config.py
@@ -49,7 +49,6 @@ class SynapseParameterizationScanConfig(ScanConfig):
         "Generates a physiological parameterization of an anatomical circuit or replaces an"
         " existing parameterization."
     )
-    single_coord_class_name: ClassVar[str] = "SynapseParameterizationSingleConfig"
 
     json_schema_extra_additions: ClassVar[dict] = {
         SchemaKey.UI_ENABLED: True,

--- a/tests/obi_one/core/test_scan_config.py
+++ b/tests/obi_one/core/test_scan_config.py
@@ -1,9 +1,14 @@
+import pytest
+
 from obi_one.core.block import Block
+from obi_one.core.exception import OBIONEError
 from obi_one.core.path import NamedPath
 from obi_one.core.scan_config import ScanConfig, get_all_annotations
 from obi_one.scientific.tasks.folder_compression import (
     FolderCompressionScanConfig,
+    FolderCompressionSingleConfig,
 )
+from obi_one.scientific.tasks.schema_example import SchemaExampleScanConfig
 
 
 class TestGetAllAnnotations:
@@ -45,16 +50,25 @@ class TestScanConfigClassVars:
     def test_default_description(self):
         assert "Add a description" in ScanConfig.description
 
-    def test_default_single_coord_class_name(self):
-        assert not ScanConfig.single_coord_class_name
-
     def test_folder_compression_name(self):
         assert FolderCompressionScanConfig.name == "Folder Compression"
 
-    def test_folder_compression_single_coord(self):
-        assert (
-            FolderCompressionScanConfig.single_coord_class_name == "FolderCompressionSingleConfig"
+
+class TestSingleConfigClass:
+    """The SingleConfig a ScanConfig expands into is resolved from TASK_MAP."""
+
+    def test_resolved_from_task_map(self):
+        config = FolderCompressionScanConfig(
+            initialize=FolderCompressionScanConfig.Initialize(
+                folder_path=NamedPath(name="t", path="/t"),
+            )
         )
+        assert config.single_config_class is FolderCompressionSingleConfig
+
+    def test_unregistered_scan_config_raises(self):
+        """SchemaExampleScanConfig is deliberately absent from TASK_MAP."""
+        with pytest.raises(OBIONEError, match="no entry in TASK_MAP"):
+            _ = SchemaExampleScanConfig.model_construct().single_config_class
 
 
 class TestScanConfigCreation:

--- a/tests/obi_one/core/test_scan_config_blocks.py
+++ b/tests/obi_one/core/test_scan_config_blocks.py
@@ -36,7 +36,6 @@ class TestRef(BlockReference):
 class SimpleConfig(ScanConfig):
     """ScanConfig with only a root-level Block, no dicts."""
 
-    single_coord_class_name: ClassVar[str] = ""
     name: ClassVar[str] = "SimpleConfig"
     description: ClassVar[str] = "Simple"
 
@@ -50,7 +49,6 @@ class SimpleConfig(ScanConfig):
 class DictBlockConfig(ScanConfig):
     """ScanConfig with a dictionary of Blocks, for block_mapping tests."""
 
-    single_coord_class_name: ClassVar[str] = ""
     name: ClassVar[str] = "DictBlockConfig"
     description: ClassVar[str] = "Has dict blocks"
 
@@ -75,7 +73,6 @@ class RefHolder(Block):
 class ConfigWithRefBlock(ScanConfig):
     """ScanConfig where a root-level block contains a BlockReference."""
 
-    single_coord_class_name: ClassVar[str] = ""
     name: ClassVar[str] = "ConfigWithRefBlock"
     description: ClassVar[str] = "Has ref block"
 
@@ -140,7 +137,6 @@ class TestBlockMappingMissingReferenceType:
         """If json_schema_extra lacks 'reference_type', should raise."""
 
         class BadConfig(ScanConfig):
-            single_coord_class_name: ClassVar[str] = ""
             name: ClassVar[str] = "Bad"
             description: ClassVar[str] = ""
 
@@ -262,7 +258,6 @@ class TestAddBlockUnknownReferenceType:
         from obi_one.core.exception import OBIONEError  # ruff: ignore[import-outside-top-level]
 
         class UnregisteredRefConfig(ScanConfig):
-            single_coord_class_name: ClassVar[str] = ""
             name: ClassVar[str] = "UnregisteredRefConfig"
             description: ClassVar[str] = "Has unregistered ref"
 


### PR DESCRIPTION
Follow-up to #933.

`single_coord_class_name` named each ScanConfig's SingleConfig as a **string**, which `cast_to_single_coord` then resolved with `getattr` on the top-level `obi_one` package. That duplicated a pairing `TASK_MAP` already knows about, and quietly required every SingleConfig to stay re-exported from `obi_one/__init__.py` or casting would break.

### Changes

* Fill in `scan_config_cls` for the 15 `TASK_MAP` entries that were missing it, so 21 of 26 now name both ends of the pair.
* Add `ScanConfig.single_config_class`, resolving the pair via `task_registry.get_registration_for_scan_config`, raising `OBIONEError` (naming the class) when a ScanConfig has no `TASK_MAP` entry.
* Point `cast_to_single_coord` and `single_coord_scan_default_subpath` at the new property.
* Remove `single_coord_class_name` from `ScanConfig` and all 23 subclasses.

### The five entries that keep `scan_config_cls=None`

These have no ScanConfig to name, so `None` is correct rather than an omission:

* `ion_channel_model_simulation_execution`, `single_neuron_simulation_execution`, `single_neuron_synaptome_simulation_execution`, `circuit_simulation_neurodamus_machine` — all derive from `SimulationExecutionSingleConfig`, which is *itself* both a `ScanConfig` and a `SingleConfigMixin`.
* `mesh_lod_generation` — `MeshLodGenerationSingleConfig` is a plain `OBIBaseModel`.

All five had `single_coord_class_name` at its empty-string default, so nothing is lost.

### Verification

Checked that all 21 registered ScanConfigs resolve to exactly the class their string previously named — no mismatches — so this is behaviour-preserving, not merely compiling.

`ty` stays at its baseline diagnostic count. Reaching that meant tightening `TaskRegistration.single_config_cls` / `scan_config_cls` to `type[OBIBaseModel]`; typed as bare `type`, the new property made `.model_construct()` an unresolved attribute.

Full suite passes (the two `basic_connectivity_plots` failures are pre-existing locally, from the optional `connalysis` extra not being installed).
