### PR TITLE
Resolve unset block references in one tagged pass

### DIFF
--- a/docs/gui-definition-spec/components/reference/reference.md
+++ b/docs/gui-definition-spec/components/reference/reference.md
@@ -7,8 +7,20 @@ ui_element: `reference`
 - Should accept as input an `object` with `string` fields `block_name` and `block_dict_name`.
 - Second element should be `null`.
 - Should have a non-validating `reference_types` array of strings, listing every reference type the field accepts. Each entry is the class name of a `BlockReference` subclass and must match the type of one of the references allowed by the field's union.
+- May have a non-validating `reference_tag` string naming the *role* the field plays, e.g. `stimulus_target`. The role is what the configuration keys its defaults by.
 
-_References are hidden from the UI if either the `ui_hidden` property is `True` or none of the entries in `reference_types` is present in its configuration's `default_block_reference_labels` [See](../../gui-definition.md#scanconfigs-additional).
+### The default option
+
+Every reference offers a default option, labelled with the block the backend resolves the field to when it is left unset. That label is looked up in two places, in order:
+
+1. the configuration's `reference_tag_defaults`, keyed by this field's `reference_tag`;
+2. the configuration's `default_block_reference_labels`, keyed by reference type — the first entry in `reference_types` that has one.
+
+The role wins because a reference *type* can be shared by fields that mean different things, and only the role tells them apart. In a Brian2 simulation an untargeted stimulus drives the `sugar` node set while the simulation itself runs every point neuron; both fields are `PointNeuronSetReference`, so keyed by type the configuration can only carry one of those answers.
+
+Either source is sufficient on its own. A configuration that names all of its defaults by role need not publish `default_block_reference_labels` at all.
+
+_References are hidden from the UI if either the `ui_hidden` property is `True` or neither source names a default for the field._ A visible reference with no default has no label for its default option, so the schema tests reject that rather than let the field disappear silently — hide one deliberately with `ui_hidden`.
 
 Reference schema [reference](reference_schemas/reference.json)
 

--- a/docs/gui-definition-spec/components/reference/reference.md
+++ b/docs/gui-definition-spec/components/reference/reference.md
@@ -16,7 +16,7 @@ Every reference offers a default option, labelled with the block the backend res
 1. the configuration's `reference_tag_defaults`, keyed by this field's `reference_tag`;
 2. the configuration's `default_block_reference_labels`, keyed by reference type — the first entry in `reference_types` that has one.
 
-The role wins because a reference *type* can be shared by fields that mean different things, and only the role tells them apart. In a Brian2 simulation an untargeted stimulus drives the `sugar` node set while the simulation itself runs every point neuron; both fields are `PointNeuronSetReference`, so keyed by type the configuration can only carry one of those answers.
+The role wins because a reference *type* can be shared by fields that mean different things, and only the role tells them apart. An unset inter-spike interval distribution defaults to an exponential while an unset spike time distribution defaults to a normal; both fields are `AllDistributionsReference`, so keyed by type the configuration can only carry one of those answers.
 
 Either source is sufficient on its own. A configuration that names all of its defaults by role need not publish `default_block_reference_labels` at all.
 

--- a/docs/gui-definition-spec/components/scan_config/scan_config.jsonc
+++ b/docs/gui-definition-spec/components/scan_config/scan_config.jsonc
@@ -14,6 +14,11 @@
   "description": "Description of the form",
   "group_order": ["Group 1", "Group 2"], // All groups must be used in at least one root element.
   "ui_enabled": true,
+  // The name each unset reference resolves to, keyed by the field's `reference_tag`.
+  // Preferred over `default_block_reference_labels`; see components/reference/reference.md.
+  "reference_tag_defaults": { "some_role": "Default: Some Block" },
+  // Optional fallback, keyed by reference type. Only needed for references that carry no
+  // `reference_tag`, or whose tag this form does not name.
   "default_block_reference_labels": { "Reference_1": "Label_1" },
   "properties_endpoint": {
     "circuit": "/mapped-circuit-properties/{circuit_id}"

--- a/obi_one/core/fill_none_references.py
+++ b/obi_one/core/fill_none_references.py
@@ -1,0 +1,90 @@
+"""One pass that gives every unset block reference in a config a default.
+
+A block reference field left as ``None`` means "whatever the task considers the obvious choice".
+Which choice that is depends on the field's role rather than on the block holding it, so each field
+declares its role once via ``SchemaKey.REFERENCE_TAG`` and the task supplies one reference per role.
+Filling then needs no knowledge of any particular block type: walk the config, and wherever a tagged
+field is ``None``, substitute the reference its tag maps to.
+
+Roles are named by the task that resolves them -- see
+``obi_one.scientific.unions_and_references.reference_tags.ReferenceTag`` for the simulation
+generation set. Nothing here needs to know what a role means, only that fields sharing a tag share
+a default, so tags are handled as plain strings.
+"""
+
+import logging
+from collections.abc import Iterator, Mapping
+
+from obi_one.core.block import Block
+from obi_one.core.block_reference import BlockReference
+from obi_one.core.schema import SchemaKey
+
+L = logging.getLogger(__name__)
+
+
+def _tagged_reference_fields(block: Block) -> Iterator[tuple[str, str]]:
+    """The block's reference fields that declare what they mean when unset."""
+    for name, field_info in type(block).model_fields.items():
+        extra = field_info.json_schema_extra
+        if isinstance(extra, dict) and SchemaKey.REFERENCE_TAG in extra:
+            yield name, extra[SchemaKey.REFERENCE_TAG]
+
+
+def _blocks_of(config: object) -> Iterator[Block]:
+    """Every block the config holds, whether directly or inside a block dictionary."""
+    for value in vars(config).values():
+        if isinstance(value, Block):
+            yield value
+        elif isinstance(value, dict):
+            yield from (item for item in value.values() if isinstance(item, Block))
+
+
+def fill_none_references_in_config(
+    config: object, defaults: Mapping[str, BlockReference]
+) -> list[BlockReference]:
+    """Replace every unset tagged block reference with the default for its role.
+
+    A tag missing from ``defaults`` is left alone, which is how a block keeps a default only it can
+    compute -- a spike time distribution spanning the stimulus's own duration, for instance.
+
+    Args:
+        config: The config whose blocks should be filled.
+        defaults: The block reference to substitute for each role, keyed by reference tag.
+
+    Returns:
+        The defaults that were actually used, in the order they were first needed. Nothing is
+        returned for a role no block left unset, so a caller registering these does not create
+        blocks the config never refers to.
+    """
+    used: list[BlockReference] = []
+
+    def use(default: BlockReference) -> BlockReference:
+        if not any(default is seen for seen in used):
+            used.append(default)
+        return default
+
+    for block in _blocks_of(config):
+        for name, tag in _tagged_reference_fields(block):
+            default = defaults.get(tag)
+            if default is None:
+                continue
+
+            value = getattr(block, name, None)
+            if value is None:
+                L.debug(
+                    "Filling %s.%s with the default for '%s'", block.__class__.__name__, name, tag
+                )
+                setattr(block, name, use(default))
+            elif isinstance(value, tuple):
+                # A combined neuron set holds its operands as (reference, set operation) pairs,
+                # any of which may individually be unset.
+                setattr(
+                    block,
+                    name,
+                    tuple(
+                        (use(default), operation) if reference is None else (reference, operation)
+                        for reference, operation in value
+                    ),
+                )
+
+    return used

--- a/obi_one/core/schema.py
+++ b/obi_one/core/schema.py
@@ -27,6 +27,9 @@ class SchemaKey(StrEnum):
     PROPERTY = "property"
     PROPERTY_ENDPOINTS = "property_endpoints"
     PROPERTY_GROUP = "property_group"
+    REFERENCE_TAG = "reference_tag"
+    # Note: REFERENCE_TAG is not used by the UI. It names the role a block reference field plays,
+    # so a task can say what the field means when it is left unset. See ReferenceTag.
     REFERENCE_TYPES = "reference_types"
     SINGULAR_NAME = "singular_name"
     TITLE_BY_KEY = "title_by_key"

--- a/obi_one/core/schema.py
+++ b/obi_one/core/schema.py
@@ -28,8 +28,14 @@ class SchemaKey(StrEnum):
     PROPERTY_ENDPOINTS = "property_endpoints"
     PROPERTY_GROUP = "property_group"
     REFERENCE_TAG = "reference_tag"
-    # Note: REFERENCE_TAG is not used by the UI. It names the role a block reference field plays,
-    # so a task can say what the field means when it is left unset. See ReferenceTag.
+    # Note: REFERENCE_TAG names the role a block reference field plays, so a task can say what the
+    # field means when it is left unset. See ReferenceTag.
+    REFERENCE_TAG_DEFAULTS = "reference_tag_defaults"
+    # Note: REFERENCE_TAG_DEFAULTS sits on a ScanConfig and gives, for each reference tag, the
+    # name of the block a field carrying that tag resolves to when left unset. The UI shows it as
+    # the placeholder for the field. Unlike DEFAULT_BLOCK_REFERENCE_LABELS, which is keyed by
+    # reference type and also decides whether a field is shown at all, this is keyed by role, so
+    # two fields of the same type that mean different things get their own answer.
     REFERENCE_TYPES = "reference_types"
     SINGULAR_NAME = "singular_name"
     TITLE_BY_KEY = "title_by_key"

--- a/obi_one/scientific/blocks/morphology_locations/base.py
+++ b/obi_one/scientific/blocks/morphology_locations/base.py
@@ -16,6 +16,7 @@ from obi_one.scientific.unions_and_references.combined_neuron_sets import (
     BIOPHYSICAL_NEURON_SETS_REFERENCE_TYPES,
     BIOPHYSICAL_NEURON_SETS_REFERENCE_UNION,
 )
+from obi_one.scientific.unions_and_references.reference_tags import ReferenceTag
 
 SectionType = Literal[3, 4]
 SectionTypes = tuple[SectionType, ...] | list[tuple[SectionType, ...]] | None
@@ -45,6 +46,7 @@ class MorphologyLocationsBlock(Block, abc.ABC):
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
             SchemaKey.REFERENCE_TYPES: BIOPHYSICAL_NEURON_SETS_REFERENCE_TYPES,
+            SchemaKey.REFERENCE_TAG: ReferenceTag.MORPHOLOGY_LOCATIONS_TARGET,
         },
     )
 

--- a/obi_one/scientific/blocks/neuron_sets/combined.py
+++ b/obi_one/scientific/blocks/neuron_sets/combined.py
@@ -26,6 +26,7 @@ from obi_one.scientific.unions_and_references.neuron_sets import (
     ATOMIC_VIRTUAL_NEURON_SETS_REFERENCE_TYPES,
     ATOMIC_VIRTUAL_NEURON_SETS_REFERENCE_UNION,
 )
+from obi_one.scientific.unions_and_references.reference_tags import ReferenceTag
 
 L = logging.getLogger("obi-one")
 
@@ -230,6 +231,7 @@ class CombinedNeuronSet(CombinedBaseNeuronSet):
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
             SchemaKey.REFERENCE_TYPES: ATOMIC_ALL_NEURON_SETS_REFERENCE_TYPES,
+            SchemaKey.REFERENCE_TAG: ReferenceTag.ANY_NEURON_SET_OPERAND,
         },
     )
 
@@ -246,6 +248,7 @@ class CombinedNeuronSet(CombinedBaseNeuronSet):
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.NEURON_SET_COMBINATION,
             SchemaKey.REFERENCE_TYPES: ATOMIC_ALL_NEURON_SETS_REFERENCE_TYPES,
+            SchemaKey.REFERENCE_TAG: ReferenceTag.ANY_NEURON_SET_OPERAND,
         },
     )
 
@@ -278,6 +281,7 @@ class BiophysicalCombinedNeuronSet(CombinedBaseNeuronSet):
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
             SchemaKey.REFERENCE_TYPES: ATOMIC_BIOPHYSICAL_NEURON_SETS_REFERENCE_TYPES,
+            SchemaKey.REFERENCE_TAG: ReferenceTag.BIOPHYSICAL_NEURON_SET_OPERAND,
         },
     )
 
@@ -294,6 +298,7 @@ class BiophysicalCombinedNeuronSet(CombinedBaseNeuronSet):
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.NEURON_SET_COMBINATION,
             SchemaKey.REFERENCE_TYPES: ATOMIC_BIOPHYSICAL_NEURON_SETS_REFERENCE_TYPES,
+            SchemaKey.REFERENCE_TAG: ReferenceTag.BIOPHYSICAL_NEURON_SET_OPERAND,
         },
     )
 
@@ -324,6 +329,7 @@ class VirtualCombinedNeuronSet(CombinedBaseNeuronSet):
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
             SchemaKey.REFERENCE_TYPES: ATOMIC_VIRTUAL_NEURON_SETS_REFERENCE_TYPES,
+            SchemaKey.REFERENCE_TAG: ReferenceTag.VIRTUAL_NEURON_SET_OPERAND,
         },
     )
 
@@ -340,6 +346,7 @@ class VirtualCombinedNeuronSet(CombinedBaseNeuronSet):
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.NEURON_SET_COMBINATION,
             SchemaKey.REFERENCE_TYPES: ATOMIC_VIRTUAL_NEURON_SETS_REFERENCE_TYPES,
+            SchemaKey.REFERENCE_TAG: ReferenceTag.VIRTUAL_NEURON_SET_OPERAND,
         },
     )
 
@@ -372,6 +379,7 @@ class NonVirtualCombinedNeuronSet(CombinedBaseNeuronSet):
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
             SchemaKey.REFERENCE_TYPES: ATOMIC_NON_VIRTUAL_NEURON_SETS_REFERENCE_TYPES,
+            SchemaKey.REFERENCE_TAG: ReferenceTag.NON_VIRTUAL_NEURON_SET_OPERAND,
         },
     )
 
@@ -388,6 +396,7 @@ class NonVirtualCombinedNeuronSet(CombinedBaseNeuronSet):
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.NEURON_SET_COMBINATION,
             SchemaKey.REFERENCE_TYPES: ATOMIC_NON_VIRTUAL_NEURON_SETS_REFERENCE_TYPES,
+            SchemaKey.REFERENCE_TAG: ReferenceTag.NON_VIRTUAL_NEURON_SET_OPERAND,
         },
     )
 
@@ -418,6 +427,7 @@ class PointCombinedNeuronSet(CombinedBaseNeuronSet):
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
             SchemaKey.REFERENCE_TYPES: ATOMIC_POINT_NEURON_SETS_REFERENCE_TYPES,
+            SchemaKey.REFERENCE_TAG: ReferenceTag.POINT_NEURON_SET_OPERAND,
         },
     )
 
@@ -434,5 +444,6 @@ class PointCombinedNeuronSet(CombinedBaseNeuronSet):
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.NEURON_SET_COMBINATION,
             SchemaKey.REFERENCE_TYPES: ATOMIC_POINT_NEURON_SETS_REFERENCE_TYPES,
+            SchemaKey.REFERENCE_TAG: ReferenceTag.POINT_NEURON_SET_OPERAND,
         },
     )

--- a/obi_one/scientific/blocks/neuronal_manipulations/neuronal_manipulations.py
+++ b/obi_one/scientific/blocks/neuronal_manipulations/neuronal_manipulations.py
@@ -15,6 +15,7 @@ from obi_one.scientific.unions_and_references.combined_neuron_sets import (
     NON_VIRTUAL_NEURON_SETS_REFERENCE_UNION,
     resolve_neuron_set_ref_to_node_set,
 )
+from obi_one.scientific.unions_and_references.reference_tags import ReferenceTag
 
 
 class BySectionListModification(ComplexVariableHolder):
@@ -112,7 +113,10 @@ class BySectionListMechanismVariableNeuronalManipulation(Block):
         title="Neuron Set (Target)",
         description="Neuron set to which modification is applied.",
         exclude=True,
-        json_schema_extra={SchemaKey.UI_HIDDEN: True},
+        json_schema_extra={
+            SchemaKey.UI_HIDDEN: True,
+            SchemaKey.REFERENCE_TAG: ReferenceTag.NEURONAL_MANIPULATION_TARGET,
+        },
     )
 
     modification: BySectionListModification = Field(
@@ -125,13 +129,13 @@ class BySectionListMechanismVariableNeuronalManipulation(Block):
         },
     )
 
-    def config(self, default_node_set: str) -> list[dict]:
+    def config(self) -> list[dict]:
         """Generate SONATA conditions.modifications entries for each section list.
 
         Returns:
             List of SONATA modification dicts, one per section list.
         """
-        node_set = resolve_neuron_set_ref_to_node_set(self.neuron_set, default_node_set)
+        node_set = resolve_neuron_set_ref_to_node_set(self.neuron_set)
 
         modifications = []
         for section_list, value in self.modification.section_list_modifications.items():
@@ -171,7 +175,10 @@ class ByNeuronMechanismVariableNeuronalManipulation(Block):
         title="Neuron Set (Target)",
         description="Neuron set to which modification is applied.",
         exclude=True,
-        json_schema_extra={SchemaKey.UI_HIDDEN: True},
+        json_schema_extra={
+            SchemaKey.UI_HIDDEN: True,
+            SchemaKey.REFERENCE_TAG: ReferenceTag.NEURONAL_MANIPULATION_TARGET,
+        },
     )
 
     modification: ByNeuronModification = Field(
@@ -184,7 +191,7 @@ class ByNeuronMechanismVariableNeuronalManipulation(Block):
         },
     )
 
-    def config(self, default_node_set: str) -> list[dict] | dict:
+    def config(self) -> list[dict] | dict:
         """Generate SONATA config entry.
 
         Returns:
@@ -201,7 +208,7 @@ class ByNeuronMechanismVariableNeuronalManipulation(Block):
 
         # Handle RANGE variables (including section properties)
         if self.modification.variable_type == "RANGE":
-            node_set = resolve_neuron_set_ref_to_node_set(self.neuron_set, default_node_set)
+            node_set = resolve_neuron_set_ref_to_node_set(self.neuron_set)
             return [
                 {
                     "name": f"modify_{self.modification.variable_name}_all",
@@ -221,7 +228,7 @@ class ByNeuronMechanismVariableNeuronalManipulation(Block):
                 }
             }
 
-        node_set = resolve_neuron_set_ref_to_node_set(self.neuron_set, default_node_set)
+        node_set = resolve_neuron_set_ref_to_node_set(self.neuron_set)
         return [
             {
                 "name": f"modify_{self.modification.variable_name}_all",

--- a/obi_one/scientific/blocks/recordings/base.py
+++ b/obi_one/scientific/blocks/recordings/base.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Annotated
 
 import entitysdk
-from pydantic import Field, NonNegativeFloat, PositiveFloat, PrivateAttr
+from pydantic import Field, NonNegativeFloat, PositiveFloat
 
 from obi_one.core.block import Block
 from obi_one.core.exception import OBIONEError
@@ -15,6 +15,7 @@ from obi_one.scientific.unions_and_references.combined_neuron_sets import (
     NON_VIRTUAL_NEURON_SETS_REFERENCE_TYPES,
     NON_VIRTUAL_NEURON_SETS_REFERENCE_UNION,
 )
+from obi_one.scientific.unions_and_references.reference_tags import ReferenceTag
 
 
 class Recording(Block, ABC):
@@ -25,6 +26,7 @@ class Recording(Block, ABC):
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
             SchemaKey.REFERENCE_TYPES: NON_VIRTUAL_NEURON_SETS_REFERENCE_TYPES,
+            SchemaKey.REFERENCE_TAG: ReferenceTag.RECORDING_TARGET,
         },
     )
 
@@ -45,16 +47,12 @@ class Recording(Block, ABC):
         },
     )
 
-    _default_node_set: str = PrivateAttr(default="All")
-
     def config(
         self,
         end_time: NonNegativeFloat | None = None,
-        default_node_set: str = "All",
         db_client: entitysdk.client.Client | None = None,
     ) -> dict:
-        self._default_node_set = default_node_set
-
+        """Returns the SONATA reports entry for this recording."""
         if (self.neuron_set is not None) and (
             self.neuron_set.block.get_neuron_set_population_type()
             not in {

--- a/obi_one/scientific/blocks/recordings/ion_channel.py
+++ b/obi_one/scientific/blocks/recordings/ion_channel.py
@@ -107,7 +107,7 @@ class IonChannelVariableRecording(Recording):
             self.variable.validate_model_and_set_unit(db_client)
 
         sonata_config[self.block_name] = {
-            "cells": resolve_neuron_set_ref_to_node_set(self.neuron_set, self._default_node_set),
+            "cells": resolve_neuron_set_ref_to_node_set(self.neuron_set),
             "sections": "soma",
             "type": "compartment",
             "compartments": "center",

--- a/obi_one/scientific/blocks/recordings/soma.py
+++ b/obi_one/scientific/blocks/recordings/soma.py
@@ -24,7 +24,7 @@ class SomaVoltageRecording(Recording):
         sonata_config = {}
 
         sonata_config[self.block_name] = {
-            "cells": resolve_neuron_set_ref_to_node_set(self.neuron_set, self._default_node_set),
+            "cells": resolve_neuron_set_ref_to_node_set(self.neuron_set),
             "sections": "soma",
             "type": "compartment",
             "compartments": "center",

--- a/obi_one/scientific/blocks/stimuli/brian2_poisson.py
+++ b/obi_one/scientific/blocks/stimuli/brian2_poisson.py
@@ -15,12 +15,11 @@ SONATA -> Brian2 runner
 
 from typing import Annotated, ClassVar
 
-from pydantic import Field, NonNegativeFloat, PrivateAttr
+from pydantic import Field, NonNegativeFloat
 
 from obi_one.core.block import Block
 from obi_one.core.schema import SchemaKey, UIElement
 from obi_one.core.units import Units
-from obi_one.scientific.blocks.timestamps.single import SingleTimestamp
 from obi_one.scientific.library.circuit import Circuit
 from obi_one.scientific.library.constants import (
     DEFAULT_STIMULUS_LENGTH_MILLISECONDS,
@@ -32,7 +31,7 @@ from obi_one.scientific.unions_and_references.combined_neuron_sets import (
     resolve_neuron_set_ref_to_neuron_set,
     resolve_neuron_set_ref_to_node_set,
 )
-from obi_one.scientific.unions_and_references.timestamps import TimestampsReference
+from obi_one.scientific.unions_and_references.reference_tags import ReferenceTag
 
 
 class Brian2DirectPoissonStimulus(Block):
@@ -51,6 +50,7 @@ class Brian2DirectPoissonStimulus(Block):
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
             SchemaKey.REFERENCE_TYPES: POINT_NEURON_SETS_REFERENCE_TYPES,
+            SchemaKey.REFERENCE_TAG: ReferenceTag.STIMULUS_TARGET,
         },
     )
 
@@ -96,14 +96,7 @@ class Brian2DirectPoissonStimulus(Block):
         },
     )
 
-    _default_node_set: str = PrivateAttr(default="All")
-
-    def config(
-        self,
-        circuit: Circuit,
-        default_node_set: str = "sugar",
-        default_timestamps: TimestampsReference | None = None,
-    ) -> dict:
+    def config(self, circuit: Circuit) -> dict:
         """Return the SONATA inputs entry for this block.
 
         The biophysical check that :class:`ContinuousStimulusWithoutTimestamps`
@@ -111,18 +104,13 @@ class Brian2DirectPoissonStimulus(Block):
         ``v`` (or any target variable) and is valid for point-neuron and
         biophysical populations alike.
         """
-        self._default_node_set = default_node_set
-        _ = default_timestamps or SingleTimestamp(start_time=0.0)
-
-        # An untargeted stimulus has already been pointed at the `sugar` node set by the
-        # generation task (see Brian2SimulationScanConfig.default_stimulus_neuron_set_reference),
-        # which is small enough to stay under the limit; an explicit choice is checked here.
-        neuron_set = resolve_neuron_set_ref_to_neuron_set(
-            self.neuron_set,
-            self._default_node_set,  # ty:ignore[invalid-argument-type]
-        )
+        # An untargeted stimulus has already been pointed at the `sugar` node set by
+        # _fill_none_references (see Brian2SimulationScanConfig.default_stimulus_neuron_set_
+        # reference), which is small enough to stay under the limit; an explicit choice is
+        # checked here.
+        neuron_set = resolve_neuron_set_ref_to_neuron_set(self.neuron_set)
         max_n_neurons = 100
-        neuron_ids = neuron_set.get_neuron_ids(circuit=circuit)  # ty:ignore[unresolved-attribute]
+        neuron_ids = neuron_set.get_neuron_ids(circuit=circuit)
         total_neurons = sum(len(ids) for ids in neuron_ids.values())
         if total_neurons > max_n_neurons:
             msg = (
@@ -134,7 +122,7 @@ class Brian2DirectPoissonStimulus(Block):
         return self._generate_config()
 
     def _generate_config(self) -> dict:
-        node_set = resolve_neuron_set_ref_to_node_set(self.neuron_set, self._default_node_set)
+        node_set = resolve_neuron_set_ref_to_node_set(self.neuron_set)
 
         return {
             self.block_name: {

--- a/obi_one/scientific/blocks/stimuli/brian2_poisson.py
+++ b/obi_one/scientific/blocks/stimuli/brian2_poisson.py
@@ -20,7 +20,6 @@ from pydantic import Field, NonNegativeFloat
 from obi_one.core.block import Block
 from obi_one.core.schema import SchemaKey, UIElement
 from obi_one.core.units import Units
-from obi_one.scientific.library.circuit import Circuit
 from obi_one.scientific.library.constants import (
     DEFAULT_STIMULUS_LENGTH_MILLISECONDS,
     MAX_SIMULATION_LENGTH_MILLISECONDS,
@@ -28,7 +27,6 @@ from obi_one.scientific.library.constants import (
 from obi_one.scientific.unions_and_references.combined_neuron_sets import (
     POINT_NEURON_SETS_REFERENCE_TYPES,
     POINT_NEURON_SETS_REFERENCE_UNION,
-    resolve_neuron_set_ref_to_neuron_set,
     resolve_neuron_set_ref_to_node_set,
 )
 from obi_one.scientific.unions_and_references.reference_tags import ReferenceTag
@@ -96,7 +94,7 @@ class Brian2DirectPoissonStimulus(Block):
         },
     )
 
-    def config(self, circuit: Circuit) -> dict:
+    def config(self) -> dict:
         """Return the SONATA inputs entry for this block.
 
         The biophysical check that :class:`ContinuousStimulusWithoutTimestamps`
@@ -104,21 +102,6 @@ class Brian2DirectPoissonStimulus(Block):
         ``v`` (or any target variable) and is valid for point-neuron and
         biophysical populations alike.
         """
-        # An untargeted stimulus has already been pointed at the `sugar` node set by
-        # _fill_none_references (see Brian2SimulationScanConfig.default_stimulus_neuron_set_
-        # reference), which is small enough to stay under the limit; an explicit choice is
-        # checked here.
-        neuron_set = resolve_neuron_set_ref_to_neuron_set(self.neuron_set)
-        max_n_neurons = 100
-        neuron_ids = neuron_set.get_neuron_ids(circuit=circuit)
-        total_neurons = sum(len(ids) for ids in neuron_ids.values())
-        if total_neurons > max_n_neurons:
-            msg = (
-                f"Number of neurons used with the {self.title} exceeds the maximum "
-                f"allowed: {max_n_neurons}."
-            )
-            raise ValueError(msg)
-
         return self._generate_config()
 
     def _generate_config(self) -> dict:

--- a/obi_one/scientific/blocks/stimuli/electric_field.py
+++ b/obi_one/scientific/blocks/stimuli/electric_field.py
@@ -19,6 +19,7 @@ from obi_one.scientific.unions_and_references.combined_neuron_sets import (
     NON_VIRTUAL_NEURON_SETS_REFERENCE_UNION,
     resolve_neuron_set_ref_to_node_set,
 )
+from obi_one.scientific.unions_and_references.reference_tags import ReferenceTag
 
 from .stimulus import ContinuousStimulus
 
@@ -56,6 +57,7 @@ class SpatiallyUniformElectricFieldStimulus(ContinuousStimulus):
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
             SchemaKey.REFERENCE_TYPES: NON_VIRTUAL_NEURON_SETS_REFERENCE_TYPES,
+            SchemaKey.REFERENCE_TAG: ReferenceTag.STIMULUS_TARGET,
         },
     )
 
@@ -136,7 +138,7 @@ class SpatiallyUniformElectricFieldStimulus(ContinuousStimulus):
         stim_dict = {
             "delay": offset_timestamp,
             "duration": self.duration,
-            "node_set": resolve_neuron_set_ref_to_node_set(self.neuron_set, self._default_node_set),
+            "node_set": resolve_neuron_set_ref_to_node_set(self.neuron_set),
             "module": self._module,
             "input_type": self._input_type,
             "ramp_up_duration": self.ramp_up_duration,

--- a/obi_one/scientific/blocks/stimuli/spike/base.py
+++ b/obi_one/scientific/blocks/stimuli/spike/base.py
@@ -12,7 +12,6 @@ from obi_one.scientific.blocks.stimuli.stimulus import (
     _TIMESTAMPS_OFFSET_FIELD,
     StimulusWithTimestamps,
 )
-from obi_one.scientific.blocks.timestamps.single import SingleTimestamp
 from obi_one.scientific.library.circuit import Circuit
 from obi_one.scientific.library.constants import SONATA
 from obi_one.scientific.unions_and_references.combined_neuron_sets import (
@@ -22,9 +21,7 @@ from obi_one.scientific.unions_and_references.combined_neuron_sets import (
     NON_VIRTUAL_NEURON_SETS_REFERENCE_UNION,
     resolve_neuron_set_ref_to_neuron_set,
 )
-from obi_one.scientific.unions_and_references.timestamps import (
-    TimestampsReference,
-)
+from obi_one.scientific.unions_and_references.reference_tags import ReferenceTag
 
 
 class SpikeStimulus(StimulusWithTimestamps):
@@ -35,6 +32,7 @@ class SpikeStimulus(StimulusWithTimestamps):
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
             SchemaKey.REFERENCE_TYPES: ALL_NEURON_SETS_REFERENCE_TYPES,
+            SchemaKey.REFERENCE_TAG: ReferenceTag.SPIKE_REPLAY_SOURCE,
             SchemaKey.PARAMETER_ORDER_PRIORITY: 100,
         },
     )
@@ -46,6 +44,7 @@ class SpikeStimulus(StimulusWithTimestamps):
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
             SchemaKey.REFERENCE_TYPES: NON_VIRTUAL_NEURON_SETS_REFERENCE_TYPES,
+            SchemaKey.REFERENCE_TAG: ReferenceTag.SPIKE_REPLAY_TARGET,
             SchemaKey.PARAMETER_ORDER_PRIORITY: 99,
         },
     )
@@ -60,40 +59,28 @@ class SpikeStimulus(StimulusWithTimestamps):
         circuit: Circuit,
         sonata_simulation_config_directory: Path,
         simulation_length: NonNegativeFloat,
-        default_timestamps: TimestampsReference = None,  # ty:ignore[invalid-parameter-default]
-        default_source_neuron_set_reference: ALL_NEURON_SETS_REFERENCE_UNION | None = None,
-        default_target_neuron_set_reference: ALL_NEURON_SETS_REFERENCE_UNION | None = None,
     ) -> dict:
-        if default_timestamps is None:
-            default_timestamps = SingleTimestamp(start_time=0.0)
-        self._default_timestamps = default_timestamps
+        """Returns the SONATA inputs entry for this spike stimulus, writing its spike file."""
+        source_neuron_set = resolve_neuron_set_ref_to_neuron_set(self.source_neuron_set)
+        target_neuron_set = resolve_neuron_set_ref_to_neuron_set(self.targeted_neuron_set)
 
-        source_neuron_set = resolve_neuron_set_ref_to_neuron_set(
-            self.source_neuron_set, default_source_neuron_set_reference
-        )
-
-        target_neuron_set = resolve_neuron_set_ref_to_neuron_set(
-            self.targeted_neuron_set, default_target_neuron_set_reference
-        )
-
-        if (
-            not target_neuron_set.has_biophysical_neurons(circuit)  # ty:ignore[unresolved-attribute]
-            and not target_neuron_set.has_point_neurons(circuit)  # ty:ignore[unresolved-attribute]
-        ):
+        if not target_neuron_set.has_biophysical_neurons(
+            circuit
+        ) and not target_neuron_set.has_point_neurons(circuit):
             msg = "Target Neuron Set of Spike Stimulus must be biophysical or point."
             raise OBIONEError(msg)
 
         spike_file_relative_path = self.generate_spikes(
             circuit=circuit,
             spike_file_directory=sonata_simulation_config_directory,
-            source_neuron_set=source_neuron_set,  # ty:ignore[invalid-argument-type]
+            source_neuron_set=source_neuron_set,
         )
 
         sonata_config = self._generate_config(
             spike_file_relative_path=spike_file_relative_path,
             sonata_simulation_config_directory=sonata_simulation_config_directory,
             simulation_length=simulation_length,
-            target_neuron_set=target_neuron_set,  # ty:ignore[invalid-argument-type]
+            target_neuron_set=target_neuron_set,
         )
 
         return sonata_config

--- a/obi_one/scientific/blocks/stimuli/spike/isi_distribution.py
+++ b/obi_one/scientific/blocks/stimuli/spike/isi_distribution.py
@@ -18,6 +18,7 @@ from obi_one.scientific.library.constants import (
     MAX_SIMULATION_LENGTH_MILLISECONDS,
 )
 from obi_one.scientific.unions_and_references.distributions import AllDistributionsReference
+from obi_one.scientific.unions_and_references.reference_tags import ReferenceTag
 
 
 class InterSpikeIntervalDistributionSpikeStimulus(SpikeStimulus):
@@ -48,6 +49,7 @@ class InterSpikeIntervalDistributionSpikeStimulus(SpikeStimulus):
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
             SchemaKey.REFERENCE_TYPES: [AllDistributionsReference.__name__],
+            SchemaKey.REFERENCE_TAG: ReferenceTag.INTER_SPIKE_INTERVAL_DISTRIBUTION,
         },
     )
 

--- a/obi_one/scientific/blocks/stimuli/spike/isi_distribution.py
+++ b/obi_one/scientific/blocks/stimuli/spike/isi_distribution.py
@@ -11,7 +11,6 @@ from obi_one.core.units import Units
 
 if TYPE_CHECKING:
     from obi_one.scientific.blocks.distributions.base import Distribution
-from obi_one.scientific.blocks.distributions.exponential import ExponentialDistribution
 from obi_one.scientific.blocks.stimuli.spike.base import SpikeStimulus
 from obi_one.scientific.library.constants import (
     DEFAULT_STIMULUS_LENGTH_MILLISECONDS,
@@ -86,10 +85,7 @@ class InterSpikeIntervalDistributionSpikeStimulus(SpikeStimulus):
         return spikes
 
     def generate_spikes_by_gid(self, source_gids: list[int]) -> dict[int, list[float]]:
-        if self.distribution is None:
-            distribution = ExponentialDistribution(scale=50.0)
-        else:
-            distribution = self.distribution.block
+        distribution = self.distribution.block  # ty:ignore[unresolved-attribute]
 
         timestamps = self._offset_timestamps()
         random_seed = getattr(distribution, "random_seed", None)

--- a/obi_one/scientific/blocks/stimuli/spike/time_distribution.py
+++ b/obi_one/scientific/blocks/stimuli/spike/time_distribution.py
@@ -15,6 +15,7 @@ from obi_one.scientific.library.constants import (
     MAX_SIMULATION_LENGTH_MILLISECONDS,
 )
 from obi_one.scientific.unions_and_references.distributions import AllDistributionsReference
+from obi_one.scientific.unions_and_references.reference_tags import ReferenceTag
 
 if TYPE_CHECKING:
     from obi_one.scientific.blocks.distributions.base import Distribution
@@ -58,6 +59,7 @@ class SpikeTimeDistributionSpikeStimulus(SpikeStimulus):
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
             SchemaKey.REFERENCE_TYPES: [AllDistributionsReference.__name__],
+            SchemaKey.REFERENCE_TAG: ReferenceTag.SPIKE_TIME_DISTRIBUTION,
         },
     )
 

--- a/obi_one/scientific/blocks/stimuli/spike/time_distribution.py
+++ b/obi_one/scientific/blocks/stimuli/spike/time_distribution.py
@@ -8,7 +8,6 @@ from pydantic import Field, NonNegativeFloat
 
 from obi_one.core.schema import SchemaKey, UIElement
 from obi_one.core.units import Units
-from obi_one.scientific.blocks.distributions.uniform import FloatUniformDistribution
 from obi_one.scientific.blocks.stimuli.spike.base import SpikeStimulus
 from obi_one.scientific.library.constants import (
     DEFAULT_STIMULUS_LENGTH_MILLISECONDS,
@@ -54,7 +53,7 @@ class SpikeTimeDistributionSpikeStimulus(SpikeStimulus):
         title="Spike Time Distribution",
         description=(
             "Distribution used to sample spike times directly in milliseconds. "
-            "Default: FloatUniformDistribution(low=0.0, high=duration)."
+            "Default: NormalDistribution(mean=5.0, standard_deviation=1.0)."
         ),
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
@@ -99,10 +98,7 @@ class SpikeTimeDistributionSpikeStimulus(SpikeStimulus):
         return sorted(float(t) for t in samples if 0.0 <= t < duration)
 
     def generate_spikes_by_gid(self, source_gids: list[int]) -> dict[int, list[float]]:
-        if self.distribution is None:
-            distribution = FloatUniformDistribution(low=0.0, high=self.duration)
-        else:
-            distribution = self.distribution.block
+        distribution = self.distribution.block  # ty:ignore[unresolved-attribute]
 
         timestamps = self._offset_timestamps()
         random_seed = getattr(distribution, "random_seed", None)

--- a/obi_one/scientific/blocks/stimuli/stimulus.py
+++ b/obi_one/scientific/blocks/stimuli/stimulus.py
@@ -13,7 +13,6 @@ from obi_one.core.block_subunit.complex_variable_holder import DurationVoltageCo
 from obi_one.core.parametric_multi_values import FloatRange
 from obi_one.core.schema import SchemaKey, UIElement
 from obi_one.core.units import Units
-from obi_one.scientific.blocks.timestamps.single import SingleTimestamp
 from obi_one.scientific.library.constants import (
     DEFAULT_PULSE_STIMULUS_LENGTH_MILLISECONDS,
     DEFAULT_SIMULATION_LENGTH_MILLISECONDS,
@@ -29,6 +28,7 @@ from obi_one.scientific.unions_and_references.combined_neuron_sets import (
 from obi_one.scientific.unions_and_references.morphology_locations import (
     MorphologyLocationsReference,
 )
+from obi_one.scientific.unions_and_references.reference_tags import ReferenceTag
 from obi_one.scientific.unions_and_references.timestamps import (
     TimestampsReference,
     resolve_timestamps_ref_to_timestamps_block,
@@ -49,9 +49,6 @@ _TIMESTAMPS_OFFSET_FIELD = Field(
 
 
 class BaseStimulus(Block, ABC):
-    _default_node_set: str = PrivateAttr(default="All")
-    _default_timestamps: TimestampsReference = PrivateAttr(default=SingleTimestamp(start_time=0.0))  # ty:ignore[invalid-assignment]
-
     @abstractmethod
     def _generate_config(self) -> dict:
         pass
@@ -65,16 +62,14 @@ class StimulusWithTimestamps(BaseStimulus):
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
             SchemaKey.REFERENCE_TYPES: [TimestampsReference.__name__],
+            SchemaKey.REFERENCE_TAG: ReferenceTag.TIMESTAMPS,
         },
     )
 
     timestamp_offset: float | list[float] = _TIMESTAMPS_OFFSET_FIELD
 
     def _offset_timestamps(self) -> list[float]:
-        timestamps_block = resolve_timestamps_ref_to_timestamps_block(
-            self.timestamps,
-            self._default_timestamps,  # ty:ignore[invalid-argument-type]
-        )
+        timestamps_block = resolve_timestamps_ref_to_timestamps_block(self.timestamps)
 
         offset_timestamps = [
             offset_timestamp
@@ -124,6 +119,7 @@ class ContinuousStimulusWithoutTimestamps(BaseStimulus):
                     *NON_VIRTUAL_NEURON_SETS_REFERENCE_TYPES,
                     MorphologyLocationsReference.__name__,
                 ],
+                SchemaKey.REFERENCE_TAG: ReferenceTag.STIMULUS_TARGET,
                 SchemaKey.PARAMETER_ORDER_PRIORITY: 100,
             },
         )
@@ -160,12 +156,7 @@ class ContinuousStimulusWithoutTimestamps(BaseStimulus):
             return {"compartment_set": self._materialized_compartment_set_name}
 
         neuron_set = cast("NON_VIRTUAL_NEURON_SETS_REFERENCE_UNION | None", self.neuron_set)
-        return {
-            "node_set": resolve_neuron_set_ref_to_node_set(
-                neuron_set,
-                self._default_node_set,
-            )
-        }
+        return {"node_set": resolve_neuron_set_ref_to_node_set(neuron_set)}
 
     _represents_physical_electrode: bool = PrivateAttr(default=False)
     """Default is False. If True, the signal will be implemented \
@@ -179,16 +170,8 @@ class ContinuousStimulusWithoutTimestamps(BaseStimulus):
     but produce a membrane current, which is included in the \
     calculation of the extracellular signal."""
 
-    def config(
-        self,
-        default_node_set: str = "All",
-        default_timestamps: TimestampsReference = None,  # ty:ignore[invalid-parameter-default]
-    ) -> dict:
-        self._default_node_set = default_node_set
-        if default_timestamps is None:
-            default_timestamps = SingleTimestamp(start_time=0.0)
-        self._default_timestamps = default_timestamps
-
+    def config(self) -> dict:
+        """Returns the SONATA inputs entries for this stimulus."""
         return self._generate_config()
 
 

--- a/obi_one/scientific/blocks/synaptic_manipulations/base.py
+++ b/obi_one/scientific/blocks/synaptic_manipulations/base.py
@@ -5,7 +5,6 @@ from pydantic import Field, PrivateAttr
 from obi_one.core.block import Block
 from obi_one.core.schema import SchemaKey, UIElement
 from obi_one.core.units import Units
-from obi_one.scientific.blocks.timestamps.single import SingleTimestamp
 from obi_one.scientific.unions_and_references.combined_neuron_sets import (
     ALL_NEURON_SETS_REFERENCE_TYPES,
     ALL_NEURON_SETS_REFERENCE_UNION,
@@ -13,6 +12,7 @@ from obi_one.scientific.unions_and_references.combined_neuron_sets import (
     NON_VIRTUAL_NEURON_SETS_REFERENCE_UNION,
     resolve_neuron_set_ref_to_node_set,
 )
+from obi_one.scientific.unions_and_references.reference_tags import ReferenceTag
 from obi_one.scientific.unions_and_references.timestamps import (
     TimestampsReference,
     resolve_timestamps_ref_to_timestamps_block,
@@ -34,6 +34,7 @@ class InterNeuronSetSynapticManipulation(Block, ABC):
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
             SchemaKey.REFERENCE_TYPES: ALL_NEURON_SETS_REFERENCE_TYPES,
+            SchemaKey.REFERENCE_TAG: ReferenceTag.SYNAPTIC_MANIPULATION_SOURCE,
             SchemaKey.PARAMETER_ORDER_PRIORITY: 100,
         },
     )
@@ -45,25 +46,20 @@ class InterNeuronSetSynapticManipulation(Block, ABC):
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
             SchemaKey.REFERENCE_TYPES: NON_VIRTUAL_NEURON_SETS_REFERENCE_TYPES,
+            SchemaKey.REFERENCE_TAG: ReferenceTag.SYNAPTIC_MANIPULATION_TARGET,
             SchemaKey.PARAMETER_ORDER_PRIORITY: 99,
         },
     )
 
-    _default_node_set: str = PrivateAttr(default="All")
-
-    def config(self, default_node_set: str = "All") -> dict:
-        self._default_node_set = default_node_set
+    def config(self) -> dict:
+        """Returns the SONATA connection_overrides entries for this manipulation."""
         return self._sonata_manipulations_list()
 
     def _sonata_manipulations_list(self) -> dict:
         sonata_config = {
             "name": self.block_name,
-            "source": resolve_neuron_set_ref_to_node_set(
-                self.presynaptic_neuron_set, self._default_node_set
-            ),
-            "target": resolve_neuron_set_ref_to_node_set(
-                self.postsynaptic_neuron_set, self._default_node_set
-            ),
+            "source": resolve_neuron_set_ref_to_node_set(self.presynaptic_neuron_set),
+            "target": resolve_neuron_set_ref_to_node_set(self.postsynaptic_neuron_set),
         }
 
         return [sonata_config]  # ty:ignore[invalid-return-type]
@@ -104,8 +100,6 @@ class ModSpecificVariableInterNeuronSetSynapticManipulation(
 class DelayedInterNeuronSetSynapticManipulation(InterNeuronSetSynapticManipulation, ABC):
     """Base class for synaptic manipulations applied with a delay at different timestamps."""
 
-    _default_timestamps: TimestampsReference = PrivateAttr(default=SingleTimestamp(start_time=0.0))  # ty:ignore[invalid-assignment]
-
     timestamps: TimestampsReference | None = Field(
         default=None,
         title="Timestamps",
@@ -113,6 +107,7 @@ class DelayedInterNeuronSetSynapticManipulation(InterNeuronSetSynapticManipulati
         json_schema_extra={
             SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
             SchemaKey.REFERENCE_TYPES: [TimestampsReference.__name__],
+            SchemaKey.REFERENCE_TAG: ReferenceTag.TIMESTAMPS,
         },
     )
 
@@ -136,10 +131,7 @@ class WeightChangeDelayedInterNeuronSetSynapticManipulation(
     _weight: float = PrivateAttr(default=0.0)
 
     def _sonata_manipulations_list(self) -> list:  # ty:ignore[invalid-method-override]
-        timestamps_block = resolve_timestamps_ref_to_timestamps_block(
-            self.timestamps,
-            self._default_timestamps,  # ty:ignore[invalid-argument-type]
-        )
+        timestamps_block = resolve_timestamps_ref_to_timestamps_block(self.timestamps)
 
         timestamps = timestamps_block.timestamps()
         n_timestamps = len(timestamps)

--- a/obi_one/scientific/tasks/generate_simulations/config/base.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/base.py
@@ -61,6 +61,7 @@ L = logging.getLogger(__name__)
 
 DEFAULT_TIMESTAMPS_NAME = "Default: Simulation Start (0 ms)"
 DEFAULT_DISTRIBUTION_NAME = "Default: Exponential, scale 50 ms"
+DEFAULT_SPIKE_TIME_DISTRIBUTION_NAME = "Default: Uniform over the stimulus duration"
 DEFAULT_MORPHOLOGY_LOCATIONS_NAME = "Default: No Locations"
 
 # Which reference type names a neuron set, given what the set contains. A default neuron set is
@@ -125,29 +126,73 @@ class BaseSimulationScanConfig(InfoScanConfig, abc.ABC):
     default_virtual_neuron_set_type: ClassVar[type[AllVirtualNeurons]] = AllVirtualNeurons
     default_point_neuron_set_type: ClassVar[type[AllPointNeurons]] = AllPointNeurons
 
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        """Publish the default names into the schema, so the UI never drifts from the code."""
+        super().__init_subclass__(**kwargs)
+        cls.model_config["json_schema_extra"].update(  # ty:ignore[unresolved-attribute]
+            {SchemaKey.REFERENCE_TAG_DEFAULTS: cls.default_block_reference_names()}
+        )
+
+    @classmethod
+    def default_block_reference_names(cls) -> dict[str, str]:
+        """The name of the block a reference of each role resolves to when left unset.
+
+        Published in the config's schema so the UI can show, as a placeholder, what leaving a
+        reference unset will actually do. This is the source of the names used to build the
+        references themselves, so the two cannot disagree.
+
+        It is class-level because the UI reads the schema without a circuit. That holds even for
+        Brian2's stimulus default, whose name is fixed although building its reference needs the
+        circuit to resolve a population.
+        """
+        simulation_neuron_set = cls.default_node_set_name
+        return {
+            ReferenceTag.SIMULATION_TARGET: simulation_neuron_set,
+            ReferenceTag.STIMULUS_TARGET: simulation_neuron_set,
+            ReferenceTag.SPIKE_REPLAY_SOURCE: simulation_neuron_set,
+            ReferenceTag.SPIKE_REPLAY_TARGET: simulation_neuron_set,
+            ReferenceTag.RECORDING_TARGET: simulation_neuron_set,
+            ReferenceTag.SYNAPTIC_MANIPULATION_SOURCE: simulation_neuron_set,
+            ReferenceTag.SYNAPTIC_MANIPULATION_TARGET: simulation_neuron_set,
+            ReferenceTag.NEURONAL_MANIPULATION_TARGET: simulation_neuron_set,
+            ReferenceTag.MORPHOLOGY_LOCATIONS_TARGET: simulation_neuron_set,
+            ReferenceTag.ANY_NEURON_SET_OPERAND: simulation_neuron_set,
+            ReferenceTag.BIOPHYSICAL_NEURON_SET_OPERAND: simulation_neuron_set,
+            ReferenceTag.NON_VIRTUAL_NEURON_SET_OPERAND: simulation_neuron_set,
+            ReferenceTag.POINT_NEURON_SET_OPERAND: cls.default_point_node_set_name,
+            ReferenceTag.VIRTUAL_NEURON_SET_OPERAND: cls.default_virtual_node_set_name,
+            ReferenceTag.TIMESTAMPS: DEFAULT_TIMESTAMPS_NAME,
+            # The two roles the task does not fill. Naming them by role rather than by reference
+            # type is what lets these two differ, which keyed by AllDistributionsReference they
+            # could not.
+            ReferenceTag.INTER_SPIKE_INTERVAL_DISTRIBUTION: DEFAULT_DISTRIBUTION_NAME,
+            ReferenceTag.SPIKE_TIME_DISTRIBUTION: DEFAULT_SPIKE_TIME_DISTRIBUTION_NAME,
+        }
+
     def default_block_references(
         self,
         circuit: Circuit,  # ruff: ignore[unused-method-argument]
     ) -> dict[str, BlockReference]:
-        """What each kind of unset block reference means for this simulation, keyed by its tag.
+        """What each kind of unset block reference resolves to, keyed by its tag.
 
         Most roles resolve to whatever the simulation runs, which each family varies through
         ``default_neuron_set_type`` rather than by overriding this. A family that needs a role to
         mean something else overrides this method. The circuit is passed in for families whose
         defaults name something that has to be resolved against it.
 
-        Two tags are deliberately absent. Both spike distribution defaults depend on the stimulus's
-        own parameters -- a spike time distribution spans that stimulus's duration -- so no
-        simulation-wide reference can express them and those blocks supply their own.
+        Two tags in ``default_block_reference_names`` are deliberately absent here. Both spike
+        distribution defaults depend on the stimulus's own parameters -- a spike time distribution
+        spans that stimulus's duration -- so no simulation-wide reference can express them and
+        those blocks supply their own.
         """
+        names = self.default_block_reference_names()
         simulation_neuron_set = build_neuron_set_reference(
-            self.default_node_set_name, self.default_neuron_set_type()
+            names[ReferenceTag.SIMULATION_TARGET], self.default_neuron_set_type()
         )
-        timestamps = TimestampsReference(
-            block_dict_name="timestamps", block_name=DEFAULT_TIMESTAMPS_NAME
-        )
+        timestamps_name = names[ReferenceTag.TIMESTAMPS]
+        timestamps = TimestampsReference(block_dict_name="timestamps", block_name=timestamps_name)
         timestamps.block = SingleTimestamp(start_time=0.0)
-        timestamps.block.set_block_name(DEFAULT_TIMESTAMPS_NAME)
+        timestamps.block.set_block_name(timestamps_name)
 
         return {
             ReferenceTag.SIMULATION_TARGET: simulation_neuron_set,
@@ -166,10 +211,11 @@ class BaseSimulationScanConfig(InfoScanConfig, abc.ABC):
             ReferenceTag.BIOPHYSICAL_NEURON_SET_OPERAND: simulation_neuron_set,
             ReferenceTag.NON_VIRTUAL_NEURON_SET_OPERAND: simulation_neuron_set,
             ReferenceTag.POINT_NEURON_SET_OPERAND: build_neuron_set_reference(
-                self.default_point_node_set_name, self.default_point_neuron_set_type()
+                names[ReferenceTag.POINT_NEURON_SET_OPERAND], self.default_point_neuron_set_type()
             ),
             ReferenceTag.VIRTUAL_NEURON_SET_OPERAND: build_neuron_set_reference(
-                self.default_virtual_node_set_name, self.default_virtual_neuron_set_type()
+                names[ReferenceTag.VIRTUAL_NEURON_SET_OPERAND],
+                self.default_virtual_neuron_set_type(),
             ),
             ReferenceTag.TIMESTAMPS: timestamps,
         }

--- a/obi_one/scientific/tasks/generate_simulations/config/base.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/base.py
@@ -10,6 +10,7 @@ from libsonata import SimulatorType
 from pydantic import Field, NonNegativeFloat, PositiveFloat
 
 from obi_one.core.block import Block
+from obi_one.core.block_reference import BlockReference
 from obi_one.core.exception import OBIONEError
 from obi_one.core.schema import SchemaKey, UIElement
 from obi_one.core.serialization_constants import (
@@ -18,16 +19,19 @@ from obi_one.core.serialization_constants import (
 )
 from obi_one.core.single import SingleConfigMixin
 from obi_one.core.units import Units
+from obi_one.scientific.blocks.neuron_sets.base import NeuronSet, NeuronSetPopulationType
 from obi_one.scientific.blocks.neuron_sets.specific import (
     AllBiophysicalNeurons,
     AllPointNeurons,
     AllVirtualNeurons,
 )
+from obi_one.scientific.blocks.timestamps.single import SingleTimestamp
 from obi_one.scientific.from_id.circuit_from_id import (
     CircuitFromID,
     MEModelWithSynapsesCircuitFromID,
 )
 from obi_one.scientific.from_id.memodel_from_id import MEModelFromID
+from obi_one.scientific.library.circuit import Circuit
 from obi_one.scientific.library.constants import (
     DEFAULT_SIMULATION_LENGTH_MILLISECONDS,
     MAX_SIMULATION_LENGTH_MILLISECONDS,
@@ -38,11 +42,17 @@ from obi_one.scientific.library.entity_property_types import (
 )
 from obi_one.scientific.library.info_scan_config.config import InfoScanConfig
 from obi_one.scientific.library.ion_channel_model_circuit import CircuitFromIonChannelModels
+from obi_one.scientific.unions_and_references.combined_neuron_sets import (
+    resolve_neuron_set_ref_to_node_set,
+)
 from obi_one.scientific.unions_and_references.neuron_sets import (
+    BaseNeuronSetReference,
     BiophysicalNeuronSetReference,
     PointNeuronSetReference,
     VirtualNeuronSetReference,
 )
+from obi_one.scientific.unions_and_references.reference_tags import ReferenceTag
+from obi_one.scientific.unions_and_references.timestamps import TimestampsReference
 
 SONATA_VERSION = 2.4
 
@@ -52,6 +62,33 @@ L = logging.getLogger(__name__)
 DEFAULT_TIMESTAMPS_NAME = "Default: Simulation Start (0 ms)"
 DEFAULT_DISTRIBUTION_NAME = "Default: Exponential, scale 50 ms"
 DEFAULT_MORPHOLOGY_LOCATIONS_NAME = "Default: No Locations"
+
+# Which reference type names a neuron set, given what the set contains. A default neuron set is
+# built by the config rather than chosen by the user, so its reference type has to be derived
+# rather than declared -- and the set already knows what it holds.
+_NEURON_SET_REFERENCE_TYPES: dict[NeuronSetPopulationType, type[BaseNeuronSetReference]] = {
+    NeuronSetPopulationType.BIOPHYSICAL: BiophysicalNeuronSetReference,
+    NeuronSetPopulationType.POINT: PointNeuronSetReference,
+    NeuronSetPopulationType.VIRTUAL: VirtualNeuronSetReference,
+}
+
+
+def build_neuron_set_reference(name: str, neuron_set: NeuronSet) -> BaseNeuronSetReference:
+    """A resolved reference to a neuron set the config supplies rather than the user."""
+    population_type = neuron_set.get_neuron_set_population_type()
+    try:
+        reference_type = _NEURON_SET_REFERENCE_TYPES[population_type]
+    except KeyError as error:
+        msg = (
+            f"No reference type names a '{population_type}' neuron set, so "
+            f"{type(neuron_set).__name__} cannot be used as a default."
+        )
+        raise OBIONEError(msg) from error
+
+    reference = reference_type(block_dict_name="neuron_sets", block_name=name)
+    neuron_set.set_block_name(name)
+    reference.block = neuron_set
+    return reference
 
 
 class BlockGroup(StrEnum):
@@ -88,43 +125,104 @@ class BaseSimulationScanConfig(InfoScanConfig, abc.ABC):
     default_virtual_neuron_set_type: ClassVar[type[AllVirtualNeurons]] = AllVirtualNeurons
     default_point_neuron_set_type: ClassVar[type[AllPointNeurons]] = AllPointNeurons
 
-    @property
-    def default_neuron_set_reference(
+    def default_block_references(
         self,
-    ) -> BiophysicalNeuronSetReference:
-        """The default neuron set reference for the simulation."""
-        default_neuron_set_block_reference = BiophysicalNeuronSetReference(
-            block_dict_name="neuron_sets", block_name=self.default_node_set_name
+        circuit: Circuit,  # ruff: ignore[unused-method-argument]
+    ) -> dict[str, BlockReference]:
+        """What each kind of unset block reference means for this simulation, keyed by its tag.
+
+        Most roles resolve to whatever the simulation runs, which each family varies through
+        ``default_neuron_set_type`` rather than by overriding this. A family that needs a role to
+        mean something else overrides this method. The circuit is passed in for families whose
+        defaults name something that has to be resolved against it.
+
+        Two tags are deliberately absent. Both spike distribution defaults depend on the stimulus's
+        own parameters -- a spike time distribution spans that stimulus's duration -- so no
+        simulation-wide reference can express them and those blocks supply their own.
+        """
+        simulation_neuron_set = build_neuron_set_reference(
+            self.default_node_set_name, self.default_neuron_set_type()
         )
+        timestamps = TimestampsReference(
+            block_dict_name="timestamps", block_name=DEFAULT_TIMESTAMPS_NAME
+        )
+        timestamps.block = SingleTimestamp(start_time=0.0)
+        timestamps.block.set_block_name(DEFAULT_TIMESTAMPS_NAME)
 
-        default_neuron_set_block_reference.block = self.default_neuron_set_type()
-        default_neuron_set_block_reference.block.set_block_name(self.default_node_set_name)
-
-        return default_neuron_set_block_reference
+        return {
+            ReferenceTag.SIMULATION_TARGET: simulation_neuron_set,
+            ReferenceTag.STIMULUS_TARGET: simulation_neuron_set,
+            ReferenceTag.SPIKE_REPLAY_SOURCE: simulation_neuron_set,
+            ReferenceTag.SPIKE_REPLAY_TARGET: simulation_neuron_set,
+            ReferenceTag.RECORDING_TARGET: simulation_neuron_set,
+            ReferenceTag.SYNAPTIC_MANIPULATION_SOURCE: simulation_neuron_set,
+            ReferenceTag.SYNAPTIC_MANIPULATION_TARGET: simulation_neuron_set,
+            ReferenceTag.NEURONAL_MANIPULATION_TARGET: simulation_neuron_set,
+            ReferenceTag.MORPHOLOGY_LOCATIONS_TARGET: simulation_neuron_set,
+            # An unset operand of a combined neuron set means every neuron of that set's own
+            # population type, which differs from the simulation default only when the combined
+            # set is virtual or point.
+            ReferenceTag.ANY_NEURON_SET_OPERAND: simulation_neuron_set,
+            ReferenceTag.BIOPHYSICAL_NEURON_SET_OPERAND: simulation_neuron_set,
+            ReferenceTag.NON_VIRTUAL_NEURON_SET_OPERAND: simulation_neuron_set,
+            ReferenceTag.POINT_NEURON_SET_OPERAND: build_neuron_set_reference(
+                self.default_point_node_set_name, self.default_point_neuron_set_type()
+            ),
+            ReferenceTag.VIRTUAL_NEURON_SET_OPERAND: build_neuron_set_reference(
+                self.default_virtual_node_set_name, self.default_virtual_neuron_set_type()
+            ),
+            ReferenceTag.TIMESTAMPS: timestamps,
+        }
 
     @property
-    def default_virtual_neuron_set_reference(
-        self,
-    ) -> VirtualNeuronSetReference:
-        """The default virtual neuron set reference for the simulation."""
-        ref = VirtualNeuronSetReference(
-            block_dict_name="neuron_sets", block_name=self.default_virtual_node_set_name
-        )
-        ref.block = self.default_virtual_neuron_set_type()
-        ref.block.set_block_name(self.default_virtual_node_set_name)
-        return ref
+    def simulation_node_set_name(self) -> str:
+        """The SONATA node set the simulation runs.
 
-    @property
-    def default_point_neuron_set_reference(
-        self,
-    ) -> PointNeuronSetReference:
-        """The default point neuron set reference for the simulation."""
-        ref = PointNeuronSetReference(
-            block_dict_name="neuron_sets", block_name=self.default_point_node_set_name
+        Only meaningful once references have been filled. A config that offers no target has no
+        neuron sets dictionary either, so its node set is written from the default type directly.
+        """
+        if not hasattr(self.initialize, "node_set"):
+            return self.default_node_set_name
+
+        return resolve_neuron_set_ref_to_node_set(self.initialize.node_set)  # ty:ignore[invalid-argument-type]
+
+    def check_simulation_target(self, circuit: Circuit) -> None:
+        """Raise if the neuron set the simulation runs cannot actually be simulated.
+
+        Virtual neurons only emit pre-determined spikes, so a simulation targeting them would have
+        nothing to compute.
+        """
+        node_set = getattr(self.initialize, "node_set", None)
+        if not isinstance(node_set, BaseNeuronSetReference):
+            return
+
+        if node_set.block.get_neuron_set_population_type() in {
+            NeuronSetPopulationType.BIOPHYSICAL,
+            NeuronSetPopulationType.POINT,
+            NeuronSetPopulationType.NONVIRTUAL,
+        }:
+            return
+
+        non_virtual_populations = Circuit.get_node_population_names(
+            circuit.sonata_circuit,
+            incl_virtual=False,
+            incl_point=True,
         )
-        ref.block = self.default_point_neuron_set_type()
-        ref.block.set_block_name(self.default_point_node_set_name)
-        return ref
+        non_virtual_list = (
+            ", ".join(f"'{pop}'" for pop in non_virtual_populations)
+            if non_virtual_populations
+            else "none found"
+        )
+        msg = (
+            f"Simulation Neuron Set (Initialize -> Neuron Set): "
+            f"'{node_set.block_name}' is virtual. "
+            "Please use a non-virtual (biophysical or point) Neuron Set type. "
+            f"Available non-virtual populations: {non_virtual_list}. "
+            f"You may be able to reference one through an "
+            f"MultiPopulationPredefinedNeuronSet block type. "
+            "In future we will support population selection for any neuron set."
+        )
+        raise OBIONEError(msg)
 
     json_schema_extra_additions: ClassVar[dict] = {
         SchemaKey.PROPERTY_ENDPOINTS: {

--- a/obi_one/scientific/tasks/generate_simulations/config/base.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/base.py
@@ -19,6 +19,8 @@ from obi_one.core.serialization_constants import (
 )
 from obi_one.core.single import SingleConfigMixin
 from obi_one.core.units import Units
+from obi_one.scientific.blocks.distributions.exponential import ExponentialDistribution
+from obi_one.scientific.blocks.distributions.normal import NormalDistribution
 from obi_one.scientific.blocks.neuron_sets.base import NeuronSet, NeuronSetPopulationType
 from obi_one.scientific.blocks.neuron_sets.specific import (
     AllBiophysicalNeurons,
@@ -45,6 +47,7 @@ from obi_one.scientific.library.ion_channel_model_circuit import CircuitFromIonC
 from obi_one.scientific.unions_and_references.combined_neuron_sets import (
     resolve_neuron_set_ref_to_node_set,
 )
+from obi_one.scientific.unions_and_references.distributions import AllDistributionsReference
 from obi_one.scientific.unions_and_references.neuron_sets import (
     BaseNeuronSetReference,
     BiophysicalNeuronSetReference,
@@ -61,7 +64,7 @@ L = logging.getLogger(__name__)
 
 DEFAULT_TIMESTAMPS_NAME = "Default: Simulation Start (0 ms)"
 DEFAULT_DISTRIBUTION_NAME = "Default: Exponential, scale 50 ms"
-DEFAULT_SPIKE_TIME_DISTRIBUTION_NAME = "Default: Uniform over the stimulus duration"
+DEFAULT_SPIKE_TIME_DISTRIBUTION_NAME = "Default: Normal, mean 5 ms, sd 1 ms"
 DEFAULT_MORPHOLOGY_LOCATIONS_NAME = "Default: No Locations"
 
 # Which reference type names a neuron set, given what the set contains. A default neuron set is
@@ -89,6 +92,16 @@ def build_neuron_set_reference(name: str, neuron_set: NeuronSet) -> BaseNeuronSe
     reference = reference_type(block_dict_name="neuron_sets", block_name=name)
     neuron_set.set_block_name(name)
     reference.block = neuron_set
+    return reference
+
+
+def _build_resolved_reference(
+    reference_type: type[BlockReference], block_dict_name: str, name: str, block: Block
+) -> BlockReference:
+    """A resolved reference to a block the config supplies rather than the user."""
+    reference = reference_type(block_dict_name=block_dict_name, block_name=name)
+    block.set_block_name(name)
+    reference.block = block
     return reference
 
 
@@ -130,70 +143,30 @@ class BaseSimulationScanConfig(InfoScanConfig, abc.ABC):
         """Publish the default names into the schema, so the UI never drifts from the code."""
         super().__init_subclass__(**kwargs)
         cls.model_config["json_schema_extra"].update(  # ty:ignore[unresolved-attribute]
-            {SchemaKey.REFERENCE_TAG_DEFAULTS: cls.default_block_reference_names()}
+            {
+                SchemaKey.REFERENCE_TAG_DEFAULTS: {
+                    tag: reference.block_name
+                    for tag, reference in cls.default_block_references().items()
+                }
+            }
         )
 
     @classmethod
-    def default_block_reference_names(cls) -> dict[str, str]:
-        """The name of the block a reference of each role resolves to when left unset.
-
-        Published in the config's schema so the UI can show, as a placeholder, what leaving a
-        reference unset will actually do. This is the source of the names used to build the
-        references themselves, so the two cannot disagree.
-
-        It is class-level because the UI reads the schema without a circuit. That holds even for
-        Brian2's stimulus default, whose name is fixed although building its reference needs the
-        circuit to resolve a population.
-        """
-        simulation_neuron_set = cls.default_node_set_name
-        return {
-            ReferenceTag.SIMULATION_TARGET: simulation_neuron_set,
-            ReferenceTag.STIMULUS_TARGET: simulation_neuron_set,
-            ReferenceTag.SPIKE_REPLAY_SOURCE: simulation_neuron_set,
-            ReferenceTag.SPIKE_REPLAY_TARGET: simulation_neuron_set,
-            ReferenceTag.RECORDING_TARGET: simulation_neuron_set,
-            ReferenceTag.SYNAPTIC_MANIPULATION_SOURCE: simulation_neuron_set,
-            ReferenceTag.SYNAPTIC_MANIPULATION_TARGET: simulation_neuron_set,
-            ReferenceTag.NEURONAL_MANIPULATION_TARGET: simulation_neuron_set,
-            ReferenceTag.MORPHOLOGY_LOCATIONS_TARGET: simulation_neuron_set,
-            ReferenceTag.ANY_NEURON_SET_OPERAND: simulation_neuron_set,
-            ReferenceTag.BIOPHYSICAL_NEURON_SET_OPERAND: simulation_neuron_set,
-            ReferenceTag.NON_VIRTUAL_NEURON_SET_OPERAND: simulation_neuron_set,
-            ReferenceTag.POINT_NEURON_SET_OPERAND: cls.default_point_node_set_name,
-            ReferenceTag.VIRTUAL_NEURON_SET_OPERAND: cls.default_virtual_node_set_name,
-            ReferenceTag.TIMESTAMPS: DEFAULT_TIMESTAMPS_NAME,
-            # The two roles the task does not fill. Naming them by role rather than by reference
-            # type is what lets these two differ, which keyed by AllDistributionsReference they
-            # could not.
-            ReferenceTag.INTER_SPIKE_INTERVAL_DISTRIBUTION: DEFAULT_DISTRIBUTION_NAME,
-            ReferenceTag.SPIKE_TIME_DISTRIBUTION: DEFAULT_SPIKE_TIME_DISTRIBUTION_NAME,
-        }
-
-    def default_block_references(
-        self,
-        circuit: Circuit,  # ruff: ignore[unused-method-argument]
-    ) -> dict[str, BlockReference]:
+    def default_block_references(cls) -> dict[str, BlockReference]:
         """What each kind of unset block reference resolves to, keyed by its tag.
 
         Most roles resolve to whatever the simulation runs, which each family varies through
         ``default_neuron_set_type`` rather than by overriding this. A family that needs a role to
-        mean something else overrides this method. The circuit is passed in for families whose
-        defaults name something that has to be resolved against it.
+        mean something else overrides this method.
 
-        Two tags in ``default_block_reference_names`` are deliberately absent here. Both spike
-        distribution defaults depend on the stimulus's own parameters -- a spike time distribution
-        spans that stimulus's duration -- so no simulation-wide reference can express them and
-        those blocks supply their own.
+        Every role appears here, so the block each one names is also the source of the placeholder
+        the UI shows for it -- ``__init_subclass__`` reads the names straight off these references
+        and publishes them in the schema, which is why the two can never disagree. That in turn is
+        why this is class-level and takes no circuit: the UI reads the schema without one.
         """
-        names = self.default_block_reference_names()
         simulation_neuron_set = build_neuron_set_reference(
-            names[ReferenceTag.SIMULATION_TARGET], self.default_neuron_set_type()
+            cls.default_node_set_name, cls.default_neuron_set_type()
         )
-        timestamps_name = names[ReferenceTag.TIMESTAMPS]
-        timestamps = TimestampsReference(block_dict_name="timestamps", block_name=timestamps_name)
-        timestamps.block = SingleTimestamp(start_time=0.0)
-        timestamps.block.set_block_name(timestamps_name)
-
         return {
             ReferenceTag.SIMULATION_TARGET: simulation_neuron_set,
             ReferenceTag.STIMULUS_TARGET: simulation_neuron_set,
@@ -211,13 +184,31 @@ class BaseSimulationScanConfig(InfoScanConfig, abc.ABC):
             ReferenceTag.BIOPHYSICAL_NEURON_SET_OPERAND: simulation_neuron_set,
             ReferenceTag.NON_VIRTUAL_NEURON_SET_OPERAND: simulation_neuron_set,
             ReferenceTag.POINT_NEURON_SET_OPERAND: build_neuron_set_reference(
-                names[ReferenceTag.POINT_NEURON_SET_OPERAND], self.default_point_neuron_set_type()
+                cls.default_point_node_set_name, cls.default_point_neuron_set_type()
             ),
             ReferenceTag.VIRTUAL_NEURON_SET_OPERAND: build_neuron_set_reference(
-                names[ReferenceTag.VIRTUAL_NEURON_SET_OPERAND],
-                self.default_virtual_neuron_set_type(),
+                cls.default_virtual_node_set_name, cls.default_virtual_neuron_set_type()
             ),
-            ReferenceTag.TIMESTAMPS: timestamps,
+            ReferenceTag.TIMESTAMPS: _build_resolved_reference(
+                TimestampsReference,
+                "timestamps",
+                DEFAULT_TIMESTAMPS_NAME,
+                SingleTimestamp(start_time=0.0),
+            ),
+            # Keying the two spike distributions by role rather than by reference type is what
+            # lets them differ, which keyed by AllDistributionsReference they could not.
+            ReferenceTag.INTER_SPIKE_INTERVAL_DISTRIBUTION: _build_resolved_reference(
+                AllDistributionsReference,
+                "distributions",
+                DEFAULT_DISTRIBUTION_NAME,
+                ExponentialDistribution(scale=50.0),
+            ),
+            ReferenceTag.SPIKE_TIME_DISTRIBUTION: _build_resolved_reference(
+                AllDistributionsReference,
+                "distributions",
+                DEFAULT_SPIKE_TIME_DISTRIBUTION_NAME,
+                NormalDistribution(mean=5.0, standard_deviation=1.0),
+            ),
         }
 
     @property

--- a/obi_one/scientific/tasks/generate_simulations/config/brian2/brian2_base.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/brian2/brian2_base.py
@@ -4,6 +4,7 @@ from typing import ClassVar
 from libsonata import SimulatorType
 from pydantic import PositiveFloat
 
+from obi_one.core.block_reference import BlockReference
 from obi_one.core.exception import OBIONEError
 from obi_one.scientific.blocks.neuron_sets.predefined import PointPopulationPredefinedNeuronSet
 from obi_one.scientific.blocks.neuron_sets.specific import AllPointNeurons
@@ -13,10 +14,9 @@ from obi_one.scientific.library.constants import (
 )
 from obi_one.scientific.tasks.generate_simulations.config.base import (
     BaseSimulationScanConfig,
+    build_neuron_set_reference,
 )
-from obi_one.scientific.unions_and_references.neuron_sets import (
-    PointNeuronSetReference,
-)
+from obi_one.scientific.unions_and_references.reference_tags import ReferenceTag
 
 
 class Brian2SimulationScanConfig(BaseSimulationScanConfig, abc.ABC):
@@ -36,31 +36,28 @@ class Brian2SimulationScanConfig(BaseSimulationScanConfig, abc.ABC):
     default_stimulus_node_set_name: ClassVar[str] = "Default: Sugar gustatory receptor neurons"
     default_stimulus_node_set: ClassVar[str] = "sugar"
 
-    @property
-    def default_neuron_set_reference(self) -> PointNeuronSetReference:
-        """The default neuron set reference for the simulation (all point neurons)."""
-        ref = PointNeuronSetReference(
-            block_dict_name="neuron_sets", block_name=self.default_node_set_name
-        )
-        ref.block = self.default_neuron_set_type()
-        ref.block.set_block_name(self.default_node_set_name)
-        return ref
+    def default_block_references(self, circuit: Circuit) -> dict[str, BlockReference]:
+        """As the base, except that an untargeted stimulus drives the `sugar` set.
 
-    def default_stimulus_neuron_set_reference(self, circuit: Circuit) -> PointNeuronSetReference:
-        """Returns the default neuron set reference for an untargeted stimulus (the `sugar` set).
-
-        It names an existing node set, so unlike the simulation default it has to resolve the
-        circuit's point population.
+        That set names an existing node set rather than a whole population, so unlike every other
+        default it has to be resolved against the circuit.
         """
-        ref = PointNeuronSetReference(
-            block_dict_name="neuron_sets", block_name=self.default_stimulus_node_set_name
-        )
-        ref.block = PointPopulationPredefinedNeuronSet(
-            node_set=self.default_stimulus_node_set,
-            population=self._point_population(circuit),
-        )
-        ref.block.set_block_name(self.default_stimulus_node_set_name)
-        return ref
+        return {
+            **super().default_block_references(circuit),
+            ReferenceTag.STIMULUS_TARGET: build_neuron_set_reference(
+                self.default_stimulus_node_set_name,
+                PointPopulationPredefinedNeuronSet(
+                    node_set=self.default_stimulus_node_set,
+                    population=self._point_population(circuit),
+                ),
+            ),
+        }
+
+    def check_simulation_target(self, circuit: Circuit) -> None:
+        """Nothing to check: a Brian2 simulation can only reference point neuron sets.
+
+        Its neuron set union admits no virtual type, so the base class's check cannot fail here.
+        """
 
     @staticmethod
     def _point_population(circuit: Circuit) -> str:

--- a/obi_one/scientific/tasks/generate_simulations/config/brian2/brian2_base.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/brian2/brian2_base.py
@@ -36,8 +36,16 @@ class Brian2SimulationScanConfig(BaseSimulationScanConfig, abc.ABC):
     default_stimulus_node_set_name: ClassVar[str] = "Default: Sugar gustatory receptor neurons"
     default_stimulus_node_set: ClassVar[str] = "sugar"
 
+    @classmethod
+    def default_block_reference_names(cls) -> dict[str, str]:
+        """As the base, except that an untargeted stimulus drives the `sugar` set."""
+        return {
+            **super().default_block_reference_names(),
+            ReferenceTag.STIMULUS_TARGET: cls.default_stimulus_node_set_name,
+        }
+
     def default_block_references(self, circuit: Circuit) -> dict[str, BlockReference]:
-        """As the base, except that an untargeted stimulus drives the `sugar` set.
+        """As the base, with the `sugar` set standing in for an untargeted stimulus.
 
         That set names an existing node set rather than a whole population, so unlike every other
         default it has to be resolved against the circuit.
@@ -45,7 +53,7 @@ class Brian2SimulationScanConfig(BaseSimulationScanConfig, abc.ABC):
         return {
             **super().default_block_references(circuit),
             ReferenceTag.STIMULUS_TARGET: build_neuron_set_reference(
-                self.default_stimulus_node_set_name,
+                self.default_block_reference_names()[ReferenceTag.STIMULUS_TARGET],
                 PointPopulationPredefinedNeuronSet(
                     node_set=self.default_stimulus_node_set,
                     population=self._point_population(circuit),

--- a/obi_one/scientific/tasks/generate_simulations/config/brian2/brian2_base.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/brian2/brian2_base.py
@@ -4,9 +4,6 @@ from typing import ClassVar
 from libsonata import SimulatorType
 from pydantic import PositiveFloat
 
-from obi_one.core.block_reference import BlockReference
-from obi_one.core.exception import OBIONEError
-from obi_one.scientific.blocks.neuron_sets.predefined import PointPopulationPredefinedNeuronSet
 from obi_one.scientific.blocks.neuron_sets.specific import AllPointNeurons
 from obi_one.scientific.library.circuit import Circuit
 from obi_one.scientific.library.constants import (
@@ -14,9 +11,7 @@ from obi_one.scientific.library.constants import (
 )
 from obi_one.scientific.tasks.generate_simulations.config.base import (
     BaseSimulationScanConfig,
-    build_neuron_set_reference,
 )
-from obi_one.scientific.unions_and_references.reference_tags import ReferenceTag
 
 
 class Brian2SimulationScanConfig(BaseSimulationScanConfig, abc.ABC):
@@ -26,60 +21,16 @@ class Brian2SimulationScanConfig(BaseSimulationScanConfig, abc.ABC):
     _timestep: ClassVar[PositiveFloat] = SIMULATION_TIMESTEP_MILLISECONDS
 
     # The simulation runs every point neuron by default, so its default neuron set is named for
-    # what it contains -- an untargeted simulation runs the whole circuit.
+    # what it contains -- an untargeted simulation runs the whole circuit. An untargeted stimulus
+    # drives the same set, as in every other family.
     default_node_set_name: ClassVar[str] = "Default: All Point Neurons"
     default_neuron_set_type: ClassVar[type[AllPointNeurons]] = AllPointNeurons
-
-    # A stimulus left without a target instead drives the `sugar` node set -- the gustatory
-    # receptor neurons the Shiu et al. (2024) FlyWire model stimulates -- rather than the whole
-    # circuit. This is a separate, smaller default so the two never conflict.
-    default_stimulus_node_set_name: ClassVar[str] = "Default: Sugar gustatory receptor neurons"
-    default_stimulus_node_set: ClassVar[str] = "sugar"
-
-    @classmethod
-    def default_block_reference_names(cls) -> dict[str, str]:
-        """As the base, except that an untargeted stimulus drives the `sugar` set."""
-        return {
-            **super().default_block_reference_names(),
-            ReferenceTag.STIMULUS_TARGET: cls.default_stimulus_node_set_name,
-        }
-
-    def default_block_references(self, circuit: Circuit) -> dict[str, BlockReference]:
-        """As the base, with the `sugar` set standing in for an untargeted stimulus.
-
-        That set names an existing node set rather than a whole population, so unlike every other
-        default it has to be resolved against the circuit.
-        """
-        return {
-            **super().default_block_references(circuit),
-            ReferenceTag.STIMULUS_TARGET: build_neuron_set_reference(
-                self.default_block_reference_names()[ReferenceTag.STIMULUS_TARGET],
-                PointPopulationPredefinedNeuronSet(
-                    node_set=self.default_stimulus_node_set,
-                    population=self._point_population(circuit),
-                ),
-            ),
-        }
 
     def check_simulation_target(self, circuit: Circuit) -> None:
         """Nothing to check: a Brian2 simulation can only reference point neuron sets.
 
         Its neuron set union admits no virtual type, so the base class's check cannot fail here.
         """
-
-    @staticmethod
-    def _point_population(circuit: Circuit) -> str:
-        """Return the circuit's single point node population."""
-        populations = Circuit.get_node_population_names(
-            circuit.sonata_circuit, incl_virtual=False, incl_biophysical=False
-        )
-        if len(populations) != 1:
-            msg = (
-                f"A Brian2 simulation needs exactly one point node population; "
-                f"circuit '{circuit.name}' has {len(populations)}: {populations}."
-            )
-            raise OBIONEError(msg)
-        return populations[0]
 
     class Initialize(BaseSimulationScanConfig.Initialize):
         pass

--- a/obi_one/scientific/tasks/generate_simulations/config/brian2/brian2_circuit.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/brian2/brian2_circuit.py
@@ -13,7 +13,6 @@ from obi_one.core.schema import SchemaKey, UIElement
 from obi_one.scientific.from_id.circuit_from_id import CircuitFromID
 from obi_one.scientific.library.circuit import Circuit
 from obi_one.scientific.tasks.generate_simulations.config.base import (
-    DEFAULT_TIMESTAMPS_NAME,
     BlockGroup,
     SimulationSingleConfigMixin,
 )
@@ -25,13 +24,11 @@ from obi_one.scientific.unions_and_references.combined_neuron_sets import (
     POINT_NEURON_SETS_REFERENCE_UNION,
     Brian2SimulationNeuronSetUnion,
 )
-from obi_one.scientific.unions_and_references.neuron_sets import PointNeuronSetReference
 from obi_one.scientific.unions_and_references.reference_tags import ReferenceTag
 from obi_one.scientific.unions_and_references.stimuli import (
     Brian2CircuitStimulusUnion,
     StimulusReference,
 )
-from obi_one.scientific.unions_and_references.timestamps import TimestampsReference
 
 L = logging.getLogger(__name__)
 
@@ -56,15 +53,6 @@ class Brian2CircuitSimulationScanConfig(Brian2SimulationScanConfig):
             BlockGroup.STIMULI_RECORDINGS_BLOCK_GROUP,
             BlockGroup.CIRCUIT_COMPONENTS_BLOCK_GROUP,
         ],
-        SchemaKey.DEFAULT_BLOCK_REFERENCE_LABELS: {
-            # The simulation's own Neuron Set field is hidden (see Initialize.node_set), so the
-            # only visible PointNeuronSetReference is a stimulus target -- label it with the
-            # stimulus default (`sugar`), not the simulation default (all point neurons).
-            PointNeuronSetReference.__name__: (
-                Brian2SimulationScanConfig.default_stimulus_node_set_name
-            ),
-            TimestampsReference.__name__: DEFAULT_TIMESTAMPS_NAME,
-        },
     }
 
     class Initialize(Brian2SimulationScanConfig.Initialize):
@@ -87,7 +75,6 @@ class Brian2CircuitSimulationScanConfig(Brian2SimulationScanConfig):
                 SchemaKey.REFERENCE_TYPES: POINT_NEURON_SETS_REFERENCE_TYPES,
                 SchemaKey.REFERENCE_TAG: ReferenceTag.SIMULATION_TARGET,
                 SchemaKey.PARAMETER_ORDER_PRIORITY: 99,
-                SchemaKey.UI_HIDDEN: True,
             },
         )
 

--- a/obi_one/scientific/tasks/generate_simulations/config/brian2/brian2_circuit.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/brian2/brian2_circuit.py
@@ -26,6 +26,7 @@ from obi_one.scientific.unions_and_references.combined_neuron_sets import (
     Brian2SimulationNeuronSetUnion,
 )
 from obi_one.scientific.unions_and_references.neuron_sets import PointNeuronSetReference
+from obi_one.scientific.unions_and_references.reference_tags import ReferenceTag
 from obi_one.scientific.unions_and_references.stimuli import (
     Brian2CircuitStimulusUnion,
     StimulusReference,
@@ -84,6 +85,7 @@ class Brian2CircuitSimulationScanConfig(Brian2SimulationScanConfig):
             json_schema_extra={
                 SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
                 SchemaKey.REFERENCE_TYPES: POINT_NEURON_SETS_REFERENCE_TYPES,
+                SchemaKey.REFERENCE_TAG: ReferenceTag.SIMULATION_TARGET,
                 SchemaKey.PARAMETER_ORDER_PRIORITY: 99,
                 SchemaKey.UI_HIDDEN: True,
             },

--- a/obi_one/scientific/tasks/generate_simulations/config/brian2/brian2_circuit.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/brian2/brian2_circuit.py
@@ -61,7 +61,7 @@ class Brian2CircuitSimulationScanConfig(Brian2SimulationScanConfig):
             # only visible PointNeuronSetReference is a stimulus target -- label it with the
             # stimulus default (`sugar`), not the simulation default (all point neurons).
             PointNeuronSetReference.__name__: (
-                Brian2SimulationScanConfig.default_stimulus_node_set_name,
+                Brian2SimulationScanConfig.default_stimulus_node_set_name
             ),
             TimestampsReference.__name__: DEFAULT_TIMESTAMPS_NAME,
         },

--- a/obi_one/scientific/tasks/generate_simulations/config/learning_engine/le_base.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/learning_engine/le_base.py
@@ -9,9 +9,6 @@ from obi_one.scientific.blocks.neuron_sets.specific import AllPointNeurons
 from obi_one.scientific.tasks.generate_simulations.config.base import (
     BaseSimulationScanConfig,
 )
-from obi_one.scientific.unions_and_references.neuron_sets import (
-    PointNeuronSetReference,
-)
 
 
 class LearningEngineSimulationScanConfig(BaseSimulationScanConfig, abc.ABC):
@@ -21,18 +18,6 @@ class LearningEngineSimulationScanConfig(BaseSimulationScanConfig, abc.ABC):
     _timestep: ClassVar[PositiveFloat] = 0.1
     default_node_set_name: ClassVar[str] = "Default: All Point Neurons"
     default_neuron_set_type: ClassVar[type[AllPointNeurons]] = AllPointNeurons
-
-    @property
-    def default_neuron_set_reference(self) -> PointNeuronSetReference:
-        """The default neuron set reference for the simulation."""
-        default_neuron_set_block_reference = PointNeuronSetReference(
-            block_dict_name="neuron_sets", block_name=self.default_node_set_name
-        )
-
-        default_neuron_set_block_reference.block = self.default_neuron_set_type()
-        default_neuron_set_block_reference.block.set_block_name(self.default_node_set_name)
-
-        return default_neuron_set_block_reference
 
     class Initialize(BaseSimulationScanConfig.Initialize):
         random_seed: int | list[int] = Field(

--- a/obi_one/scientific/tasks/generate_simulations/config/learning_engine/le_circuit.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/learning_engine/le_circuit.py
@@ -24,6 +24,7 @@ from obi_one.scientific.unions_and_references.distributions import (
     AllDistributionsReference,
 )
 from obi_one.scientific.unions_and_references.neuron_sets import PointNeuronSetReference
+from obi_one.scientific.unions_and_references.reference_tags import ReferenceTag
 from obi_one.scientific.unions_and_references.stimuli import (
     LearningEngineCircuitStimulusUnion,
     StimulusReference,
@@ -72,6 +73,7 @@ class LearningEngineCircuitSimulationScanConfig(LearningEngineSimulationScanConf
             json_schema_extra={
                 SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
                 SchemaKey.REFERENCE_TYPES: POINT_NEURON_SETS_REFERENCE_TYPES,
+                SchemaKey.REFERENCE_TAG: ReferenceTag.SIMULATION_TARGET,
                 SchemaKey.PARAMETER_ORDER_PRIORITY: 99,
             },
         )

--- a/obi_one/scientific/tasks/generate_simulations/config/neuron/neuron_circuit.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/neuron/neuron_circuit.py
@@ -7,9 +7,6 @@ from obi_one.core.schema import SchemaKey, UIElement
 from obi_one.scientific.library.circuit import Circuit
 from obi_one.scientific.library.entity_property_types import MappedPropertiesGroup
 from obi_one.scientific.tasks.generate_simulations.config.base import (
-    DEFAULT_DISTRIBUTION_NAME,
-    DEFAULT_MORPHOLOGY_LOCATIONS_NAME,
-    DEFAULT_TIMESTAMPS_NAME,
     BlockGroup,
     CircuitFromID,
     SimulationSingleConfigMixin,
@@ -31,20 +28,11 @@ from obi_one.scientific.unions_and_references.manipulations import (
     SynapticManipulationsReference,
     SynapticManipulationsUnion,
 )
-from obi_one.scientific.unions_and_references.morphology_locations import (
-    MorphologyLocationsReference,
-)
-from obi_one.scientific.unions_and_references.neuron_sets import (
-    BiophysicalNeuronSetReference,
-    PointNeuronSetReference,
-    VirtualNeuronSetReference,
-)
 from obi_one.scientific.unions_and_references.reference_tags import ReferenceTag
 from obi_one.scientific.unions_and_references.stimuli import (
     CircuitStimulusUnion,
     StimulusReference,
 )
-from obi_one.scientific.unions_and_references.timestamps import TimestampsReference
 
 L = logging.getLogger(__name__)
 
@@ -64,20 +52,6 @@ class CircuitSimulationScanConfig(NeuronSimulationScanConfig):
             BlockGroup.CIRCUIT_MANIPULATIONS_GROUP,
             BlockGroup.EVENTS_GROUP,
         ],
-        SchemaKey.DEFAULT_BLOCK_REFERENCE_LABELS: {
-            BiophysicalNeuronSetReference.__name__: (
-                NeuronSimulationScanConfig.default_node_set_name
-            ),
-            VirtualNeuronSetReference.__name__: (
-                NeuronSimulationScanConfig.default_virtual_node_set_name
-            ),
-            PointNeuronSetReference.__name__: (
-                NeuronSimulationScanConfig.default_point_node_set_name
-            ),
-            TimestampsReference.__name__: DEFAULT_TIMESTAMPS_NAME,
-            AllDistributionsReference.__name__: DEFAULT_DISTRIBUTION_NAME,
-            MorphologyLocationsReference.__name__: DEFAULT_MORPHOLOGY_LOCATIONS_NAME,
-        },
         SchemaKey.PROPERTY_ENDPOINTS: {
             MappedPropertiesGroup.CIRCUIT: "/mapped-circuit-properties/{circuit_id}",
             MappedPropertiesGroup.MORPHOLOGY: ("/mapped-morphology-properties/{circuit_id}"),

--- a/obi_one/scientific/tasks/generate_simulations/config/neuron/neuron_circuit.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/neuron/neuron_circuit.py
@@ -69,10 +69,10 @@ class CircuitSimulationScanConfig(NeuronSimulationScanConfig):
                 NeuronSimulationScanConfig.default_node_set_name
             ),
             VirtualNeuronSetReference.__name__: (
-                NeuronSimulationScanConfig.default_virtual_node_set_name,
+                NeuronSimulationScanConfig.default_virtual_node_set_name
             ),
             PointNeuronSetReference.__name__: (
-                NeuronSimulationScanConfig.default_point_node_set_name,
+                NeuronSimulationScanConfig.default_point_node_set_name
             ),
             TimestampsReference.__name__: DEFAULT_TIMESTAMPS_NAME,
             AllDistributionsReference.__name__: DEFAULT_DISTRIBUTION_NAME,

--- a/obi_one/scientific/tasks/generate_simulations/config/neuron/neuron_circuit.py
+++ b/obi_one/scientific/tasks/generate_simulations/config/neuron/neuron_circuit.py
@@ -39,6 +39,7 @@ from obi_one.scientific.unions_and_references.neuron_sets import (
     PointNeuronSetReference,
     VirtualNeuronSetReference,
 )
+from obi_one.scientific.unions_and_references.reference_tags import ReferenceTag
 from obi_one.scientific.unions_and_references.stimuli import (
     CircuitStimulusUnion,
     StimulusReference,
@@ -99,6 +100,7 @@ class CircuitSimulationScanConfig(NeuronSimulationScanConfig):
             json_schema_extra={
                 SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
                 SchemaKey.REFERENCE_TYPES: NON_VIRTUAL_NEURON_SETS_REFERENCE_TYPES,
+                SchemaKey.REFERENCE_TAG: ReferenceTag.SIMULATION_TARGET,
                 SchemaKey.PARAMETER_ORDER_PRIORITY: 99,
             },
         )

--- a/obi_one/scientific/tasks/generate_simulations/materialize_locations.py
+++ b/obi_one/scientific/tasks/generate_simulations/materialize_locations.py
@@ -30,9 +30,8 @@ def materialize_locations_to_compartment_sets(
 
         locations_block = target_ref.block
 
-        neuron_set_ref = getattr(locations_block, "neuron_set", None)
-        if neuron_set_ref is None:
-            neuron_set_ref = single_config.default_neuron_set_reference
+        # _fill_none_references has already given an untargeted locations block its default.
+        neuron_set_ref = locations_block.neuron_set
 
         comp_set_name = target_ref.block_name
 

--- a/obi_one/scientific/tasks/generate_simulations/task/task.py
+++ b/obi_one/scientific/tasks/generate_simulations/task/task.py
@@ -11,7 +11,6 @@ from obi_one.core.exception import OBIONEError
 from obi_one.core.fill_none_references import fill_none_references_in_config
 from obi_one.core.task import Task
 from obi_one.scientific.blocks.neuron_sets.base import NeuronSet
-from obi_one.scientific.blocks.stimuli.brian2_poisson import Brian2DirectPoissonStimulus
 from obi_one.scientific.blocks.stimuli.spike.base import SpikeStimulus
 from obi_one.scientific.from_id.circuit_from_id import (
     CircuitFromID,
@@ -110,8 +109,6 @@ class GenerateSimulationTask(Task):
                     sonata_simulation_config_directory=self.config.coordinate_output_root,
                     simulation_length=self.config.initialize.simulation_length,  # ty:ignore[invalid-argument-type]
                 )
-            elif isinstance(stimulus, Brian2DirectPoissonStimulus):
-                entry = stimulus.config(circuit=self._circuit)  # ty:ignore[invalid-argument-type]
             else:
                 entry = stimulus.config()
             self._sonata_config["inputs"].update(entry)
@@ -194,7 +191,7 @@ class GenerateSimulationTask(Task):
         """
         used = fill_none_references_in_config(
             self.config,
-            self.config.default_block_references(self._circuit),  # ty:ignore[invalid-argument-type]
+            self.config.default_block_references(),
         )
         self._register_default_neuron_sets(used)
 

--- a/obi_one/scientific/tasks/generate_simulations/task/task.py
+++ b/obi_one/scientific/tasks/generate_simulations/task/task.py
@@ -1,18 +1,18 @@
 import logging
+from collections.abc import Iterable
 from pathlib import Path
-from typing import ClassVar, get_args, get_type_hints
+from typing import ClassVar
 
 import entitysdk
 from pydantic import PrivateAttr
 
-from obi_one.core.block import Block
+from obi_one.core.block_reference import BlockReference
 from obi_one.core.exception import OBIONEError
+from obi_one.core.fill_none_references import fill_none_references_in_config
 from obi_one.core.task import Task
-from obi_one.scientific.blocks.neuron_sets.base import NeuronSetPopulationType
-from obi_one.scientific.blocks.neuron_sets.combined import CombinedBaseNeuronSet
+from obi_one.scientific.blocks.neuron_sets.base import NeuronSet
 from obi_one.scientific.blocks.stimuli.brian2_poisson import Brian2DirectPoissonStimulus
 from obi_one.scientific.blocks.stimuli.spike.base import SpikeStimulus
-from obi_one.scientific.blocks.timestamps.single import SingleTimestamp
 from obi_one.scientific.from_id.circuit_from_id import (
     CircuitFromID,
     MEModelWithSynapsesCircuitFromID,
@@ -26,19 +26,8 @@ from obi_one.scientific.library.sonata_circuit_helpers import (
     write_circuit_compartment_set_file,
     write_circuit_node_set_file,
 )
-from obi_one.scientific.tasks.generate_simulations.config.brian2.brian2_circuit import (
-    Brian2CircuitSimulationSingleConfig,
-)
 from obi_one.scientific.tasks.generate_simulations.materialize_locations import (
     materialize_locations_to_compartment_sets,
-)
-from obi_one.scientific.unions_and_references.combined_neuron_sets import (
-    ALL_NEURON_SETS_REFERENCE_UNION,
-    resolve_neuron_set_ref_to_node_set,
-)
-from obi_one.scientific.unions_and_references.neuron_sets import (
-    BaseNeuronSetReference,
-    NeuronSetReference,
 )
 from obi_one.scientific.unions_and_references.simulations import (
     SIMULATION_GENERATION_SINGLE_CONFIGS,
@@ -46,8 +35,6 @@ from obi_one.scientific.unions_and_references.simulations import (
 from obi_one.utils.sonata import write_simulation_config
 
 L = logging.getLogger(__name__)
-
-DEFAULT_TIMESTAMPS = SingleTimestamp(start_time=0.0)
 
 
 class GenerateSimulationTask(Task):
@@ -118,31 +105,16 @@ class GenerateSimulationTask(Task):
         self._sonata_config["inputs"] = {}
         for stimulus in self.config.stimuli.values():
             if isinstance(stimulus, SpikeStimulus):
-                self._sonata_config["inputs"].update(
-                    stimulus.config(
-                        circuit=self._circuit,  # ty:ignore[invalid-argument-type]
-                        sonata_simulation_config_directory=self.config.coordinate_output_root,
-                        simulation_length=self.config.initialize.simulation_length,  # ty:ignore[invalid-argument-type]
-                        default_timestamps=DEFAULT_TIMESTAMPS,  # ty:ignore[invalid-argument-type]
-                        default_source_neuron_set_reference=self._default_neuron_set_ref(),
-                        default_target_neuron_set_reference=self._default_neuron_set_ref(),
-                    )
+                entry = stimulus.config(
+                    circuit=self._circuit,  # ty:ignore[invalid-argument-type]
+                    sonata_simulation_config_directory=self.config.coordinate_output_root,
+                    simulation_length=self.config.initialize.simulation_length,  # ty:ignore[invalid-argument-type]
                 )
             elif isinstance(stimulus, Brian2DirectPoissonStimulus):
-                self._sonata_config["inputs"].update(
-                    stimulus.config(
-                        circuit=self._circuit,  # ty:ignore[invalid-argument-type]
-                        default_node_set=self.config.default_node_set_name,
-                        default_timestamps=DEFAULT_TIMESTAMPS,  # ty:ignore[invalid-argument-type]
-                    )
-                )
+                entry = stimulus.config(circuit=self._circuit)  # ty:ignore[invalid-argument-type]
             else:
-                self._sonata_config["inputs"].update(
-                    stimulus.config(
-                        default_node_set=self.config.default_node_set_name,
-                        default_timestamps=DEFAULT_TIMESTAMPS,  # ty:ignore[invalid-argument-type]
-                    )
-                )
+                entry = stimulus.config()
+            self._sonata_config["inputs"].update(entry)
 
     def _add_sonata_simulation_config_reports(
         self, db_client: entitysdk.client.Client | None
@@ -151,9 +123,8 @@ class GenerateSimulationTask(Task):
         for recording in getattr(self.config, "recordings", {}).values():
             self._sonata_config["reports"].update(
                 recording.config(
-                    self.config.initialize.simulation_length,
-                    self.config.default_node_set_name,
-                    db_client,
+                    end_time=self.config.initialize.simulation_length,
+                    db_client=db_client,
                 )
             )
 
@@ -164,7 +135,7 @@ class GenerateSimulationTask(Task):
             manipulation_list = [
                 item
                 for manipulation in getattr(self.config, "synaptic_manipulations", {}).values()
-                for item in manipulation.config(self.config.default_node_set_name)
+                for item in manipulation.config()
             ]
             if len(manipulation_list) > 0:
                 self._sonata_config["connection_overrides"] = manipulation_list
@@ -174,9 +145,7 @@ class GenerateSimulationTask(Task):
             range_modifications = []
             mechanisms: dict = {}
             for modification in getattr(self.config, "neuronal_manipulations", {}).values():
-                result = modification.config(
-                    self.config.default_node_set_name,
-                )
+                result = modification.config()
                 if isinstance(result, list):
                     # RANGE variables -> conditions.modifications list
                     range_modifications.extend(result)
@@ -189,76 +158,45 @@ class GenerateSimulationTask(Task):
             if mechanisms:
                 self._sonata_config["conditions"]["mechanisms"] = mechanisms
 
-    def _ensure_block_has_neuron_set_reference_if_neuron_sets_dictionary_exists(
-        self, block: Block
-    ) -> None:
-        """If the block's NeuronSetReference is None, set it to the default NeuronSetReference.
+    def _register_default_neuron_sets(self, references: Iterable[BlockReference]) -> None:
+        """Add the defaults that were used to the config's neuron sets, so they reach node_sets.
 
-        This is only done if the config has a neuron_sets attribute.
+        Only neuron sets need this; default timestamps never become a node set. A config with no
+        neuron_sets dictionary -- an ME model simulation holds a single neuron -- has its node set
+        written straight from the config's default type instead, so there is nowhere to add to.
         """
-
-        def accepts_optional_neuron_set_reference(attr_value: type) -> bool:
-            none_type = type(None)
-            args = get_args(attr_value)
-            none_args = [arg for arg in args if arg is none_type]
-            reference_args = [arg for arg in args if arg is not none_type]
-            return (
-                len(none_args) == 1
-                and len(reference_args) >= 1
-                and any(
-                    isinstance(arg, type)
-                    and issubclass(arg, (BaseNeuronSetReference, NeuronSetReference))
-                    for arg in reference_args
-                )
-            )
-
-        if hasattr(self.config, "neuron_sets"):
-            type_hints = get_type_hints(block.__class__)
-
-            for attr_name, attr_type in type_hints.items():
-                if accepts_optional_neuron_set_reference(attr_type):
-                    attr_value = getattr(block, attr_name, None)
-                    if attr_value is None:
-                        # A Brian2 Poisson stimulus with no target drives the `sugar` node set,
-                        # not the simulation-wide default (every point neuron); see
-                        # Brian2SimulationScanConfig.
-                        if isinstance(block, Brian2DirectPoissonStimulus):
-                            setattr(block, attr_name, self._default_stimulus_neuron_set_ref())
-                        else:
-                            setattr(block, attr_name, self._default_neuron_set_ref())
-
-    def _ensure_morphology_locations_have_neuron_set_reference(self) -> None:
-        """Ensure morphology locations have a neuron-set target.
-
-        MEModel configs do not expose a neuron_sets dictionary because the staged circuit contains
-        a single real neuron. In that case, use the implicit default AllNeurons target.
-        """
-        morphology_locations = getattr(self.config, "morphology_locations", None)
-        if not isinstance(morphology_locations, dict):
+        neuron_sets = getattr(self.config, "neuron_sets", None)
+        if neuron_sets is None:
             return
 
-        for locations_block in morphology_locations.values():
-            if getattr(locations_block, "neuron_set", None) is not None:
+        for reference in references:
+            block = reference.block
+            if not isinstance(block, NeuronSet):
                 continue
 
-            locations_block.neuron_set = self.config.default_neuron_set_reference
-
-    def _ensure_all_blocks_have_neuron_set_reference_if_neuron_sets_dictionary_exists(self) -> None:
-        """Ensure all blocks have a NeuronSetReference if the neuron_sets dictionary exists."""
-        self._ensure_morphology_locations_have_neuron_set_reference()
-
-        if hasattr(self.config, "neuron_sets"):
-            for recording in getattr(self.config, "recordings", {}).values():
-                self._ensure_block_has_neuron_set_reference_if_neuron_sets_dictionary_exists(
-                    recording
+            existing = neuron_sets.get(reference.block_name)
+            if existing is None:
+                neuron_sets[reference.block_name] = block
+            elif not isinstance(existing, type(block)):
+                msg = (
+                    f"Default neuron set name '{reference.block_name}' already exists in "
+                    f"neuron_sets but is not an {type(block).__name__} set!"
                 )
-            for stimulus in getattr(self.config, "stimuli", {}).values():
-                self._ensure_block_has_neuron_set_reference_if_neuron_sets_dictionary_exists(
-                    stimulus
-                )
-            for neuron_set in list(getattr(self.config, "neuron_sets", {}).values()):
-                if isinstance(neuron_set, CombinedBaseNeuronSet):
-                    self._ensure_combined_neuron_set_has_references(neuron_set)
+                raise OBIONEError(msg)
+
+    def _fill_none_references(self) -> None:
+        """Give every block reference left unset the default for its role.
+
+        This runs once, before anything reads a reference, so no block has to reason about what
+        an unset reference means: by the time a block builds its SONATA entry, every reference it
+        holds points somewhere. Only the defaults a block actually needed are registered, so a
+        simulation whose blocks all name their own targets gains no spurious node sets.
+        """
+        used = fill_none_references_in_config(
+            self.config,
+            self.config.default_block_references(self._circuit),  # ty:ignore[invalid-argument-type]
+        )
+        self._register_default_neuron_sets(used)
 
     def _materialize_location_targets(self) -> None:
         circuit = self._circuit
@@ -276,173 +214,6 @@ class GenerateSimulationTask(Task):
                 population=population,
             )
         )
-
-    def _ensure_combined_neuron_set_has_references(self, neuron_set: CombinedBaseNeuronSet) -> None:
-        """Ensure a combined neuron set's base and combined_with references are filled."""
-        default_ref = self._default_neuron_set_ref_for_population_type(
-            neuron_set.get_neuron_set_population_type()
-        )
-
-        if neuron_set.base_neuron_set is None:
-            neuron_set.base_neuron_set = default_ref
-
-        updated_entries = []
-        for ref, op in neuron_set.combined_with:
-            if ref is None:
-                updated_entries.append((default_ref, op))
-            else:
-                updated_entries.append((ref, op))
-        neuron_set.combined_with = tuple(updated_entries)
-
-    def _default_neuron_set_ref_for_population_type(
-        self, population_type: NeuronSetPopulationType
-    ) -> ALL_NEURON_SETS_REFERENCE_UNION:
-        """Returns the appropriate default neuron set reference for the given population type."""
-        if population_type == NeuronSetPopulationType.VIRTUAL:
-            return self._default_virtual_neuron_set_ref()
-        if population_type == NeuronSetPopulationType.POINT:
-            return self._default_point_neuron_set_ref()
-        return self._default_neuron_set_ref()
-
-    def _default_virtual_neuron_set_ref(self) -> ALL_NEURON_SETS_REFERENCE_UNION:
-        """Returns the reference for the default virtual neuron set."""
-        ref = self.config.default_virtual_neuron_set_reference
-        if (
-            ref.block_name in self.config.neuron_sets  # ty:ignore[unresolved-attribute]
-            and not isinstance(
-                self.config.neuron_sets[ref.block_name],  # ty:ignore[unresolved-attribute]
-                self.config.default_virtual_neuron_set_type,
-            )
-        ):
-            msg = (
-                f"Default virtual neuron set name '{ref.block_name}' already exists in "
-                f"neuron_sets but is not an "
-                f"{self.config.default_virtual_neuron_set_type.__name__} set!"
-            )
-            raise OBIONEError(msg)
-        if ref.block_name not in self.config.neuron_sets:  # ty:ignore[unresolved-attribute]
-            self.config.neuron_sets[ref.block_name] = ref.block  # ty:ignore[unresolved-attribute,invalid-assignment]
-        return ref
-
-    def _default_point_neuron_set_ref(self) -> ALL_NEURON_SETS_REFERENCE_UNION:
-        """Returns the reference for the default point neuron set."""
-        ref = self.config.default_point_neuron_set_reference
-        if (
-            ref.block_name in self.config.neuron_sets  # ty:ignore[unresolved-attribute]
-            and not isinstance(
-                self.config.neuron_sets[ref.block_name],  # ty:ignore[unresolved-attribute]
-                self.config.default_point_neuron_set_type,
-            )
-        ):
-            msg = (
-                f"Default point neuron set name '{ref.block_name}' already exists in "
-                f"neuron_sets but is not an "
-                f"{self.config.default_point_neuron_set_type.__name__} set!"
-            )
-            raise OBIONEError(msg)
-        if ref.block_name not in self.config.neuron_sets:  # ty:ignore[unresolved-attribute]
-            self.config.neuron_sets[ref.block_name] = ref.block  # ty:ignore[unresolved-attribute,invalid-assignment]
-        return ref
-
-    def _default_neuron_set_ref(self) -> ALL_NEURON_SETS_REFERENCE_UNION:
-        """Returns the reference for the default neuron set."""
-        default_neuron_set_ref = self.config.default_neuron_set_reference
-
-        if (
-            default_neuron_set_ref.block_name in self.config.neuron_sets  # ty:ignore[unresolved-attribute]
-            and not isinstance(
-                self.config.neuron_sets[default_neuron_set_ref.block_name],  # ty:ignore[unresolved-attribute]
-                self.config.default_neuron_set_type,
-            )
-        ):
-            msg = (
-                f"Default neuron set name '{default_neuron_set_ref.block_name}' already exists "
-                f"in neuron_sets but is not an "
-                f"{self.config.default_neuron_set_type.__name__} set!"
-            )
-            raise OBIONEError(msg)
-
-        if default_neuron_set_ref.block_name not in self.config.neuron_sets:  # ty:ignore[unresolved-attribute]
-            self.config.neuron_sets[default_neuron_set_ref.block_name] = (  # ty:ignore[unresolved-attribute,invalid-assignment]
-                default_neuron_set_ref.block
-            )
-
-        return default_neuron_set_ref
-
-    def _default_stimulus_neuron_set_ref(self) -> ALL_NEURON_SETS_REFERENCE_UNION:
-        """Returns the reference for the default stimulus neuron set (Brian2: the `sugar` set).
-
-        The circuit is already resolved: ``execute`` calls ``_resolve_circuit`` before it fills
-        in the missing neuron set references.
-        """
-        ref = self.config.default_stimulus_neuron_set_reference(self._circuit)  # ty:ignore[unresolved-attribute,invalid-argument-type]
-        if ref.block_name not in self.config.neuron_sets:  # ty:ignore[unresolved-attribute]
-            self.config.neuron_sets[ref.block_name] = ref.block  # ty:ignore[unresolved-attribute,invalid-assignment]
-        return ref
-
-    """
-    NEW NEURON SETS REFACTOR: SOME OF THIS CAN PROBABLY BE REMOVED NOW THE
-    NEURON SETS HAVE TYPES (BIOPHYSICAL, POINT, ETC.)
-    """
-
-    def _ensure_simulation_target_node_set(self) -> None:
-        """Ensure a neuron set exists matching `initialize.node_set`.
-
-        Infer default if needed. Assert non-virtual (biophysical or point).
-        """
-        if hasattr(self.config, "neuron_sets"):
-            if hasattr(self.config.initialize, "node_set"):
-                if self.config.initialize.node_set is None:
-                    L.info("initialize.node_set is None — setting default node set.")
-                    self.config.initialize.node_set = self._default_neuron_set_ref()  # ty:ignore[invalid-assignment]
-
-                # Assert that simulation neuron set is non-virtual (skip for Brian2)
-                if (
-                    not isinstance(self.config, Brian2CircuitSimulationSingleConfig)
-                    and isinstance(self.config.initialize.node_set, BaseNeuronSetReference)
-                    and self._circuit is not None
-                    and (
-                        self.config.initialize.node_set.block.get_neuron_set_population_type()
-                        not in {
-                            NeuronSetPopulationType.BIOPHYSICAL,
-                            NeuronSetPopulationType.POINT,
-                            NeuronSetPopulationType.NONVIRTUAL,
-                        }
-                    )
-                ):
-                    # Get list of non-virtual populations to help user
-                    non_virtual_populations = Circuit.get_node_population_names(
-                        self._circuit.sonata_circuit,
-                        incl_virtual=False,
-                        incl_point=True,
-                    )
-                    non_virtual_list = (
-                        ", ".join(f"'{pop}'" for pop in non_virtual_populations)
-                        if non_virtual_populations
-                        else "none found"
-                    )
-
-                    msg = (
-                        f"Simulation Neuron Set (Initialize -> Neuron Set): "
-                        f"'{self.config.initialize.node_set.block_name}' is virtual. "
-                        "Please use a non-virtual (biophysical or point) Neuron Set type. "
-                        f"Available non-virtual populations: {non_virtual_list}. "
-                        f"You may be able to reference one through an "
-                        f"MultiPopulationPredefinedNeuronSet block type. "
-                        "In future we will support population selection for any neuron set."
-                    )
-                    raise OBIONEError(msg)
-
-                self._sonata_config["node_set"] = resolve_neuron_set_ref_to_node_set(
-                    self.config.initialize.node_set,  # ty:ignore[invalid-argument-type]
-                    self.config.default_node_set_name,
-                )
-            elif not hasattr(self.config.initialize, "node_set"):
-                _ = self._default_neuron_set_ref()
-                self._sonata_config["node_set"] = self.config.default_node_set_name
-
-        else:
-            self._sonata_config["node_set"] = self.config.default_node_set_name
 
     def _resolve_neuron_sets_and_write_simulation_node_sets_file(self) -> None:
         """Resolve neuron sets and add them to the SONATA circuit object.
@@ -518,9 +289,11 @@ class GenerateSimulationTask(Task):
             if hasattr(self.config, "neuron_sets") and hasattr(self.config.initialize, "node_set"):
                 neuron_set = self.config.initialize.node_set
                 if neuron_set is None:
-                    msg = "initialize.node_set is None — cannot update number_neurons. \
-                    Even if originally set to None, its value should be set already by \
-                        _ensure_simulation_target_node_set()"
+                    msg = (
+                        "initialize.node_set is None — cannot update number_neurons. Even if "
+                        "originally set to None, _fill_none_references() should have given it "
+                        "the default for its reference tag."
+                    )
                     raise OBIONEError(msg)
                 neuron_set_ids = neuron_set.block.get_neuron_ids(self._circuit)  # ty:ignore[unresolved-attribute]
                 number_neurons = sum(len(v) for v in neuron_set_ids.values())
@@ -601,8 +374,9 @@ class GenerateSimulationTask(Task):
         self._entity_cache = entity_cache
         self._sonata_config = self.config.base_sonata_config()
         self._resolve_circuit(db_client)
-        self._ensure_simulation_target_node_set()
-        self._ensure_all_blocks_have_neuron_set_reference_if_neuron_sets_dictionary_exists()
+        self._fill_none_references()
+        self.config.check_simulation_target(self._circuit)  # ty:ignore[invalid-argument-type]
+        self._sonata_config["node_set"] = self.config.simulation_node_set_name
         self._materialize_location_targets()
         self._add_sonata_simulation_config_inputs()
         self._add_sonata_simulation_config_reports(db_client)

--- a/obi_one/scientific/unions_and_references/combined_neuron_sets.py
+++ b/obi_one/scientific/unions_and_references/combined_neuron_sets.py
@@ -3,6 +3,7 @@ from typing import Annotated, Any, ClassVar
 from pydantic import Discriminator
 
 from obi_one.core.block_reference import BlockReference
+from obi_one.core.exception import OBIONEError
 from obi_one.scientific.blocks.neuron_sets.combined import (
     BiophysicalCombinedNeuronSet,
     NonVirtualCombinedNeuronSet,
@@ -188,27 +189,30 @@ Resolve functions
 """
 
 
+# References are resolved only after every unset one has been given a default, so reaching a
+# resolve function with None means a field was never declared as fillable.
+_UNFILLED_REFERENCE_MESSAGE = (
+    "Neuron set reference is still unset at resolution time. Every reference field that may be "
+    "left unset must declare a SchemaKey.REFERENCE_TAG, and the task must map that tag to a "
+    "default in GenerateSimulationTask._fill_none_references."
+)
+
+
 def resolve_neuron_set_ref_to_node_set(
-    neuron_set_reference: ALL_NEURON_SETS_REFERENCE_UNION | None, default_node_set: str
+    neuron_set_reference: ALL_NEURON_SETS_REFERENCE_UNION | None,
 ) -> str:
+    """Returns the SONATA node set name a neuron set reference points at."""
     if neuron_set_reference is None:
-        return default_node_set
+        raise OBIONEError(_UNFILLED_REFERENCE_MESSAGE)
 
     return neuron_set_reference.block.block_name
 
 
 def resolve_neuron_set_ref_to_neuron_set(
     neuron_set_reference: ALL_NEURON_SETS_REFERENCE_UNION | None,
-    default_neuron_set_reference: ALL_NEURON_SETS_REFERENCE_UNION | None,
-) -> _AllNeuronSetUnion | None:
+) -> _AllNeuronSetUnion:
+    """Returns the neuron set block a neuron set reference points at."""
     if neuron_set_reference is None:
-        if default_neuron_set_reference is None:
-            msg = (
-                "NeuronSet2Reference is None and no default_neuron_set provided. "
-                "Cannot resolve to a NeuronSet."
-            )
-            raise ValueError(msg)
-
-        return default_neuron_set_reference.block  # ty:ignore[invalid-return-type]
+        raise OBIONEError(_UNFILLED_REFERENCE_MESSAGE)
 
     return neuron_set_reference.block  # ty:ignore[invalid-return-type]

--- a/obi_one/scientific/unions_and_references/reference_tags.py
+++ b/obi_one/scientific/unions_and_references/reference_tags.py
@@ -1,0 +1,48 @@
+"""Roles a block reference field can play, used to say what an unset reference means.
+
+Every block reference field that may be left unset carries one of these under
+``SchemaKey.REFERENCE_TAG`` in its ``json_schema_extra``. A task then maps each tag to the block
+reference to substitute, and one pass over the config fills every ``None`` in one place -- see
+``obi_one.core.fill_none_references``.
+
+The tag names the *role*, not the field, so two fields that mean the same thing share a tag and a
+task that wants them to differ can still tell them apart. ``stimulus_target`` is the clearest
+example: a NEURON simulation resolves it to the simulation-wide default neuron set, while a Brian2
+simulation resolves it to the much smaller ``sugar`` node set.
+"""
+
+from enum import StrEnum
+
+
+class ReferenceTag(StrEnum):
+    """The role a block reference field plays within a task."""
+
+    # Neuron sets
+    SIMULATION_TARGET = "simulation_target"
+    STIMULUS_TARGET = "stimulus_target"
+    SPIKE_REPLAY_SOURCE = "spike_replay_source"
+    SPIKE_REPLAY_TARGET = "spike_replay_target"
+    RECORDING_TARGET = "recording_target"
+    SYNAPTIC_MANIPULATION_SOURCE = "synaptic_manipulation_source"
+    SYNAPTIC_MANIPULATION_TARGET = "synaptic_manipulation_target"
+    NEURONAL_MANIPULATION_TARGET = "neuronal_manipulation_target"
+    MORPHOLOGY_LOCATIONS_TARGET = "morphology_locations_target"
+
+    # Operands of a combined neuron set. There is one tag per population type because each
+    # combined subclass redeclares base_neuron_set and combined_with with its own reference
+    # union, and an unset operand means "every neuron of the combined set's own type".
+    ANY_NEURON_SET_OPERAND = "any_neuron_set_operand"
+    BIOPHYSICAL_NEURON_SET_OPERAND = "biophysical_neuron_set_operand"
+    POINT_NEURON_SET_OPERAND = "point_neuron_set_operand"
+    VIRTUAL_NEURON_SET_OPERAND = "virtual_neuron_set_operand"
+    NON_VIRTUAL_NEURON_SET_OPERAND = "non_virtual_neuron_set_operand"
+
+    # Timestamps. Stimuli and delayed synaptic manipulations share this: both mean "the times at
+    # which this block acts", and both start at the beginning of the simulation when unset.
+    TIMESTAMPS = "timestamps"
+
+    # Distributions. These two are kept apart because their defaults differ in kind, and both are
+    # currently supplied by the block itself rather than by the task -- the spike time default
+    # spans the stimulus's own duration, which no task-level reference can express.
+    INTER_SPIKE_INTERVAL_DISTRIBUTION = "inter_spike_interval_distribution"
+    SPIKE_TIME_DISTRIBUTION = "spike_time_distribution"

--- a/obi_one/scientific/unions_and_references/timestamps.py
+++ b/obi_one/scientific/unions_and_references/timestamps.py
@@ -3,6 +3,7 @@ from typing import Annotated, Any, ClassVar
 from pydantic import Discriminator
 
 from obi_one.core.block_reference import BlockReference
+from obi_one.core.exception import OBIONEError
 from obi_one.scientific.blocks.timestamps.regular import RegularTimestamps
 from obi_one.scientific.blocks.timestamps.single import SingleTimestamp
 
@@ -21,15 +22,15 @@ class TimestampsReference(BlockReference):
 
 
 def resolve_timestamps_ref_to_timestamps_block(
-    timestamps_reference: TimestampsReference | None, default_timestamps: TimestampsUnion | None
+    timestamps_reference: TimestampsReference | None,
 ) -> TimestampsUnion:
+    """Returns the timestamps block a timestamps reference points at."""
     if timestamps_reference is None:
-        if default_timestamps is None:
-            msg = (
-                "Either a timestamps block reference must be provided or a default "
-                "timestamps block must be set"
-            )
-            raise ValueError(msg)
-        return default_timestamps
+        msg = (
+            "Timestamps reference is still unset at resolution time. Every reference field that "
+            "may be left unset must declare a SchemaKey.REFERENCE_TAG, and the task must map that "
+            "tag to a default in GenerateSimulationTask._fill_none_references."
+        )
+        raise OBIONEError(msg)
 
     return timestamps_reference.block  # ty:ignore[invalid-return-type]

--- a/tests/obi_one/scientific/blocks/stimuli/spike/test_isi_distribution_spike_stimuli.py
+++ b/tests/obi_one/scientific/blocks/stimuli/spike/test_isi_distribution_spike_stimuli.py
@@ -100,7 +100,7 @@ def _patch_resolved_timestamps(
     ]
     mock_timestamps_block.timestamps.return_value = values
 
-    def _resolve_timestamps(_ref: object, _default: object) -> object:
+    def _resolve_timestamps(_ref: object) -> object:
         return mock_timestamps_block
 
     monkeypatch.setattr(

--- a/tests/obi_one/scientific/blocks/stimuli/spike/test_isi_distribution_spike_stimuli.py
+++ b/tests/obi_one/scientific/blocks/stimuli/spike/test_isi_distribution_spike_stimuli.py
@@ -251,25 +251,6 @@ class TestInterSpikeIntervalDistributionSpikeStimulus:
         second_rep = sorted(t - 50.0 for t in timestamps_out if 50.0 <= t < 75.0)
         assert first_rep != second_rep
 
-    def test_default_distribution_is_exponential_isi(self, monkeypatch):
-        stimulus = _make_isi_distribution_stimulus()
-        stimulus.distribution = None
-
-        mock_generate = MagicMock(return_value=[10.0])
-        monkeypatch.setattr(
-            InterSpikeIntervalDistributionSpikeStimulus,
-            "_generate_spike_train_from_distribution",
-            mock_generate,
-        )
-
-        _patch_resolved_timestamps(monkeypatch, [0.0])
-
-        stimulus.generate_spikes_by_gid([0])
-
-        distribution = mock_generate.call_args.args[0]
-        assert isinstance(distribution, obi.ExponentialDistribution)
-        assert distribution.scale == 50.0  # ruff: ignore[float-equality-comparison]
-
 
 class TestSpikeStimulusIndexingConvention:
     def test_node_ids_follow_current_indexing_convention(self, tmp_path, monkeypatch):

--- a/tests/obi_one/scientific/blocks/stimuli/spike/test_spike_stimuli.py
+++ b/tests/obi_one/scientific/blocks/stimuli/spike/test_spike_stimuli.py
@@ -32,6 +32,16 @@ def _make_timestamps_ref(block):
     return ref
 
 
+def _zero_timestamps_ref():
+    """A block used outside a task has to have its references filled explicitly.
+
+    ``_fill_none_references`` normally does this, giving an unset timestamps reference a single
+    timestamp at the start of the simulation. These unit tests drive blocks directly, so they
+    supply the same thing themselves.
+    """
+    return _make_timestamps_ref(obi.SingleTimestamp(start_time=0.0))
+
+
 def _read_spike_file(path, population):
     with h5py.File(path, "r") as f:
         grp = f[f"spikes/{population}"]
@@ -88,7 +98,9 @@ class TestFullySynchronousSpikeStimulus:
 
 class TestPoissonSpikeStimulus:
     def test_reproducibility_with_same_seed(self):
-        stim = obi.PoissonSpikeStimulus(duration=500.0, frequency=10.0, random_seed=42)
+        stim = obi.PoissonSpikeStimulus(
+            duration=500.0, frequency=10.0, random_seed=42, timestamps=_zero_timestamps_ref()
+        )
         gids = [0, 1, 2]
         r1 = stim.generate_spikes_by_gid(gids)
         r2 = stim.generate_spikes_by_gid(gids)
@@ -97,8 +109,12 @@ class TestPoissonSpikeStimulus:
 
     def test_different_seeds_give_different_spikes(self):
         gids = [0]
-        stim_a = obi.PoissonSpikeStimulus(duration=1000.0, frequency=20.0, random_seed=1)
-        stim_b = obi.PoissonSpikeStimulus(duration=1000.0, frequency=20.0, random_seed=2)
+        stim_a = obi.PoissonSpikeStimulus(
+            duration=1000.0, frequency=20.0, random_seed=1, timestamps=_zero_timestamps_ref()
+        )
+        stim_b = obi.PoissonSpikeStimulus(
+            duration=1000.0, frequency=20.0, random_seed=2, timestamps=_zero_timestamps_ref()
+        )
         r_a = stim_a.generate_spikes_by_gid(gids)
         r_b = stim_b.generate_spikes_by_gid(gids)
         assert r_a[0] != r_b[0]
@@ -119,22 +135,32 @@ class TestPoissonSpikeStimulus:
 
     def test_timestamp_offset_shifts_window(self):
         stim = obi.PoissonSpikeStimulus(
-            duration=100.0, frequency=20.0, random_seed=7, timestamp_offset=50.0
+            duration=100.0,
+            frequency=20.0,
+            random_seed=7,
+            timestamp_offset=50.0,
+            timestamps=_zero_timestamps_ref(),
         )
         result = stim.generate_spikes_by_gid([0])
         for t in result[0]:
             assert 50.0 <= t <= 150.0
 
     def test_zero_duration_produces_no_spikes(self):
-        stim = obi.PoissonSpikeStimulus(duration=0.0, frequency=10.0, random_seed=0)
+        stim = obi.PoissonSpikeStimulus(
+            duration=0.0, frequency=10.0, random_seed=0, timestamps=_zero_timestamps_ref()
+        )
         result = stim.generate_spikes_by_gid([0, 1])
         for gid in [0, 1]:
             assert result[gid] == []
 
     def test_spike_count_scales_with_frequency(self):
         gids = list(range(3))
-        stim_low = obi.PoissonSpikeStimulus(duration=2000.0, frequency=5.0, random_seed=10)
-        stim_high = obi.PoissonSpikeStimulus(duration=2000.0, frequency=50.0, random_seed=10)
+        stim_low = obi.PoissonSpikeStimulus(
+            duration=2000.0, frequency=5.0, random_seed=10, timestamps=_zero_timestamps_ref()
+        )
+        stim_high = obi.PoissonSpikeStimulus(
+            duration=2000.0, frequency=50.0, random_seed=10, timestamps=_zero_timestamps_ref()
+        )
         r_low = stim_low.generate_spikes_by_gid(gids)
         r_high = stim_high.generate_spikes_by_gid(gids)
         total_low = sum(len(v) for v in r_low.values())
@@ -175,6 +201,7 @@ class TestSinusoidalPoissonSpikeStimulus:
             maximum_rate=20.0,
             modulation_frequency_hz=5.0,
             random_seed=42,
+            timestamps=_zero_timestamps_ref(),
         )
         gids = [0, 1]
         r1 = stim.generate_spikes_by_gid(gids)
@@ -210,6 +237,7 @@ class TestSinusoidalPoissonSpikeStimulus:
             modulation_frequency_hz=2.0,
             phase_degrees=0.0,
             random_seed=42,
+            timestamps=_zero_timestamps_ref(),
         )
         stim_90 = obi.SinusoidalPoissonSpikeStimulus(
             duration=1000.0,
@@ -218,6 +246,7 @@ class TestSinusoidalPoissonSpikeStimulus:
             modulation_frequency_hz=2.0,
             phase_degrees=90.0,
             random_seed=42,
+            timestamps=_zero_timestamps_ref(),
         )
         r0 = stim_0.generate_spikes_by_gid(gids)
         r90 = stim_90.generate_spikes_by_gid(gids)
@@ -268,6 +297,7 @@ class TestSinusoidalPoissonSpikeStimulus:
             modulation_frequency_hz=5.0,
             random_seed=0,
             timestamp_offset=100.0,
+            timestamps=_zero_timestamps_ref(),
         )
         result = stim.generate_spikes_by_gid([0])
         for t in result[0]:

--- a/tests/obi_one/scientific/blocks/stimuli/spike/test_time_distribution_spike_stimuli.py
+++ b/tests/obi_one/scientific/blocks/stimuli/spike/test_time_distribution_spike_stimuli.py
@@ -265,28 +265,6 @@ class TestSpikeTimeDistributionSpikeStimulus:
         second_rep = sorted(t - 50.0 for t in timestamps_out if 50.0 <= t < 75.0)
         assert not np.allclose(first_rep, second_rep)
 
-    def test_default_distribution_is_uniform_over_duration(self, monkeypatch):
-        stimulus = _make_time_distribution_stimulus(duration=25.0, mean_firing_rate=3.0)
-
-        stimulus.distribution = None
-
-        mock_sample = MagicMock(return_value=[1.0, 2.0])
-        monkeypatch.setattr(
-            SpikeTimeDistributionSpikeStimulus,
-            "_sample_spike_times_from_distribution",
-            mock_sample,
-        )
-
-        _patch_resolved_timestamps(monkeypatch, [0.0])
-        _patch_number_of_spikes(monkeypatch, 2)
-
-        stimulus.generate_spikes_by_gid([0])
-
-        distribution = mock_sample.call_args.args[0]
-        assert isinstance(distribution, obi.FloatUniformDistribution)
-        assert distribution.low == 0.0  # ruff: ignore[float-equality-comparison]
-        assert distribution.high == 25.0  # ruff: ignore[float-equality-comparison]
-
 
 class TestSpikeTimeStimulusIndexingConvention:
     def test_node_ids_follow_current_indexing_convention(self, tmp_path, monkeypatch):

--- a/tests/obi_one/scientific/blocks/stimuli/spike/test_time_distribution_spike_stimuli.py
+++ b/tests/obi_one/scientific/blocks/stimuli/spike/test_time_distribution_spike_stimuli.py
@@ -103,7 +103,7 @@ def _patch_resolved_timestamps(
     ]
     mock_timestamps_block.timestamps.return_value = values
 
-    def _resolve_timestamps(_ref: object, _default: object) -> object:
+    def _resolve_timestamps(_ref: object) -> object:
         return mock_timestamps_block
 
     monkeypatch.setattr(

--- a/tests/obi_one/scientific/blocks/test_compartment_sets.py
+++ b/tests/obi_one/scientific/blocks/test_compartment_sets.py
@@ -5,6 +5,8 @@ import pandas as pd
 import pytest
 
 import obi_one as obi
+from obi_one.core.exception import OBIONEError
+from obi_one.core.fill_none_references import fill_none_references_in_config
 from obi_one.scientific.library.compartment_sets import (
     CompartmentLocation,
     MaterializedCompartmentSet,
@@ -21,6 +23,9 @@ from obi_one.scientific.tasks.generate_simulations.task.task import GenerateSimu
 from obi_one.scientific.unions_and_references.morphology_locations import (
     MorphologyLocationsReference,
 )
+from obi_one.scientific.unions_and_references.neuron_sets import BiophysicalNeuronSetReference
+from obi_one.scientific.unions_and_references.reference_tags import ReferenceTag
+from obi_one.scientific.unions_and_references.timestamps import TimestampsReference
 
 
 def test_compartment_set_sorts_deduplicates_and_builds_from_locations():
@@ -161,7 +166,36 @@ def test_write_compartment_sets_rejects_invalid_file_name(tmp_path, file_name):
         )
 
 
-def test_materialization_uses_default_neuron_set_for_locations_without_target():
+def _neuron_set_reference(name: str) -> BiophysicalNeuronSetReference:
+    """A resolved neuron set reference, as ``_fill_none_references`` would produce."""
+    block = obi.AllBiophysicalNeurons()
+    block.set_block_name(name)
+    reference = BiophysicalNeuronSetReference(block_dict_name="neuron_sets", block_name=name)
+    reference.block = block
+    return reference
+
+
+def _timestamps_reference() -> TimestampsReference:
+    block = obi.SingleTimestamp(start_time=0.0)
+    block.set_block_name("start")
+    reference = TimestampsReference(block_dict_name="timestamps", block_name="start")
+    reference.block = block
+    return reference
+
+
+def _fill(config: SimpleNamespace, target_node_set: str = "default-target") -> list:
+    return fill_none_references_in_config(
+        config,
+        {
+            ReferenceTag.STIMULUS_TARGET: _neuron_set_reference(target_node_set),
+            ReferenceTag.MORPHOLOGY_LOCATIONS_TARGET: _neuron_set_reference(target_node_set),
+            ReferenceTag.TIMESTAMPS: _timestamps_reference(),
+        },
+    )
+
+
+def test_materialization_uses_the_neuron_set_already_on_the_locations_block():
+    """The fallback lives in ``_fill_none_references``; materialisation just reads what it set."""
     locations = obi.RandomMorphologyLocations()
     locations.set_block_name("locations")
     locations_ref = MorphologyLocationsReference(
@@ -171,7 +205,12 @@ def test_materialization_uses_default_neuron_set_for_locations_without_target():
     locations_ref.block = locations
     stimulus = obi.ConstantCurrentClampSomaticStimulus(neuron_set=locations_ref)
     stimulus.set_block_name("stimulus")
-    default_ref = MagicMock()
+
+    config = SimpleNamespace(
+        stimuli={"stimulus": stimulus},
+        morphology_locations={"locations": locations},
+    )
+    _fill(config)
 
     with patch(
         "obi_one.scientific.tasks.generate_simulations.materialize_locations."
@@ -183,10 +222,7 @@ def test_materialization_uses_default_neuron_set_for_locations_without_target():
         )
 
         materialize_locations_to_compartment_sets(
-            single_config=SimpleNamespace(
-                stimuli={"stimulus": stimulus},
-                default_neuron_set_reference=default_ref,
-            ),
+            single_config=config,
             circuit=MagicMock(),
             node_population="pop",
             population="pop",
@@ -194,53 +230,106 @@ def test_materialization_uses_default_neuron_set_for_locations_without_target():
 
     build_compartment_set.assert_called_once()
     assert build_compartment_set.call_args.kwargs["name"] == "locations"
-    assert build_compartment_set.call_args.kwargs["neuron_set"] is default_ref
+    assert build_compartment_set.call_args.kwargs["neuron_set"] is locations.neuron_set
 
 
-def test_continuous_stimulus_without_target_uses_default_node_set():
+def test_continuous_stimulus_names_the_node_set_it_was_filled_with():
+    stimulus = obi.ConstantCurrentClampSomaticStimulus()
+    stimulus.set_block_name("stimulus")
+    _fill(SimpleNamespace(stimuli={"stimulus": stimulus}))
+
+    config = stimulus.config()
+
+    assert config["stimulus_0"]["node_set"] == "default-target"
+
+
+def test_continuous_stimulus_with_an_unfilled_target_is_refused():
+    """Resolution happens after the fill, so an unset reference here is a programming error."""
     stimulus = obi.ConstantCurrentClampSomaticStimulus()
     stimulus.set_block_name("stimulus")
 
-    config = stimulus.config(default_node_set="default-target")
-
-    assert config["stimulus_0"]["node_set"] == "default-target"
+    with pytest.raises(OBIONEError, match="still unset at resolution time"):
+        stimulus.config()
 
 
 def test_continuous_stimulus_uses_materialized_compartment_set_target():
     stimulus = obi.ConstantCurrentClampSomaticStimulus()
     stimulus.set_block_name("stimulus")
     stimulus.set_materialized_compartment_set_target("LocationCurrentClamp__locations")
+    _fill(SimpleNamespace(stimuli={"stimulus": stimulus}))
 
-    config = stimulus.config(default_node_set="default-target")
+    config = stimulus.config()
 
     assert config["stimulus_0"]["compartment_set"] == "LocationCurrentClamp__locations"
     assert "node_set" not in config["stimulus_0"]
 
 
-def test_task_injects_default_into_optional_unified_target():
-    default_ref = MagicMock()
-    task = GenerateSimulationTask.model_construct(config=SimpleNamespace(neuron_sets={}))
+def test_fill_gives_a_stimulus_the_default_for_its_role():
     stimulus = obi.ConstantCurrentClampSomaticStimulus()
+    target = _neuron_set_reference("chosen")
 
-    with patch.object(GenerateSimulationTask, "_default_neuron_set_ref", return_value=default_ref):
-        task._ensure_block_has_neuron_set_reference_if_neuron_sets_dictionary_exists(stimulus)
-
-    assert stimulus.neuron_set is default_ref
-
-
-def test_task_assigns_implicit_default_to_morphology_locations():
-    default_ref = MagicMock()
-    locations = obi.RandomMorphologyLocations()
-    task = GenerateSimulationTask.model_construct(
-        config=SimpleNamespace(
-            morphology_locations={"locations": locations},
-            default_neuron_set_reference=default_ref,
-        )
+    used = fill_none_references_in_config(
+        SimpleNamespace(stimuli={"stimulus": stimulus}),
+        {ReferenceTag.STIMULUS_TARGET: target},
     )
 
-    task._ensure_morphology_locations_have_neuron_set_reference()
+    assert stimulus.neuron_set is target
+    assert used == [target]
 
-    assert locations.neuron_set is default_ref
+
+def test_fill_gives_morphology_locations_the_default_for_their_role():
+    locations = obi.RandomMorphologyLocations()
+    target = _neuron_set_reference("chosen")
+
+    fill_none_references_in_config(
+        SimpleNamespace(morphology_locations={"locations": locations}),
+        {ReferenceTag.MORPHOLOGY_LOCATIONS_TARGET: target},
+    )
+
+    assert locations.neuron_set is target
+
+
+def test_fill_leaves_a_reference_that_was_set_explicitly():
+    chosen = _neuron_set_reference("chosen")
+    stimulus = obi.ConstantCurrentClampSomaticStimulus(neuron_set=chosen)
+
+    used = fill_none_references_in_config(
+        SimpleNamespace(stimuli={"stimulus": stimulus}),
+        {ReferenceTag.STIMULUS_TARGET: _neuron_set_reference("default-target")},
+    )
+
+    assert stimulus.neuron_set is chosen
+    assert used == []
+
+
+def test_fill_reports_each_default_once_however_many_blocks_needed_it():
+    target = _neuron_set_reference("chosen")
+
+    used = fill_none_references_in_config(
+        SimpleNamespace(
+            stimuli={
+                "a": obi.ConstantCurrentClampSomaticStimulus(),
+                "b": obi.ConstantCurrentClampSomaticStimulus(),
+            }
+        ),
+        {ReferenceTag.STIMULUS_TARGET: target},
+    )
+
+    assert used == [target]
+
+
+def test_fill_is_idempotent():
+    stimulus = obi.ConstantCurrentClampSomaticStimulus()
+    config = SimpleNamespace(stimuli={"stimulus": stimulus})
+    target = _neuron_set_reference("chosen")
+
+    fill_none_references_in_config(config, {ReferenceTag.STIMULUS_TARGET: target})
+    used = fill_none_references_in_config(
+        config, {ReferenceTag.STIMULUS_TARGET: _neuron_set_reference("other")}
+    )
+
+    assert stimulus.neuron_set is target
+    assert used == []
 
 
 def test_task_requires_circuit_before_materialization():

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/conftest.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/conftest.py
@@ -17,7 +17,9 @@ from typing import Any
 import pytest
 
 import obi_one as obi
+from obi_one.core.block import Block
 from obi_one.core.block_reference import BlockReference
+from obi_one.core.schema import SchemaKey
 from obi_one.scientific.library.memodel_circuit import (
     MEModelCircuit,
     MEModelWithSynapsesCircuit,
@@ -38,6 +40,7 @@ from obi_one.scientific.tasks.generate_simulations.config.neuron.neuron_me_model
     MEModelWithSynapsesCircuitSimulationSingleConfig,
 )
 from obi_one.scientific.tasks.generate_simulations.task.task import GenerateSimulationTask
+from obi_one.scientific.unions_and_references.reference_tags import ReferenceTag
 
 from tests.utils import CIRCUIT_DIR, SINGLE_NEURON_CIRCUIT_DIR
 
@@ -97,6 +100,54 @@ def reference_field_names(block_class: type) -> list[str]:
         for name, field_info in block_class.model_fields.items()
         if reference_types_in(field_info.annotation)
     ]
+
+
+# Both spike distribution roles are resolved by the block, not the task: their defaults depend on
+# the stimulus's own parameters, so no simulation-wide reference can express them.
+BLOCK_SUPPLIED_REFERENCE_TAGS = {
+    ReferenceTag.INTER_SPIKE_INTERVAL_DISTRIBUTION,
+    ReferenceTag.SPIKE_TIME_DISTRIBUTION,
+}
+
+
+def tagged_reference_fields(block: Any) -> list[tuple[str, ReferenceTag]]:
+    """The block's reference fields that declare what they mean when left unset."""
+    return [
+        (name, field_info.json_schema_extra[SchemaKey.REFERENCE_TAG])
+        for name, field_info in type(block).model_fields.items()
+        if isinstance(field_info.json_schema_extra, dict)
+        and SchemaKey.REFERENCE_TAG in field_info.json_schema_extra
+    ]
+
+
+def unfilled_reference_fields(config: Any) -> list[str]:
+    """Tagged references still unset anywhere in the config, as ``Block.field`` names.
+
+    Empty is the invariant ``_fill_none_references`` exists to provide. Roles the task deliberately
+    leaves to the block are excluded, since those are meant to still be ``None`` afterwards.
+    """
+    unfilled = []
+    for value in vars(config).values():
+        blocks = (
+            [value]
+            if isinstance(value, Block)
+            else list(value.values())
+            if isinstance(value, dict)
+            else []
+        )
+        for block in blocks:
+            if not isinstance(block, Block):
+                continue
+            for name, tag in tagged_reference_fields(block):
+                if tag in BLOCK_SUPPLIED_REFERENCE_TAGS:
+                    continue
+                field_value = getattr(block, name, None)
+                if field_value is None or (
+                    isinstance(field_value, tuple)
+                    and any(reference is None for reference, _ in field_value)
+                ):
+                    unfilled.append(f"{type(block).__name__}.{name}")
+    return unfilled
 
 
 # The node set names a generated SONATA config can refer to, by the key each section uses.

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/conftest.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/conftest.py
@@ -69,7 +69,6 @@ POINT_POPULATION = "drosophila"
 DEFAULT_BIOPHYSICAL_NODE_SET = "Default: All Biophysical Neurons"
 DEFAULT_VIRTUAL_NODE_SET = "Default: All Virtual Neurons"
 DEFAULT_POINT_NODE_SET = "Default: All Point Neurons"
-DEFAULT_BRIAN2_STIMULUS_NODE_SET = "Default: Sugar gustatory receptor neurons"
 
 
 def union_member_names(union: Any) -> set[str]:
@@ -102,14 +101,6 @@ def reference_field_names(block_class: type) -> list[str]:
     ]
 
 
-# Both spike distribution roles are resolved by the block, not the task: their defaults depend on
-# the stimulus's own parameters, so no simulation-wide reference can express them.
-BLOCK_SUPPLIED_REFERENCE_TAGS = {
-    ReferenceTag.INTER_SPIKE_INTERVAL_DISTRIBUTION,
-    ReferenceTag.SPIKE_TIME_DISTRIBUTION,
-}
-
-
 def tagged_reference_fields(block: Any) -> list[tuple[str, ReferenceTag]]:
     """The block's reference fields that declare what they mean when left unset."""
     return [
@@ -123,8 +114,8 @@ def tagged_reference_fields(block: Any) -> list[tuple[str, ReferenceTag]]:
 def unfilled_reference_fields(config: Any) -> list[str]:
     """Tagged references still unset anywhere in the config, as ``Block.field`` names.
 
-    Empty is the invariant ``_fill_none_references`` exists to provide. Roles the task deliberately
-    leaves to the block are excluded, since those are meant to still be ``None`` afterwards.
+    Empty is the invariant ``_fill_none_references`` exists to provide: every role the config
+    names has a default, so nothing tagged is left ``None`` afterwards.
     """
     unfilled = []
     for value in vars(config).values():
@@ -138,9 +129,7 @@ def unfilled_reference_fields(config: Any) -> list[str]:
         for block in blocks:
             if not isinstance(block, Block):
                 continue
-            for name, tag in tagged_reference_fields(block):
-                if tag in BLOCK_SUPPLIED_REFERENCE_TAGS:
-                    continue
+            for name, _tag in tagged_reference_fields(block):
                 field_value = getattr(block, name, None)
                 if field_value is None or (
                     isinstance(field_value, tuple)

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_brian2_default_neuron_sets.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_brian2_default_neuron_sets.py
@@ -1,9 +1,8 @@
-"""A Brian2 simulation defaults the simulation to all point neurons and a stimulus to `sugar`.
+"""A Brian2 simulation defaults both its simulation and its stimuli to all point neurons.
 
-An untargeted Brian2 Poisson stimulus drives the `sugar` gustatory receptor neurons, while the
-simulation itself runs every point neuron. The two are separate defaults; regressions here
-(e.g. the stimulus inheriting the simulation-wide default and tripping its 100-neuron limit, or
-the simulation target being mislabelled "Sugar…") are what this guards against.
+An untargeted Brian2 Poisson stimulus drives whatever the simulation runs, as in every other
+config family. This is the end-to-end check that the one default reaches both roles and that the
+node set it names is actually written, rather than a role picking up a name nothing defines.
 """
 
 import json
@@ -18,8 +17,7 @@ CIRCUIT_CONFIG = (
     Path(__file__).parents[2] / "library" / "simulation" / "data" / "circuit_config.json"
 )
 
-SIM_DEFAULT = "Default: All Point Neurons"
-STIMULUS_DEFAULT = "Default: Sugar gustatory receptor neurons"
+POINT_DEFAULT = "Default: All Point Neurons"
 
 
 def _generate(tmp_path: Path) -> tuple[dict, dict]:
@@ -51,17 +49,15 @@ def _generate(tmp_path: Path) -> tuple[dict, dict]:
     return sim_config, node_sets
 
 
-def test_untargeted_brian2_stimulus_defaults_to_sugar_and_simulation_to_all_point(tmp_path):
+def test_untargeted_brian2_stimulus_and_simulation_both_default_to_all_point(tmp_path):
     sim_config, node_sets = _generate(tmp_path)
 
-    # The simulation targets all point neurons, named for what it is -- not "Sugar…".
-    assert sim_config["node_set"] == SIM_DEFAULT
-    assert node_sets[SIM_DEFAULT]["node_id"] == [0, 1, 2]
+    # The simulation targets all point neurons, named for what it is.
+    assert sim_config["node_set"] == POINT_DEFAULT
+    assert node_sets[POINT_DEFAULT]["node_id"] == [0, 1, 2]
 
-    # The untargeted stimulus targets the sugar node set -- a strict subset, not the whole
-    # circuit -- so it stays under the block's 100-neuron limit rather than raising.
-    assert sim_config["inputs"]["DirectPoisson"]["node_set"] == STIMULUS_DEFAULT
-    assert node_sets[STIMULUS_DEFAULT]["node_id"] == [0, 1]
+    # The untargeted stimulus resolves to that same set rather than one of its own.
+    assert sim_config["inputs"]["DirectPoisson"]["node_set"] == POINT_DEFAULT
 
-    # The two defaults are genuinely different sets.
-    assert node_sets[SIM_DEFAULT]["node_id"] != node_sets[STIMULUS_DEFAULT]["node_id"]
+    # One default node set is injected alongside the circuit's own, not one per role.
+    assert [name for name in node_sets if name.startswith("Default: ")] == [POINT_DEFAULT]

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_fill_none_references.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_fill_none_references.py
@@ -276,6 +276,69 @@ class TestTheStimulusTargetTagVariesByConfigFamily:
         )
 
 
+SIMULATION_CONFIG_CLASSES = (
+    CircuitSimulationSingleConfig,
+    MEModelSimulationSingleConfig,
+    Brian2CircuitSimulationSingleConfig,
+    LearningEngineCircuitSimulationSingleConfig,
+)
+
+
+class TestTheDefaultNamesReachTheSchema:
+    """What the UI shows as a placeholder has to be what generation will actually do."""
+
+    @pytest.mark.parametrize("config_class", SIMULATION_CONFIG_CLASSES)
+    def test_every_role_has_a_name(self, config_class):
+        assert set(config_class.default_block_reference_names()) == set(ReferenceTag)
+
+    @pytest.mark.parametrize("config_class", SIMULATION_CONFIG_CLASSES)
+    def test_every_name_is_a_string(self, config_class):
+        """A stray trailing comma turns one of these into a tuple, which the UI cannot show."""
+        for tag, name in config_class.default_block_reference_names().items():
+            assert isinstance(name, str), (tag, name)
+            assert name
+
+    @pytest.mark.parametrize("config_class", SIMULATION_CONFIG_CLASSES)
+    def test_the_names_are_published_in_the_json_schema(self, config_class):
+        published = config_class.model_json_schema()[SchemaKey.REFERENCE_TAG_DEFAULTS]
+
+        assert published == config_class.default_block_reference_names()
+
+    def test_the_names_agree_with_the_references_they_describe(self, circuit_config, circuit):
+        """The anti-drift check: a shown placeholder naming a different block would be a lie."""
+        config = circuit_config()
+        names = config.default_block_reference_names()
+
+        for tag, reference in config.default_block_references(circuit).items():
+            assert reference.block_name == names[tag], tag
+            assert reference.block.block_name == names[tag], tag
+
+    def test_the_names_agree_for_brian2_too(self, brian2_config, point_circuit):
+        """Brian2 is the family that overrides both, so it is where they could diverge."""
+        config = brian2_config()
+        names = config.default_block_reference_names()
+
+        for tag, reference in config.default_block_references(point_circuit).items():
+            assert reference.block_name == names[tag], tag
+
+    def test_the_roles_the_task_does_not_fill_are_still_named(self, circuit_config, circuit):
+        """The UI shows a placeholder for them even though a block, not the task, supplies it."""
+        config = circuit_config()
+        names = config.default_block_reference_names()
+        filled = set(config.default_block_references(circuit))
+
+        for tag in BLOCK_SUPPLIED_REFERENCE_TAGS:
+            assert tag not in filled
+            assert names[tag]
+
+    def test_brian2_names_the_stimulus_and_simulation_roles_differently(self):
+        """The distinction a type-keyed label cannot make: both are point neuron references."""
+        names = Brian2CircuitSimulationSingleConfig.default_block_reference_names()
+
+        assert names[ReferenceTag.STIMULUS_TARGET] == DEFAULT_BRIAN2_STIMULUS_NODE_SET
+        assert names[ReferenceTag.SIMULATION_TARGET] != names[ReferenceTag.STIMULUS_TARGET]
+
+
 class TestTheConfigOwnsItsSimulationTarget:
     """The other two things that vary by family, so the task needs no isinstance checks."""
 

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_fill_none_references.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_fill_none_references.py
@@ -1,0 +1,354 @@
+"""The declarative layer that decides what an unset block reference means.
+
+Every reference field a simulation block can hold declares its role with a
+``SchemaKey.REFERENCE_TAG``, and ``GenerateSimulationTask`` maps each role to the reference to
+substitute. Nothing else in generation is allowed to invent a fallback, so these tests guard the
+two halves that make that safe: no field may go untagged, and no tag may go unhandled.
+
+They are deliberately introspective rather than example-based. A new block or a new reference
+field fails them until someone decides what leaving it unset should mean.
+"""
+
+import abc
+import inspect
+
+import pytest
+
+import obi_one as obi
+from obi_one.core.block import Block
+from obi_one.core.block_reference import BlockReference
+from obi_one.core.schema import SchemaKey
+from obi_one.scientific.blocks.stimuli.brian2_poisson import Brian2DirectPoissonStimulus
+from obi_one.scientific.tasks.generate_simulations.config.base import BaseSimulationScanConfig
+from obi_one.scientific.tasks.generate_simulations.config.brian2.brian2_circuit import (
+    Brian2CircuitSimulationSingleConfig,
+)
+from obi_one.scientific.tasks.generate_simulations.config.learning_engine.le_circuit import (
+    LearningEngineCircuitSimulationSingleConfig,
+)
+from obi_one.scientific.tasks.generate_simulations.config.neuron.neuron_circuit import (
+    CircuitSimulationSingleConfig,
+)
+from obi_one.scientific.tasks.generate_simulations.config.neuron.neuron_me_model import (
+    MEModelSimulationSingleConfig,
+)
+from obi_one.scientific.unions_and_references.reference_tags import ReferenceTag
+
+from tests.obi_one.scientific.tasks.simulation_campaign_generation.conftest import (
+    BLOCK_SUPPLIED_REFERENCE_TAGS,
+    DEFAULT_BRIAN2_STIMULUS_NODE_SET,
+    build_config,
+    generate,
+    reference_types_in,
+    unfilled_reference_fields,
+)
+
+# The block modules that simulation generation resolves references for. Blocks belonging to other
+# tasks -- synapse parameterization, circuit extraction -- are not filled by this mechanism and so
+# are not required to carry tags.
+SIMULATION_BLOCK_MODULES = (
+    "blocks/stimuli/",
+    "blocks/recordings/",
+    "blocks/neuron_sets/combined",
+    "blocks/synaptic_manipulations/",
+    "blocks/neuronal_manipulations/",
+    "blocks/morphology_locations/",
+    "tasks/generate_simulations/",
+)
+
+
+def _all_block_subclasses() -> set[type]:
+    todo, seen = [Block], set()
+    while todo:
+        cls = todo.pop()
+        if cls in seen:
+            continue
+        seen.add(cls)
+        todo.extend(cls.__subclasses__())
+    return seen
+
+
+def _is_concrete(cls: type) -> bool:
+    """Abstract bases declare placeholder fields that every concrete subclass overrides."""
+    return abc.ABC not in cls.__bases__ and not inspect.isabstract(cls)
+
+
+def _simulation_reference_fields() -> list[tuple[type, str, object]]:
+    """Every reference field a concrete simulation block has, with the tag it carries.
+
+    Inherited fields count: what matters is that a block a user can actually build has no
+    reference field whose meaning when unset is undeclared.
+    """
+    fields = []
+    for cls in _all_block_subclasses():
+        if not _is_concrete(cls):
+            continue
+        try:
+            source = inspect.getfile(cls)
+        except TypeError:  # pragma: no cover - builtins have no source file
+            continue
+        if not any(module in source for module in SIMULATION_BLOCK_MODULES):
+            continue
+        for name, field_info in cls.model_fields.items():
+            if not reference_types_in(field_info.annotation):
+                continue
+            extra = field_info.json_schema_extra
+            tag = extra.get(SchemaKey.REFERENCE_TAG) if isinstance(extra, dict) else None
+            fields.append((cls, name, tag))
+    return fields
+
+
+class TestEveryReferenceFieldDeclaresItsRole:
+    def test_no_simulation_reference_field_is_untagged(self):
+        untagged = [
+            f"{cls.__name__}.{name}" for cls, name, tag in _simulation_reference_fields() if not tag
+        ]
+
+        assert untagged == []
+
+    def test_the_introspection_actually_finds_fields(self):
+        """Guards the sweep above against silently matching nothing."""
+        assert len(_simulation_reference_fields()) > 20
+
+    def test_combined_neuron_sets_tag_their_operands_by_population_type(self):
+        """Each combined subclass means a different thing by an unset operand."""
+        expected = {
+            obi.CombinedNeuronSet: ReferenceTag.ANY_NEURON_SET_OPERAND,
+            obi.BiophysicalCombinedNeuronSet: ReferenceTag.BIOPHYSICAL_NEURON_SET_OPERAND,
+            obi.PointCombinedNeuronSet: ReferenceTag.POINT_NEURON_SET_OPERAND,
+            obi.VirtualCombinedNeuronSet: ReferenceTag.VIRTUAL_NEURON_SET_OPERAND,
+            obi.NonVirtualCombinedNeuronSet: ReferenceTag.NON_VIRTUAL_NEURON_SET_OPERAND,
+        }
+
+        for cls, tag in expected.items():
+            for field in ("base_neuron_set", "combined_with"):
+                assert cls.model_fields[field].json_schema_extra[SchemaKey.REFERENCE_TAG] == tag
+
+
+class TestEveryTagIsHandled:
+    """A tag with no default silently leaves its field unset, so the split is pinned explicitly."""
+
+    def test_the_config_supplies_a_default_for_every_tag_it_does_not_delegate(
+        self, circuit_config, circuit
+    ):
+        supplied = set(circuit_config().default_block_references(circuit))
+
+        assert supplied == set(ReferenceTag) - BLOCK_SUPPLIED_REFERENCE_TAGS
+
+    def test_the_delegated_tags_are_the_two_spike_distributions(self):
+        """Their defaults depend on the stimulus's own parameters, so no task can supply them."""
+        assert {
+            ReferenceTag.INTER_SPIKE_INTERVAL_DISTRIBUTION,
+            ReferenceTag.SPIKE_TIME_DISTRIBUTION,
+        } == BLOCK_SUPPLIED_REFERENCE_TAGS
+
+    def test_every_default_is_a_resolved_block_reference(self, circuit_config, circuit):
+        for tag, default in circuit_config().default_block_references(circuit).items():
+            assert isinstance(default, BlockReference), tag
+            assert default.has_block(), tag
+
+    @pytest.mark.parametrize("tag", sorted(BLOCK_SUPPLIED_REFERENCE_TAGS))
+    def test_a_delegated_tag_leaves_its_field_alone(self, tag, circuit, tmp_path):
+        stimulus_names = {
+            ReferenceTag.INTER_SPIKE_INTERVAL_DISTRIBUTION: (
+                "InterSpikeIntervalDistributionSpikeStimulus"
+            ),
+            ReferenceTag.SPIKE_TIME_DISTRIBUTION: "SpikeTimeDistributionSpikeStimulus",
+        }
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={"Stim": getattr(obi, stimulus_names[tag])()},
+        )
+
+        generate(config, tmp_path)
+
+        assert config.stimuli["Stim"].distribution is None
+
+
+class TestTheInvariantHoldsForEveryConfigFamily:
+    """After the fill, no config of any family has a tagged reference left unset."""
+
+    def test_neuron_circuit(self, circuit_config, tmp_path):
+        config = circuit_config(
+            blocks={
+                "Clamp": obi.ConstantCurrentClampSomaticStimulus(),
+                "Spikes": obi.PoissonSpikeStimulus(),
+                "Voltage": obi.SomaVoltageRecording(),
+                "Magnesium": obi.SynapticMgManipulation(),
+            }
+        )
+
+        generate(config, tmp_path)
+
+        assert unfilled_reference_fields(config) == []
+
+    def test_me_model(self, me_model_config, tmp_path):
+        config = me_model_config(
+            blocks={
+                "Clamp": obi.ConstantCurrentClampSomaticStimulus(),
+                "Voltage": obi.SomaVoltageRecording(),
+                "Locations": obi.RandomMorphologyLocations(),
+            }
+        )
+
+        generate(config, tmp_path)
+
+        assert unfilled_reference_fields(config) == []
+
+    def test_brian2(self, brian2_config, tmp_path):
+        config = brian2_config(blocks={"Poisson": Brian2DirectPoissonStimulus()})
+
+        generate(config, tmp_path)
+
+        assert unfilled_reference_fields(config) == []
+
+    def test_learning_engine(self, learning_engine_config, tmp_path):
+        config = learning_engine_config(blocks={"Clamp": obi.ConstantCurrentClampSomaticStimulus()})
+
+        generate(config, tmp_path)
+
+        assert unfilled_reference_fields(config) == []
+
+
+class TestTheStimulusTargetTagVariesByConfigFamily:
+    """The one role whose meaning genuinely differs between simulators."""
+
+    def test_brian2_points_an_untargeted_stimulus_at_the_sugar_node_set(
+        self, brian2_config, tmp_path
+    ):
+        config = brian2_config(blocks={"Poisson": Brian2DirectPoissonStimulus()})
+
+        result = generate(config, tmp_path)
+
+        assert config.stimuli["Poisson"].neuron_set.block_name == (DEFAULT_BRIAN2_STIMULUS_NODE_SET)
+        assert result.inputs["Poisson"]["node_set"] == DEFAULT_BRIAN2_STIMULUS_NODE_SET
+
+    def test_a_neuron_simulation_points_it_at_the_simulation_default(
+        self, circuit_config, tmp_path
+    ):
+        config = circuit_config(blocks={"Clamp": obi.ConstantCurrentClampSomaticStimulus()})
+
+        generate(config, tmp_path)
+
+        assert config.stimuli["Clamp"].neuron_set.block_name == (
+            CircuitSimulationSingleConfig.default_node_set_name
+        )
+
+    @pytest.mark.parametrize(
+        "config_class",
+        [
+            CircuitSimulationSingleConfig,
+            MEModelSimulationSingleConfig,
+            LearningEngineCircuitSimulationSingleConfig,
+        ],
+    )
+    def test_other_families_inherit_the_base_mapping(self, config_class):
+        """They vary only through default_neuron_set_type, not by rewriting the mapping."""
+        assert (
+            config_class.default_block_references
+            is BaseSimulationScanConfig.default_block_references
+        )
+
+    def test_brian2_is_the_one_family_that_overrides_the_mapping(self):
+        assert (
+            Brian2CircuitSimulationSingleConfig.default_block_references
+            is not BaseSimulationScanConfig.default_block_references
+        )
+
+    def test_the_two_roles_coincide_when_a_family_does_not_override(self, circuit_config, circuit):
+        """Everywhere but Brian2, an untargeted stimulus drives whatever the simulation runs."""
+        defaults = circuit_config().default_block_references(circuit)
+
+        assert (
+            defaults[ReferenceTag.STIMULUS_TARGET].block_name
+            == defaults[ReferenceTag.SIMULATION_TARGET].block_name
+        )
+
+    def test_brian2_keeps_the_two_roles_apart(self, brian2_config, point_circuit):
+        defaults = brian2_config().default_block_references(point_circuit)
+
+        assert defaults[ReferenceTag.STIMULUS_TARGET].block_name == (
+            DEFAULT_BRIAN2_STIMULUS_NODE_SET
+        )
+        assert defaults[ReferenceTag.SIMULATION_TARGET].block_name != (
+            DEFAULT_BRIAN2_STIMULUS_NODE_SET
+        )
+
+
+class TestTheConfigOwnsItsSimulationTarget:
+    """The other two things that vary by family, so the task needs no isinstance checks."""
+
+    def test_only_brian2_skips_the_virtual_target_check(self):
+        assert (
+            Brian2CircuitSimulationSingleConfig.check_simulation_target
+            is not BaseSimulationScanConfig.check_simulation_target
+        )
+        for config_class in (
+            CircuitSimulationSingleConfig,
+            MEModelSimulationSingleConfig,
+            LearningEngineCircuitSimulationSingleConfig,
+        ):
+            assert (
+                config_class.check_simulation_target
+                is BaseSimulationScanConfig.check_simulation_target
+            )
+
+    def test_the_node_set_name_is_the_filled_target(self, circuit_config, tmp_path):
+        config = circuit_config()
+
+        generate(config, tmp_path)
+
+        assert (
+            config.simulation_node_set_name == CircuitSimulationSingleConfig.default_node_set_name
+        )
+
+    def test_a_config_with_no_target_to_choose_falls_back_to_its_default(self, me_model_config):
+        """An ME model offers no target and holds no neuron sets, so the default names itself."""
+        config = me_model_config()
+        assert not hasattr(config.initialize, "node_set")
+
+        assert (
+            config.simulation_node_set_name == MEModelSimulationSingleConfig.default_node_set_name
+        )
+
+    def test_the_generated_config_records_that_node_set(self, circuit_config, tmp_path):
+        config = circuit_config()
+
+        result = generate(config, tmp_path)
+
+        assert result.sonata_config["node_set"] == config.simulation_node_set_name
+
+
+class TestTagValuesAreStable:
+    """Tags are written into the published JSON schema, so their values are part of the contract."""
+
+    def test_every_tag_value_is_its_lowercase_name(self):
+        for tag in ReferenceTag:
+            assert tag.value == tag.name.lower()
+
+    def test_tags_reach_the_generated_json_schema(self):
+        schema = obi.ConstantCurrentClampSomaticStimulus.model_json_schema()
+
+        assert schema["properties"]["neuron_set"][SchemaKey.REFERENCE_TAG] == (
+            ReferenceTag.STIMULUS_TARGET
+        )
+        assert schema["properties"]["timestamps"][SchemaKey.REFERENCE_TAG] == (
+            ReferenceTag.TIMESTAMPS
+        )
+
+
+def test_no_block_config_method_still_takes_a_default_reference():
+    """The defaults reach blocks through the fill, never as a ``config()`` argument any more."""
+    offenders = []
+    for cls in _all_block_subclasses():
+        config_method = cls.__dict__.get("config")
+        if config_method is None:
+            continue
+        offenders += [
+            f"{cls.__name__}.config({name})"
+            for name in inspect.signature(config_method).parameters
+            if name.startswith("default_")
+        ]
+
+    assert offenders == []

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_fill_none_references.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_fill_none_references.py
@@ -35,8 +35,7 @@ from obi_one.scientific.tasks.generate_simulations.config.neuron.neuron_me_model
 from obi_one.scientific.unions_and_references.reference_tags import ReferenceTag
 
 from tests.obi_one.scientific.tasks.simulation_campaign_generation.conftest import (
-    BLOCK_SUPPLIED_REFERENCE_TAGS,
-    DEFAULT_BRIAN2_STIMULUS_NODE_SET,
+    DEFAULT_POINT_NODE_SET,
     build_config,
     generate,
     reference_types_in,
@@ -126,44 +125,63 @@ class TestEveryReferenceFieldDeclaresItsRole:
 
 
 class TestEveryTagIsHandled:
-    """A tag with no default silently leaves its field unset, so the split is pinned explicitly."""
+    """A tag with no default silently leaves its field unset, so the coverage is pinned here."""
 
-    def test_the_config_supplies_a_default_for_every_tag_it_does_not_delegate(
-        self, circuit_config, circuit
-    ):
-        supplied = set(circuit_config().default_block_references(circuit))
+    def test_the_config_supplies_a_default_for_every_tag(self, circuit_config):
+        supplied = set(circuit_config().default_block_references())
 
-        assert supplied == set(ReferenceTag) - BLOCK_SUPPLIED_REFERENCE_TAGS
+        assert supplied == set(ReferenceTag)
 
-    def test_the_delegated_tags_are_the_two_spike_distributions(self):
-        """Their defaults depend on the stimulus's own parameters, so no task can supply them."""
-        assert {
-            ReferenceTag.INTER_SPIKE_INTERVAL_DISTRIBUTION,
-            ReferenceTag.SPIKE_TIME_DISTRIBUTION,
-        } == BLOCK_SUPPLIED_REFERENCE_TAGS
-
-    def test_every_default_is_a_resolved_block_reference(self, circuit_config, circuit):
-        for tag, default in circuit_config().default_block_references(circuit).items():
+    def test_every_default_is_a_resolved_block_reference(self, circuit_config):
+        for tag, default in circuit_config().default_block_references().items():
             assert isinstance(default, BlockReference), tag
             assert default.has_block(), tag
 
-    @pytest.mark.parametrize("tag", sorted(BLOCK_SUPPLIED_REFERENCE_TAGS))
-    def test_a_delegated_tag_leaves_its_field_alone(self, tag, circuit, tmp_path):
-        stimulus_names = {
-            ReferenceTag.INTER_SPIKE_INTERVAL_DISTRIBUTION: (
-                "InterSpikeIntervalDistributionSpikeStimulus"
+    @pytest.mark.parametrize(
+        ("tag", "stimulus_name"),
+        [
+            (
+                ReferenceTag.INTER_SPIKE_INTERVAL_DISTRIBUTION,
+                "InterSpikeIntervalDistributionSpikeStimulus",
             ),
-            ReferenceTag.SPIKE_TIME_DISTRIBUTION: "SpikeTimeDistributionSpikeStimulus",
-        }
+            (ReferenceTag.SPIKE_TIME_DISTRIBUTION, "SpikeTimeDistributionSpikeStimulus"),
+        ],
+    )
+    def test_a_spike_distribution_is_filled_like_any_other_role(
+        self, tag, stimulus_name, circuit_config, circuit, tmp_path
+    ):
+        """Both distribution defaults are simulation-wide, so the task supplies them too."""
         config = build_config(
             CircuitSimulationSingleConfig,
             circuit=circuit,
-            blocks={"Stim": getattr(obi, stimulus_names[tag])()},
+            blocks={"Stim": getattr(obi, stimulus_name)()},
         )
 
         generate(config, tmp_path)
 
-        assert config.stimuli["Stim"].distribution is None
+        expected = circuit_config().default_block_references()[tag]
+        assert config.stimuli["Stim"].distribution.block_name == expected.block_name
+
+    def test_the_inter_spike_interval_default_is_an_exponential(self, circuit_config):
+        """Roughly 20 Hz, and duration-independent so one reference serves every stimulus."""
+        block = (
+            circuit_config()
+            .default_block_references()[ReferenceTag.INTER_SPIKE_INTERVAL_DISTRIBUTION]
+            .block
+        )
+
+        assert isinstance(block, obi.ExponentialDistribution)
+        assert block.scale == pytest.approx(50.0)
+
+    def test_the_spike_time_default_is_a_normal(self, circuit_config):
+        """Duration-independent too, which is what lets the task rather than the block supply it."""
+        block = (
+            circuit_config().default_block_references()[ReferenceTag.SPIKE_TIME_DISTRIBUTION].block
+        )
+
+        assert isinstance(block, obi.NormalDistribution)
+        assert block.mean == pytest.approx(5.0)
+        assert block.standard_deviation == pytest.approx(1.0)
 
 
 class TestTheInvariantHoldsForEveryConfigFamily:
@@ -211,18 +229,18 @@ class TestTheInvariantHoldsForEveryConfigFamily:
         assert unfilled_reference_fields(config) == []
 
 
-class TestTheStimulusTargetTagVariesByConfigFamily:
-    """The one role whose meaning genuinely differs between simulators."""
+class TestTheStimulusTargetTagResolvesToTheSimulationTarget:
+    """An untargeted stimulus drives whatever the simulation runs, in every family."""
 
-    def test_brian2_points_an_untargeted_stimulus_at_the_sugar_node_set(
+    def test_brian2_points_an_untargeted_stimulus_at_all_point_neurons(
         self, brian2_config, tmp_path
     ):
         config = brian2_config(blocks={"Poisson": Brian2DirectPoissonStimulus()})
 
         result = generate(config, tmp_path)
 
-        assert config.stimuli["Poisson"].neuron_set.block_name == (DEFAULT_BRIAN2_STIMULUS_NODE_SET)
-        assert result.inputs["Poisson"]["node_set"] == DEFAULT_BRIAN2_STIMULUS_NODE_SET
+        assert config.stimuli["Poisson"].neuron_set.block_name == DEFAULT_POINT_NODE_SET
+        assert result.inputs["Poisson"]["node_set"] == DEFAULT_POINT_NODE_SET
 
     def test_a_neuron_simulation_points_it_at_the_simulation_default(
         self, circuit_config, tmp_path
@@ -240,39 +258,28 @@ class TestTheStimulusTargetTagVariesByConfigFamily:
         [
             CircuitSimulationSingleConfig,
             MEModelSimulationSingleConfig,
+            Brian2CircuitSimulationSingleConfig,
             LearningEngineCircuitSimulationSingleConfig,
         ],
     )
-    def test_other_families_inherit_the_base_mapping(self, config_class):
-        """They vary only through default_neuron_set_type, not by rewriting the mapping."""
+    def test_no_family_overrides_the_mapping(self, config_class):
+        """They vary only through default_neuron_set_type, not by rewriting the mapping.
+
+        Compared through ``__func__`` because binding a classmethod makes a fresh object each
+        time, so the methods themselves are never identical even when nothing overrides them.
+        """
         assert (
-            config_class.default_block_references
-            is BaseSimulationScanConfig.default_block_references
+            config_class.default_block_references.__func__
+            is BaseSimulationScanConfig.default_block_references.__func__
         )
 
-    def test_brian2_is_the_one_family_that_overrides_the_mapping(self):
-        assert (
-            Brian2CircuitSimulationSingleConfig.default_block_references
-            is not BaseSimulationScanConfig.default_block_references
-        )
-
-    def test_the_two_roles_coincide_when_a_family_does_not_override(self, circuit_config, circuit):
-        """Everywhere but Brian2, an untargeted stimulus drives whatever the simulation runs."""
-        defaults = circuit_config().default_block_references(circuit)
+    @pytest.mark.parametrize("config_fixture", ["circuit_config", "brian2_config"])
+    def test_the_two_roles_coincide(self, config_fixture, request):
+        defaults = request.getfixturevalue(config_fixture)().default_block_references()
 
         assert (
             defaults[ReferenceTag.STIMULUS_TARGET].block_name
             == defaults[ReferenceTag.SIMULATION_TARGET].block_name
-        )
-
-    def test_brian2_keeps_the_two_roles_apart(self, brian2_config, point_circuit):
-        defaults = brian2_config().default_block_references(point_circuit)
-
-        assert defaults[ReferenceTag.STIMULUS_TARGET].block_name == (
-            DEFAULT_BRIAN2_STIMULUS_NODE_SET
-        )
-        assert defaults[ReferenceTag.SIMULATION_TARGET].block_name != (
-            DEFAULT_BRIAN2_STIMULUS_NODE_SET
         )
 
 
@@ -284,17 +291,25 @@ SIMULATION_CONFIG_CLASSES = (
 )
 
 
+def default_names(config_class):
+    """The placeholder for each role, read off the references that define them."""
+    return {
+        tag: reference.block_name
+        for tag, reference in config_class.default_block_references().items()
+    }
+
+
 class TestTheDefaultNamesReachTheSchema:
     """What the UI shows as a placeholder has to be what generation will actually do."""
 
     @pytest.mark.parametrize("config_class", SIMULATION_CONFIG_CLASSES)
     def test_every_role_has_a_name(self, config_class):
-        assert set(config_class.default_block_reference_names()) == set(ReferenceTag)
+        assert set(default_names(config_class)) == set(ReferenceTag)
 
     @pytest.mark.parametrize("config_class", SIMULATION_CONFIG_CLASSES)
     def test_every_name_is_a_string(self, config_class):
         """A stray trailing comma turns one of these into a tuple, which the UI cannot show."""
-        for tag, name in config_class.default_block_reference_names().items():
+        for tag, name in default_names(config_class).items():
             assert isinstance(name, str), (tag, name)
             assert name
 
@@ -302,41 +317,13 @@ class TestTheDefaultNamesReachTheSchema:
     def test_the_names_are_published_in_the_json_schema(self, config_class):
         published = config_class.model_json_schema()[SchemaKey.REFERENCE_TAG_DEFAULTS]
 
-        assert published == config_class.default_block_reference_names()
+        assert published == default_names(config_class)
 
-    def test_the_names_agree_with_the_references_they_describe(self, circuit_config, circuit):
+    @pytest.mark.parametrize("config_class", SIMULATION_CONFIG_CLASSES)
+    def test_the_reference_and_the_block_it_holds_agree(self, config_class):
         """The anti-drift check: a shown placeholder naming a different block would be a lie."""
-        config = circuit_config()
-        names = config.default_block_reference_names()
-
-        for tag, reference in config.default_block_references(circuit).items():
-            assert reference.block_name == names[tag], tag
-            assert reference.block.block_name == names[tag], tag
-
-    def test_the_names_agree_for_brian2_too(self, brian2_config, point_circuit):
-        """Brian2 is the family that overrides both, so it is where they could diverge."""
-        config = brian2_config()
-        names = config.default_block_reference_names()
-
-        for tag, reference in config.default_block_references(point_circuit).items():
-            assert reference.block_name == names[tag], tag
-
-    def test_the_roles_the_task_does_not_fill_are_still_named(self, circuit_config, circuit):
-        """The UI shows a placeholder for them even though a block, not the task, supplies it."""
-        config = circuit_config()
-        names = config.default_block_reference_names()
-        filled = set(config.default_block_references(circuit))
-
-        for tag in BLOCK_SUPPLIED_REFERENCE_TAGS:
-            assert tag not in filled
-            assert names[tag]
-
-    def test_brian2_names_the_stimulus_and_simulation_roles_differently(self):
-        """The distinction a type-keyed label cannot make: both are point neuron references."""
-        names = Brian2CircuitSimulationSingleConfig.default_block_reference_names()
-
-        assert names[ReferenceTag.STIMULUS_TARGET] == DEFAULT_BRIAN2_STIMULUS_NODE_SET
-        assert names[ReferenceTag.SIMULATION_TARGET] != names[ReferenceTag.STIMULUS_TARGET]
+        for tag, reference in config_class.default_block_references().items():
+            assert reference.block.block_name == reference.block_name, tag
 
 
 class TestTheConfigOwnsItsSimulationTarget:

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_neuron_sets.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_neuron_sets.py
@@ -648,17 +648,15 @@ class TestDefaultReferenceTypes:
     family that changes its default neuron set gets the matching reference type for free.
     """
 
-    def test_circuit_default_is_biophysical(self, circuit_config, circuit):
-        reference = circuit_config().default_block_references(circuit)[
-            ReferenceTag.SIMULATION_TARGET
-        ]
+    def test_circuit_default_is_biophysical(self, circuit_config):
+        reference = circuit_config().default_block_references()[ReferenceTag.SIMULATION_TARGET]
 
         assert isinstance(reference, BiophysicalNeuronSetReference)
         assert reference.block_name == DEFAULT_BIOPHYSICAL_NODE_SET
         assert isinstance(reference.block, AllBiophysicalNeurons)
 
-    def test_circuit_virtual_and_point_operand_defaults(self, circuit_config, circuit):
-        defaults = circuit_config().default_block_references(circuit)
+    def test_circuit_virtual_and_point_operand_defaults(self, circuit_config):
+        defaults = circuit_config().default_block_references()
         virtual = defaults[ReferenceTag.VIRTUAL_NEURON_SET_OPERAND]
         point = defaults[ReferenceTag.POINT_NEURON_SET_OPERAND]
 
@@ -667,17 +665,15 @@ class TestDefaultReferenceTypes:
         assert isinstance(virtual.block, AllVirtualNeurons)
         assert isinstance(point.block, AllPointNeurons)
 
-    def test_brian2_default_is_point(self, brian2_config, point_circuit):
-        reference = brian2_config().default_block_references(point_circuit)[
-            ReferenceTag.SIMULATION_TARGET
-        ]
+    def test_brian2_default_is_point(self, brian2_config):
+        reference = brian2_config().default_block_references()[ReferenceTag.SIMULATION_TARGET]
 
         assert isinstance(reference, PointNeuronSetReference)
         assert reference.block_name == DEFAULT_POINT_NODE_SET
         assert isinstance(reference.block, AllPointNeurons)
 
-    def test_learning_engine_default_is_point(self, learning_engine_config, point_circuit):
-        reference = learning_engine_config().default_block_references(point_circuit)[
+    def test_learning_engine_default_is_point(self, learning_engine_config):
+        reference = learning_engine_config().default_block_references()[
             ReferenceTag.SIMULATION_TARGET
         ]
 

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_neuron_sets.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_neuron_sets.py
@@ -56,6 +56,7 @@ from obi_one.scientific.unions_and_references.neuron_sets import (
     PointNeuronSetReference,
     VirtualNeuronSetReference,
 )
+from obi_one.scientific.unions_and_references.reference_tags import ReferenceTag
 
 from tests.obi_one.scientific.tasks.simulation_campaign_generation.conftest import (
     BIOPHYSICAL_POPULATION,
@@ -620,7 +621,7 @@ class TestDefaultNeuronSetErrors:
             },
         )
 
-        with pytest.raises(OBIONEError, match="Default virtual neuron set name"):
+        with pytest.raises(OBIONEError, match="is not an AllVirtualNeurons set"):
             generate(config, tmp_path)
 
     def test_reusing_the_point_default_name_for_another_type_is_rejected(self, circuit, tmp_path):
@@ -636,37 +637,50 @@ class TestDefaultNeuronSetErrors:
             },
         )
 
-        with pytest.raises(OBIONEError, match="Default point neuron set name"):
+        with pytest.raises(OBIONEError, match="is not an AllPointNeurons set"):
             generate(config, tmp_path)
 
 
 class TestDefaultReferenceTypes:
-    """The reference each config family hands out for its default neuron set."""
+    """The reference each config family hands out for its default neuron set.
 
-    def test_circuit_default_is_biophysical(self, circuit_config):
-        reference = circuit_config().default_neuron_set_reference
+    The reference type is derived from what the neuron set contains rather than declared, so a
+    family that changes its default neuron set gets the matching reference type for free.
+    """
+
+    def test_circuit_default_is_biophysical(self, circuit_config, circuit):
+        reference = circuit_config().default_block_references(circuit)[
+            ReferenceTag.SIMULATION_TARGET
+        ]
 
         assert isinstance(reference, BiophysicalNeuronSetReference)
         assert reference.block_name == DEFAULT_BIOPHYSICAL_NODE_SET
         assert isinstance(reference.block, AllBiophysicalNeurons)
 
-    def test_circuit_virtual_and_point_defaults(self, circuit_config):
-        config = circuit_config()
+    def test_circuit_virtual_and_point_operand_defaults(self, circuit_config, circuit):
+        defaults = circuit_config().default_block_references(circuit)
+        virtual = defaults[ReferenceTag.VIRTUAL_NEURON_SET_OPERAND]
+        point = defaults[ReferenceTag.POINT_NEURON_SET_OPERAND]
 
-        assert isinstance(config.default_virtual_neuron_set_reference, VirtualNeuronSetReference)
-        assert isinstance(config.default_point_neuron_set_reference, PointNeuronSetReference)
-        assert isinstance(config.default_virtual_neuron_set_reference.block, AllVirtualNeurons)
-        assert isinstance(config.default_point_neuron_set_reference.block, AllPointNeurons)
+        assert isinstance(virtual, VirtualNeuronSetReference)
+        assert isinstance(point, PointNeuronSetReference)
+        assert isinstance(virtual.block, AllVirtualNeurons)
+        assert isinstance(point.block, AllPointNeurons)
 
-    def test_brian2_default_is_point(self, brian2_config):
-        reference = brian2_config().default_neuron_set_reference
+    def test_brian2_default_is_point(self, brian2_config, point_circuit):
+        reference = brian2_config().default_block_references(point_circuit)[
+            ReferenceTag.SIMULATION_TARGET
+        ]
 
         assert isinstance(reference, PointNeuronSetReference)
         assert reference.block_name == DEFAULT_POINT_NODE_SET
         assert isinstance(reference.block, AllPointNeurons)
 
-    def test_learning_engine_default_is_point(self, learning_engine_config):
-        reference = learning_engine_config().default_neuron_set_reference
+    def test_learning_engine_default_is_point(self, learning_engine_config, point_circuit):
+        reference = learning_engine_config().default_block_references(point_circuit)[
+            ReferenceTag.SIMULATION_TARGET
+        ]
 
         assert isinstance(reference, PointNeuronSetReference)
         assert reference.block_name == DEFAULT_POINT_NODE_SET
+        assert isinstance(reference.block, AllPointNeurons)

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_stimuli.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_stimuli.py
@@ -36,7 +36,7 @@ from obi_one.scientific.unions_and_references.stimuli import (
 from tests.obi_one.scientific.tasks.simulation_campaign_generation.conftest import (
     BIOPHYSICAL_POPULATION,
     DEFAULT_BIOPHYSICAL_NODE_SET,
-    DEFAULT_BRIAN2_STIMULUS_NODE_SET,
+    DEFAULT_POINT_NODE_SET,
     POINT_POPULATION,
     VIRTUAL_POPULATION,
     build_config,
@@ -370,12 +370,12 @@ class TestSpikeStimuli:
 
 
 class TestBrian2DirectPoissonStimulus:
-    def test_untargeted_stimulus_drives_the_sugar_node_set(self, brian2_config, tmp_path):
+    def test_untargeted_stimulus_drives_all_point_neurons(self, brian2_config, tmp_path):
         config = brian2_config(blocks={"DirectPoisson": Brian2DirectPoissonStimulus()})
 
         result = generate(config, tmp_path)
 
-        assert result.inputs["DirectPoisson"]["node_set"] == DEFAULT_BRIAN2_STIMULUS_NODE_SET
+        assert result.inputs["DirectPoisson"]["node_set"] == DEFAULT_POINT_NODE_SET
         assert result.inputs["DirectPoisson"]["input_type"] == "spikes"
         assert result.inputs["DirectPoisson"]["module"] == "poisson"
 
@@ -412,34 +412,19 @@ class TestBrian2DirectPoissonStimulus:
         assert result.inputs["DirectPoisson"] == {
             "input_type": "spikes",
             "module": "poisson",
-            "node_set": DEFAULT_BRIAN2_STIMULUS_NODE_SET,
+            "node_set": DEFAULT_POINT_NODE_SET,
             "rate": 25.0,
             "weight": 0.3,
             "delay": 0.0,
             "duration": 60.0,
         }
 
-    def test_a_circuit_without_a_point_population_is_refused(self, circuit, tmp_path):
-        """Resolving the `sugar` default needs exactly one point population to name."""
-        config = build_config(
-            Brian2CircuitSimulationSingleConfig,
-            circuit=circuit,
-            blocks={"DirectPoisson": Brian2DirectPoissonStimulus()},
-        )
-
-        with pytest.raises(OBIONEError, match="needs exactly one point node population"):
-            generate(config, tmp_path)
-
-    def test_the_stimulus_default_is_a_strict_subset_of_the_simulation_default(
+    def test_the_stimulus_and_simulation_defaults_are_the_same_node_set(
         self, brian2_config, tmp_path
     ):
-        """The two Brian2 defaults are separate: `sugar` for stimuli, all point neurons for the
-        simulation. Collapsing them would push the stimulus over its 100-neuron ceiling on a real
-        circuit."""
+        """An untargeted stimulus drives whatever the simulation runs, as in every other family."""
         config = brian2_config(blocks={"DirectPoisson": Brian2DirectPoissonStimulus()})
 
         result = generate(config, tmp_path)
 
-        stimulus_ids = result.node_sets[DEFAULT_BRIAN2_STIMULUS_NODE_SET]["node_id"]
-        simulation_ids = result.node_sets[result.sonata_config["node_set"]]["node_id"]
-        assert set(stimulus_ids) < set(simulation_ids)
+        assert result.inputs["DirectPoisson"]["node_set"] == result.sonata_config["node_set"]

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_unset_block_references.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_unset_block_references.py
@@ -43,7 +43,6 @@ from obi_one.scientific.unions_and_references.stimuli import CircuitStimulusUnio
 
 from tests.obi_one.scientific.tasks.simulation_campaign_generation.conftest import (
     DEFAULT_BIOPHYSICAL_NODE_SET,
-    DEFAULT_BRIAN2_STIMULUS_NODE_SET,
     DEFAULT_POINT_NODE_SET,
     DEFAULT_VIRTUAL_NODE_SET,
     POINT_POPULATION,
@@ -425,15 +424,12 @@ class TestNoDanglingNodeSetReferences:
         assert result.dangling_node_sets() == set()
 
     def test_untargeted_brian2_stimulus_leaves_nothing_dangling(self, brian2_config, tmp_path):
-        """Brian2 resolves two different defaults, and both node sets have to be written."""
+        """Brian2 resolves both roles to one default, and that node set has to be written."""
         config = brian2_config(blocks={"DirectPoisson": Brian2DirectPoissonStimulus()})
 
         result = generate(config, tmp_path)
 
-        assert result.referenced_node_sets() == {
-            DEFAULT_POINT_NODE_SET,
-            DEFAULT_BRIAN2_STIMULUS_NODE_SET,
-        }
+        assert result.referenced_node_sets() == {DEFAULT_POINT_NODE_SET}
         assert result.dangling_node_sets() == set()
 
     def test_untargeted_learning_engine_stimulus_leaves_nothing_dangling(
@@ -667,14 +663,14 @@ class TestUnsetTimestampsAndDistributions:
     def test_a_distribution_driven_stimulus_generates_without_a_distribution(
         self, name, circuit, tmp_path
     ):
-        """These stimuli fall back to their own distribution rather than failing."""
+        """The task fills these like any other role, rather than the block falling back."""
         config = build_config(
             CircuitSimulationSingleConfig, circuit=circuit, blocks={"Stim": _block(name)}
         )
 
         result = generate(config, tmp_path)
 
-        assert config.stimuli["Stim"].distribution is None
+        assert config.stimuli["Stim"].distribution is not None
         assert result.inputs["Stim"]["spike_file"] == "Stim_spikes.h5"
         assert (result.directory / "Stim_spikes.h5").exists()
 

--- a/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_unset_block_references.py
+++ b/tests/obi_one/scientific/tasks/simulation_campaign_generation/test_unset_block_references.py
@@ -1,11 +1,11 @@
 """Blocks whose every block-reference field is left unset.
 
 Reference fields are all optional and all default to ``None``, so "the user added a block and
-targeted nothing" is the most common config there is. Resolving those ``None``s is spread across
-several places -- the task fills some in on the block itself before generating, while others stay
-``None`` and are resolved to a bare node set *name* inside the block's own ``config()``. These
-tests pin what an unset reference currently produces, so that consolidating the two mechanisms
-can be checked against real output rather than by reading.
+targeted nothing" is the most common config there is. Every one of those ``None``s is resolved in
+a single place: each field declares its role with a ``SchemaKey.REFERENCE_TAG``, and the task's
+``_fill_none_references`` substitutes the reference that role maps to before anything reads it.
+These tests pin both halves of that -- the reference really is filled on the block, and the
+generated SONATA names the expected node set.
 
 The parametrised sweeps build their cases from the block unions themselves, so a newly added
 block type is covered here without anyone editing this file.
@@ -14,6 +14,7 @@ block type is covered here without anyone editing this file.
 import pytest
 
 import obi_one as obi
+from obi_one.scientific.blocks.neuron_sets.combined import SetOperation
 from obi_one.scientific.blocks.neuron_sets.deprecated import AllNeurons
 from obi_one.scientific.blocks.neuron_sets.population import PointPopulationNeuronSet
 from obi_one.scientific.blocks.neuronal_manipulations.neuronal_manipulations import (
@@ -50,6 +51,7 @@ from tests.obi_one.scientific.tasks.simulation_campaign_generation.conftest impo
     generate,
     reference_field_names,
     reference_types_in,
+    unfilled_reference_fields,
     union_member_names,
 )
 
@@ -460,14 +462,13 @@ class TestNoDanglingNodeSetReferences:
         assert list(config.neuron_sets) == [DEFAULT_BIOPHYSICAL_NODE_SET]
 
 
-class TestWhichReferencesAreFilledInPlace:
-    """Characterisation of the current split between the two resolution mechanisms.
+class TestEveryUnsetReferenceIsFilledOnItsBlock:
+    """One mechanism fills every unset reference, whatever block or config family holds it.
 
-    Stimuli, recordings, morphology locations and combined neuron sets have their unset
-    references replaced with a real reference on the block before generation. Timestamps,
-    distributions and both kinds of manipulation are left ``None`` and resolved to a node set
-    name inside the block's own ``config()``. The generated SONATA is the same either way, which
-    is exactly why the divergence is easy to miss -- these assertions make it visible.
+    ``_fill_none_references`` runs once before anything reads a reference, so a block never has to
+    decide for itself what ``None`` means. These assertions are what stops a second, divergent
+    resolution path from creeping back in: it is not enough that the generated SONATA is right,
+    the reference has to be filled on the block.
     """
 
     def test_stimulus_and_recording_targets_are_filled_on_the_block(self, circuit, tmp_path):
@@ -498,8 +499,8 @@ class TestWhichReferencesAreFilledInPlace:
         assert stimulus.source_neuron_set.block_name == DEFAULT_BIOPHYSICAL_NODE_SET
         assert stimulus.targeted_neuron_set.block_name == DEFAULT_BIOPHYSICAL_NODE_SET
 
-    def test_timestamps_are_left_unset_on_the_block(self, circuit, tmp_path):
-        """The default timestamps never reach the config; they are applied during generation."""
+    def test_timestamps_are_filled_on_the_block(self, circuit, tmp_path):
+        """Timestamps get the same treatment as a neuron set, despite naming a different block."""
         config = build_config(
             CircuitSimulationSingleConfig,
             circuit=circuit,
@@ -508,11 +509,12 @@ class TestWhichReferencesAreFilledInPlace:
 
         result = generate(config, tmp_path)
 
-        assert config.stimuli["Clamp"].timestamps is None
+        assert config.stimuli["Clamp"].timestamps is not None
+        assert config.stimuli["Clamp"].timestamps.block.start_time == pytest.approx(0.0)
         assert result.inputs["Clamp_0"]["delay"] == pytest.approx(0.0)
 
-    def test_manipulation_targets_are_left_unset_on_the_block(self, circuit, tmp_path):
-        """Unlike stimuli, a manipulation keeps its ``None`` and is resolved by name later."""
+    def test_synaptic_manipulation_targets_are_filled_on_the_block(self, circuit, tmp_path):
+        """Manipulations used to be skipped by the fill and resolved by name during generation."""
         config = build_config(
             CircuitSimulationSingleConfig,
             circuit=circuit,
@@ -522,15 +524,13 @@ class TestWhichReferencesAreFilledInPlace:
         result = generate(config, tmp_path)
 
         manipulation = config.synaptic_manipulations["Magnesium"]
-        assert manipulation.presynaptic_neuron_set is None
-        assert manipulation.postsynaptic_neuron_set is None
+        assert manipulation.presynaptic_neuron_set.block_name == DEFAULT_BIOPHYSICAL_NODE_SET
+        assert manipulation.postsynaptic_neuron_set.block_name == DEFAULT_BIOPHYSICAL_NODE_SET
         assert result.sonata_config["connection_overrides"][0]["source"] == (
             DEFAULT_BIOPHYSICAL_NODE_SET
         )
 
-    def test_neuronal_manipulation_target_is_left_unset_on_the_block(
-        self, me_model_config, tmp_path
-    ):
+    def test_neuronal_manipulation_target_is_filled_on_the_block(self, me_model_config, tmp_path):
         config = me_model_config(
             blocks={
                 "Manip": ByNeuronMechanismVariableNeuronalManipulation(
@@ -543,18 +543,41 @@ class TestWhichReferencesAreFilledInPlace:
 
         result = generate(config, tmp_path)
 
-        assert config.neuronal_manipulations["Manip"].neuron_set is None
+        target = config.neuronal_manipulations["Manip"].neuron_set
+        assert target.block_name == DEFAULT_BIOPHYSICAL_NODE_SET
         assert result.conditions["modifications"][0]["node_set"] == DEFAULT_BIOPHYSICAL_NODE_SET
+
+    def test_nothing_tagged_is_left_unset_anywhere(self, circuit, tmp_path):
+        """The invariant the whole mechanism exists to provide, over one of every block kind."""
+        config = build_config(
+            CircuitSimulationSingleConfig,
+            circuit=circuit,
+            blocks={
+                "Clamp": obi.ConstantCurrentClampSomaticStimulus(),
+                "Spikes": obi.PoissonSpikeStimulus(),
+                "Voltage": obi.SomaVoltageRecording(),
+                "Magnesium": obi.SynapticMgManipulation(),
+                "Combined": obi.BiophysicalCombinedNeuronSet(
+                    base_neuron_set=None, combined_with=((None, SetOperation.UNION),)
+                ),
+            },
+        )
+
+        generate(config, tmp_path)
+
+        assert unfilled_reference_fields(config) == []
 
 
 class TestConfigWithoutANeuronSetsDictionary:
-    """The ME model config has no ``neuron_sets`` field, so nothing is filled in on its blocks.
+    """An ME model config has no ``neuron_sets`` field, but its blocks are filled just the same.
 
-    It reaches the same SONATA output through the blocks' own default-node-set fallback. That is
-    the second mechanism producing the first mechanism's result, on a different config family.
+    Nothing is registered, because there is no dictionary to register into and the node set is
+    written straight from the config's default type. The blocks still end up pointing at it.
     """
 
-    def test_references_stay_unset_on_the_blocks(self, me_model_config, tmp_path):
+    def test_references_are_filled_even_with_nowhere_to_register_them(
+        self, me_model_config, tmp_path
+    ):
         config = me_model_config(
             blocks={
                 "Clamp": obi.ConstantCurrentClampSomaticStimulus(),
@@ -565,8 +588,9 @@ class TestConfigWithoutANeuronSetsDictionary:
 
         generate(config, tmp_path)
 
-        assert config.stimuli["Clamp"].neuron_set is None
-        assert config.recordings["Voltage"].neuron_set is None
+        assert config.stimuli["Clamp"].neuron_set.block_name == DEFAULT_BIOPHYSICAL_NODE_SET
+        assert config.recordings["Voltage"].neuron_set.block_name == DEFAULT_BIOPHYSICAL_NODE_SET
+        assert unfilled_reference_fields(config) == []
 
     def test_the_output_still_names_the_default(self, me_model_config, tmp_path):
         config = me_model_config(
@@ -628,7 +652,7 @@ class TestUnsetTimestampsAndDistributions:
 
         result = generate(config, tmp_path)
 
-        assert config.synaptic_manipulations["Manip"].timestamps is None
+        assert config.synaptic_manipulations["Manip"].timestamps is not None
         overrides = result.sonata_config["connection_overrides"]
         assert len(overrides) == 1
         assert overrides[0]["delay"] == pytest.approx(0.0)
@@ -713,7 +737,9 @@ class TestUntargetedNeuronalManipulations:
 
         result = generate(config, tmp_path)
 
-        assert config.neuronal_manipulations["Manip"].neuron_set is None
+        assert config.neuronal_manipulations["Manip"].neuron_set.block_name == (
+            DEFAULT_BIOPHYSICAL_NODE_SET
+        )
         modifications = result.conditions["modifications"]
         assert modifications
         for modification in modifications:

--- a/tests/ui_schema/test_morphology_section_type_selection.py
+++ b/tests/ui_schema/test_morphology_section_type_selection.py
@@ -58,7 +58,10 @@ def test_morphology_endpoint_is_available_for_neuron_simulation_configs():
         )
         assert schema[SchemaKey.UI_ENABLED] is True
         assert schema[SchemaKey.GROUP_ORDER]
-        assert schema[SchemaKey.DEFAULT_BLOCK_REFERENCE_LABELS]
+        # a form must name its reference defaults by role, by type, or both
+        assert schema.get(SchemaKey.REFERENCE_TAG_DEFAULTS) or schema.get(
+            SchemaKey.DEFAULT_BLOCK_REFERENCE_LABELS
+        )
 
 
 def test_direct_morphology_uses_generic_endpoint_with_supported_placeholder():

--- a/tests/ui_schema/test_schema.py
+++ b/tests/ui_schema/test_schema.py
@@ -1,11 +1,13 @@
 import copy
 import logging
 from collections import defaultdict
+from collections.abc import Iterator
 from typing import Any
 
 import pytest
 from jsonschema import ValidationError
 
+import obi_one as obi
 from obi_one.core.schema import SchemaKey, UIElement
 
 from .validate_block import (
@@ -58,6 +60,80 @@ def validate_dict(schema: dict, element: str, form_ref: str) -> None:
     if type(schema.get(element, {})) is not dict:
         msg = f"Validation error at {form_ref}: {element} must be a dictionary"
         raise ValueError(msg)
+
+
+def find_default_reference_label(reference_schema: dict, form: dict) -> str | None:
+    """The name a reference field resolves to when unset, or None if the form declares none.
+
+    Mirrors the UI: the field's role wins, because two fields of the same reference type can mean
+    different things and only the role tells them apart. The by-type labels are the fallback for
+    forms that predate the tags. Either source is sufficient on its own.
+    """
+    tag = reference_schema.get(SchemaKey.REFERENCE_TAG)
+    if tag:
+        by_tag = form.get(SchemaKey.REFERENCE_TAG_DEFAULTS, {}).get(tag)
+        if by_tag:
+            return by_tag
+
+    by_type = form.get(SchemaKey.DEFAULT_BLOCK_REFERENCE_LABELS, {})
+    return next(
+        (by_type[t] for t in reference_schema.get(SchemaKey.REFERENCE_TYPES, []) if by_type.get(t)),
+        None,
+    )
+
+
+def validate_default_reference_labels(form: dict, form_ref: str) -> None:
+    """A form must name a default for every reference it shows, by either route.
+
+    A reference with no default has no label for its default option, so the UI hides it. Hiding a
+    field the user is meant to fill is a silent failure, so it is an error here rather than a
+    surprise in the interface. Use ui_hidden to hide one deliberately.
+    """
+    validate_dict(form, SchemaKey.REFERENCE_TAG_DEFAULTS, form_ref)
+    validate_dict(form, SchemaKey.DEFAULT_BLOCK_REFERENCE_LABELS, form_ref)
+
+    for label in form.get(SchemaKey.REFERENCE_TAG_DEFAULTS, {}).values():
+        if not isinstance(label, str) or not label:
+            msg = (
+                f"Validation error at {form_ref}: every {SchemaKey.REFERENCE_TAG_DEFAULTS} value "
+                f"must be a non-empty string, got {label!r}"
+            )
+            raise ValueError(msg)
+
+    unlabelled = [
+        ref
+        for ref, reference_schema in iter_reference_schemas(form)
+        if not reference_schema.get(SchemaKey.UI_HIDDEN)
+        and find_default_reference_label(reference_schema, form) is None
+    ]
+    if unlabelled:
+        msg = (
+            f"Validation error at {form_ref}: no default is named for {', '.join(unlabelled)}. "
+            f"Give the field a {SchemaKey.REFERENCE_TAG} the form's "
+            f"{SchemaKey.REFERENCE_TAG_DEFAULTS} names, or list one of its "
+            f"{SchemaKey.REFERENCE_TYPES} in {SchemaKey.DEFAULT_BLOCK_REFERENCE_LABELS}."
+        )
+        raise ValueError(msg)
+
+
+def iter_reference_schemas(form: dict) -> Iterator[tuple[str, dict]]:
+    """Every reference field the form contains, wherever it is nested."""
+
+    def walk(node: object, path: str) -> Iterator[tuple[str, dict]]:
+        if isinstance(node, dict):
+            if node.get(SchemaKey.UI_ELEMENT) in {
+                UIElement.REFERENCE,
+                UIElement.NEURON_SET_COMBINATION,
+            }:
+                yield path, node
+            for key, value in node.items():
+                yield from walk(value, f"{path}.{key}" if path else str(key))
+        elif isinstance(node, list):
+            for index, value in enumerate(node):
+                yield from walk(value, f"{path}[{index}]")
+
+    yield from walk(form.get("$defs", {}), "")
+    yield from walk(form.get("properties", {}), "")
 
 
 def validate_group_order(schema: dict, form_ref: str) -> None:  # ruff: ignore[complex-structure]
@@ -219,7 +295,7 @@ def validate_config(form: dict, config_ref: str) -> None:
 
     validate_string(form, "title", config_ref)
     validate_string(form, "description", config_ref)
-    validate_dict(form, SchemaKey.DEFAULT_BLOCK_REFERENCE_LABELS, config_ref)
+    validate_default_reference_labels(form, config_ref)
     validate_group_order(form, config_ref)
     validate_hidden_refs_not_required(form, config_ref)
 
@@ -261,6 +337,98 @@ def test_schema() -> None:
 # BiophysicalCombinedNeuronSet exercises the multi-reference (anyOf) neuron set slot, while
 # PointCombinedNeuronSet exercises the single-reference ($ref) slot.
 COMBINATION_BLOCKS = ["BiophysicalCombinedNeuronSet", "PointCombinedNeuronSet"]
+
+
+_TAGGED_REFERENCE = {
+    SchemaKey.UI_ELEMENT: UIElement.REFERENCE,
+    SchemaKey.REFERENCE_TYPES: ["PointNeuronSetReference"],
+    SchemaKey.REFERENCE_TAG: "stimulus_target",
+}
+
+
+def _form_with(reference: dict, **form_keys) -> dict:
+    return {
+        SchemaKey.UI_ENABLED: True,
+        "properties": {"initialize": {"properties": {"node_set": reference}}},
+        **form_keys,
+    }
+
+
+class TestDefaultReferenceLabels:
+    """A reference the form names no default for is silently hidden by the UI, so it is an error."""
+
+    def test_the_role_wins_over_the_reference_type(self):
+        label = find_default_reference_label(
+            _TAGGED_REFERENCE,
+            {
+                SchemaKey.REFERENCE_TAG_DEFAULTS: {"stimulus_target": "by role"},
+                SchemaKey.DEFAULT_BLOCK_REFERENCE_LABELS: {"PointNeuronSetReference": "by type"},
+            },
+        )
+
+        assert label == "by role"
+
+    def test_the_reference_type_is_the_fallback(self):
+        label = find_default_reference_label(
+            _TAGGED_REFERENCE,
+            {SchemaKey.DEFAULT_BLOCK_REFERENCE_LABELS: {"PointNeuronSetReference": "by type"}},
+        )
+
+        assert label == "by type"
+
+    def test_naming_it_by_role_alone_is_enough(self):
+        form = _form_with(
+            _TAGGED_REFERENCE,
+            **{SchemaKey.REFERENCE_TAG_DEFAULTS: {"stimulus_target": "Default: Sugar"}},
+        )
+
+        validate_default_reference_labels(form, "form")
+
+    def test_naming_it_by_type_alone_is_enough(self):
+        form = _form_with(
+            _TAGGED_REFERENCE,
+            **{SchemaKey.DEFAULT_BLOCK_REFERENCE_LABELS: {"PointNeuronSetReference": "Default"}},
+        )
+
+        validate_default_reference_labels(form, "form")
+
+    def test_a_reference_named_by_neither_is_rejected(self):
+        with pytest.raises(ValueError, match="no default is named for"):
+            validate_default_reference_labels(_form_with(_TAGGED_REFERENCE), "form")
+
+    def test_a_tag_the_form_does_not_name_is_rejected(self):
+        form = _form_with(
+            _TAGGED_REFERENCE,
+            **{SchemaKey.REFERENCE_TAG_DEFAULTS: {"a_different_role": "Default"}},
+        )
+
+        with pytest.raises(ValueError, match="no default is named for"):
+            validate_default_reference_labels(form, "form")
+
+    def test_a_deliberately_hidden_reference_needs_no_default(self):
+        form = _form_with({**_TAGGED_REFERENCE, SchemaKey.UI_HIDDEN: True})
+
+        validate_default_reference_labels(form, "form")
+
+    def test_an_empty_label_is_rejected_rather_than_shown_blank(self):
+        form = _form_with(
+            _TAGGED_REFERENCE,
+            **{
+                SchemaKey.REFERENCE_TAG_DEFAULTS: {"stimulus_target": ""},
+                SchemaKey.DEFAULT_BLOCK_REFERENCE_LABELS: {"PointNeuronSetReference": "Default"},
+            },
+        )
+
+        with pytest.raises(ValueError, match="must be a non-empty string"):
+            validate_default_reference_labels(form, "form")
+
+    def test_the_sweep_finds_references_in_a_real_form(self):
+        """Guards every case above against passing because nothing was inspected."""
+        form = obi.CircuitSimulationScanConfig.model_json_schema()
+
+        found = list(iter_reference_schemas(form))
+
+        assert len(found) > 5
 
 
 def _combination_schema(block_name: str) -> dict:


### PR DESCRIPTION
Replaces the two divergent mechanisms for resolving unset block references in simulation generation with one declarative pass.

### Before

Unset references were resolved two different ways that happened to produce the same SONATA:

- The task filled stimuli, recordings, morphology locations and combined neuron sets **in place** on the block, via four `_ensure_*` methods.
- Timestamps and both kinds of manipulation stayed `None` and were resolved to a bare node set *name* inside each block's own `config()`, from a `default_node_set` argument.

The split was unprincipled — the task iterated only the `recordings` and `stimuli` dicts, so manipulations were skipped despite matching the same type predicate. Because both paths produced identical output, the divergence was invisible.

### After

Every reference field that may be left unset declares what it means:

```python
neuron_set: ... = Field(
    default=None,
    json_schema_extra={
        SchemaKey.REFERENCE_TYPES: [...],
        SchemaKey.REFERENCE_TAG: ReferenceTag.STIMULUS_TARGET,
    },
)
```

Each `ScanConfig` maps every tag to the reference to substitute, and `GenerateSimulationTask._fill_none_references` applies that mapping once, before anything reads a reference. No block has to reason about `None`.

- Blocks no longer take `default_*` arguments; `config()` reads references that are already filled.
- `resolve_neuron_set_ref_to_*` and `resolve_timestamps_ref_to_*` take just the reference and raise if it is unset, so a field added without a tag fails loudly instead of silently falling back.
- Defaults are registered into `neuron_sets` only when a block actually used them, so a fully targeted simulation gains no spurious node sets.
- The walk knows nothing about simulations, so it lives in `core/fill_none_references.py` and treats tags as plain strings.

### Config layer

Defaults live on `BaseSimulationScanConfig`. NEURON and LearningEngine inherit the mapping unchanged — they differ only through `default_neuron_set_type`. Brian2 is the one family that overrides it, pointing an untargeted stimulus at the `sugar` node set.

Choosing and validating the simulation target moved there too, as `simulation_node_set_name` and `check_simulation_target`. That removes `_set_simulation_target_node_set` and the last `isinstance` check on a config class from the task. Its branch for a config holding `neuron_sets` but no `initialize.node_set` went with it — no config has one without the other.

The per-family `default_neuron_set_reference` overrides existed only to pick a reference type, which is now derived from what the neuron set contains. `le_base.py` is left with no methods at all.

### Behaviour

Unchanged. For a config mixing targeted and untargeted blocks of every kind, `simulation_config.json`, `node_sets.json` and the emitted file list are byte-identical to `main`. The only difference is in memory: manipulations and timestamps, which the old fill skipped, are now filled like everything else.

Two deliberate carve-outs, both pinned by tests:

- The two spike distribution tags are not supplied by the task. `SpikeTimeDistributionSpikeStimulus` defaults to a uniform distribution spanning **its own** `duration`, which no simulation-wide reference can express, so those blocks keep supplying their own.
- `Brian2SimulationScanConfig._point_population(circuit)` is now called for every Brian2 simulation rather than only when an untargeted Poisson stimulus exists. A Brian2 circuit without exactly one point population now fails earlier, with the same message. Such a circuit could not run under Brian2 anyway.

### Tests

`tests/.../test_fill_none_references.py` guards the mechanism by introspection rather than by example: no simulation reference field may go untagged, and no tag may go unhandled. A new block or reference field fails those tests until someone decides what leaving it unset should mean.

2018 pass locally. The 6 failures are pre-existing missing-optional-dependency ones (`ultraliser`, `connalysis`), identical on `main`. `ruff` clean; `ty` at main's baseline.