### PR TITLE
Fix compute_cell for circuit validation/asset launch jobs

### DIFF
--- a/app/endpoints/circuit_helpers.py
+++ b/app/endpoints/circuit_helpers.py
@@ -20,6 +20,7 @@ def trigger_validation_task(
     circuit_id: UUID,
     project_id: UUID,
     virtual_lab_id: UUID,
+    compute_cell: str,
     force: bool = False,
 ) -> None:
     """Submit a circuit validation job to the launch-system.
@@ -29,6 +30,7 @@ def trigger_validation_task(
         circuit_id: Circuit entity ID to validate.
         project_id: Project ID for the job.
         virtual_lab_id: Virtual lab ID for the job.
+        compute_cell: Compute cell for the launch-system job (from the vlab).
         force: When True, validate even if the circuit is not in ``draft`` status.
     """
     submit_circuit_validation_job(
@@ -37,6 +39,7 @@ def trigger_validation_task(
         project_id=project_id,
         virtual_lab_id=virtual_lab_id,
         api_url=settings.API_URL,
+        compute_cell=compute_cell,
         obi_one_repo=settings.OBI_ONE_REPO,
         app_version=settings.APP_VERSION,
         force=force,
@@ -49,6 +52,7 @@ def trigger_asset_generation_task(
     circuit_id: UUID,
     project_id: UUID,
     virtual_lab_id: UUID,
+    compute_cell: str,
     force: bool = False,
 ) -> None:
     """Submit an asset generation job to the launch-system.
@@ -58,6 +62,7 @@ def trigger_asset_generation_task(
         circuit_id: Circuit entity ID to generate assets for.
         project_id: Project ID for the job.
         virtual_lab_id: Virtual lab ID for the job.
+        compute_cell: Compute cell for the launch-system job (from the vlab).
         force: When True, regenerate compressed archive even if it already exists.
     """
     submit_circuit_asset_generation_job(
@@ -65,6 +70,7 @@ def trigger_asset_generation_task(
         circuit_id=circuit_id,
         project_id=project_id,
         virtual_lab_id=virtual_lab_id,
+        compute_cell=compute_cell,
         obi_one_repo=settings.OBI_ONE_REPO,
         app_version=settings.APP_VERSION,
         force=force,

--- a/app/endpoints/circuit_registration.py
+++ b/app/endpoints/circuit_registration.py
@@ -16,6 +16,7 @@ from entitysdk.types import CircuitScale, DerivationType
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 
 from app.dependencies.auth import user_verified
+from app.dependencies.compute_cell import ComputeCellDep
 from app.dependencies.entitysdk import get_client
 from app.dependencies.launch_system import LaunchSystemClientDep
 from app.endpoints.circuit_helpers import trigger_asset_generation_task, trigger_validation_task
@@ -194,6 +195,7 @@ def _register_draft_from_uploads(  # ruff: ignore[too-many-arguments]
 def register_circuit_endpoint(  # ruff: ignore[too-many-arguments, too-many-positional-arguments]
     ls_client: LaunchSystemClientDep,
     db_client: Annotated[entitysdk.client.Client, Depends(get_client)],
+    compute_cell: ComputeCellDep,
     name: Annotated[str, Form()],
     description: Annotated[str, Form()],
     brain_region_id: Annotated[UUID, Form()],
@@ -308,6 +310,7 @@ def register_circuit_endpoint(  # ruff: ignore[too-many-arguments, too-many-posi
             circuit_id=registered.id,
             project_id=db_client.project_context.project_id,  # ty:ignore[unresolved-attribute]
             virtual_lab_id=db_client.project_context.virtual_lab_id,  # ty:ignore[unresolved-attribute, invalid-argument-type]
+            compute_cell=compute_cell,
         )
 
     number_connections = registered.number_connections
@@ -326,6 +329,7 @@ def validate_circuit_endpoint(
     circuit_id: UUID,
     ls_client: LaunchSystemClientDep,
     db_client: Annotated[entitysdk.client.Client, Depends(get_client)],
+    compute_cell: ComputeCellDep,
     force: bool = False,  # ruff: ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
 ) -> dict:
     """Trigger (re-)validation for a circuit.
@@ -346,6 +350,7 @@ def validate_circuit_endpoint(
         circuit_id=circuit_id,
         project_id=db_client.project_context.project_id,  # ty:ignore[unresolved-attribute]
         virtual_lab_id=db_client.project_context.virtual_lab_id,  # ty:ignore[unresolved-attribute, invalid-argument-type]
+        compute_cell=compute_cell,
         force=force,
     )
 
@@ -357,6 +362,7 @@ def generate_assets_endpoint(
     circuit_id: UUID,
     ls_client: LaunchSystemClientDep,
     db_client: Annotated[entitysdk.client.Client, Depends(get_client)],
+    compute_cell: ComputeCellDep,
     force: bool = False,  # ruff: ignore[boolean-type-hint-positional-argument, boolean-default-value-positional-argument]
 ) -> dict:
     """Trigger asset generation for an active circuit.
@@ -388,6 +394,7 @@ def generate_assets_endpoint(
         circuit_id=circuit_id,
         project_id=db_client.project_context.project_id,  # ty:ignore[unresolved-attribute]
         virtual_lab_id=db_client.project_context.virtual_lab_id,  # ty:ignore[unresolved-attribute, invalid-argument-type]
+        compute_cell=compute_cell,
         force=force,
     )
 

--- a/obi_one/db_sdk/registration/circuit/launch_jobs.py
+++ b/obi_one/db_sdk/registration/circuit/launch_jobs.py
@@ -24,6 +24,7 @@ def submit_circuit_validation_job(
     project_id: UUID,
     virtual_lab_id: UUID,
     api_url: str,
+    compute_cell: str,
     obi_one_repo: str = DEFAULT_OBI_ONE_REPO,
     app_version: str | None = None,
     force: bool = False,
@@ -40,6 +41,7 @@ def submit_circuit_validation_job(
         project_id: Project ID for the job.
         virtual_lab_id: Virtual lab ID for the job.
         api_url: Base URL of the obi-one API (for the generate-assets callback).
+        compute_cell: Compute cell for the launch-system job (from the vlab).
         obi_one_repo: Git repository URL for the launch script checkout.
         app_version: App version used to form ``tag:<version>``; defaults to ``0.0.0``.
         force: When True, validate even if the circuit is not in ``draft`` status.
@@ -69,7 +71,7 @@ def submit_circuit_validation_job(
             "cores": 1,
             "memory": 8,
             "timelimit": "00:30",
-            "compute_cell": "local",
+            "compute_cell": compute_cell,
         },
         "inputs": [
             f"--circuit_id {circuit_id}",
@@ -96,6 +98,7 @@ def submit_circuit_asset_generation_job(
     circuit_id: UUID,
     project_id: UUID,
     virtual_lab_id: UUID,
+    compute_cell: str,
     obi_one_repo: str = DEFAULT_OBI_ONE_REPO,
     app_version: str | None = None,
     force: bool = False,
@@ -110,6 +113,7 @@ def submit_circuit_asset_generation_job(
         circuit_id: Circuit entity ID to generate assets for.
         project_id: Project ID for the job.
         virtual_lab_id: Virtual lab ID for the job.
+        compute_cell: Compute cell for the launch-system job (from the vlab).
         obi_one_repo: Git repository URL for the launch script checkout.
         app_version: App version used to form ``tag:<version>``; defaults to ``0.0.0``.
         force: When True, regenerate compressed archive even if it already exists.
@@ -130,7 +134,7 @@ def submit_circuit_asset_generation_job(
             "cores": 1,
             "memory": 16,
             "timelimit": "01:00",
-            "compute_cell": "local",
+            "compute_cell": compute_cell,
         },
         "inputs": [
             f"--circuit_id {circuit_id}",

--- a/tests/app/endpoints/test_circuit_registration.py
+++ b/tests/app/endpoints/test_circuit_registration.py
@@ -65,6 +65,7 @@ class TestTriggerValidationTask:
             circuit_id=circuit_id,
             project_id=project_id,
             virtual_lab_id=virtual_lab_id,
+            compute_cell="cell_a",
         )
 
         ls_client.post.assert_called_once()
@@ -73,6 +74,7 @@ class TestTriggerValidationTask:
         job_data = call_kwargs["json"]
         assert job_data["code"]["ref"] == "tag:1.2.3"
         assert job_data["resources"]["image_type"] == "python_3_12_openmpi5_neuron9_neurodamus"
+        assert job_data["resources"]["compute_cell"] == "cell_a"
         assert f"--circuit_id {circuit_id}" in job_data["inputs"]
         assert "--force false" in job_data["inputs"]
         assert str(project_id) == job_data["project_id"]
@@ -93,11 +95,13 @@ class TestTriggerValidationTask:
             circuit_id=uuid4(),
             project_id=uuid4(),
             virtual_lab_id=uuid4(),
+            compute_cell="cell_b",
             force=True,
         )
 
         job_data = ls_client.post.call_args[1]["json"]
         assert "--force true" in job_data["inputs"]
+        assert job_data["resources"]["compute_cell"] == "cell_b"
 
     @patch("app.endpoints.circuit_helpers.settings")
     def test_failure_logs_warning(self, mock_settings):
@@ -116,6 +120,7 @@ class TestTriggerValidationTask:
             circuit_id=uuid4(),
             project_id=uuid4(),
             virtual_lab_id=uuid4(),
+            compute_cell="cell_a",
         )
         ls_client.post.assert_called_once()
         assert ls_client.post.call_args[1]["json"]["code"]["ref"] == "tag:0.0.0"
@@ -136,11 +141,15 @@ class TestValidateCircuitEndpoint:
         mock_circuit.lifecycle_status = "active"
 
         from app.application import app  # ruff: ignore[import-outside-top-level]
+        from app.dependencies.compute_cell import (  # ruff: ignore[import-outside-top-level]
+            get_compute_cell,
+        )
         from app.dependencies.entitysdk import get_client  # ruff: ignore[import-outside-top-level]
 
         mock_db = MagicMock()
         mock_db.get_entity.return_value = mock_circuit
         app.dependency_overrides[get_client] = lambda: mock_db
+        app.dependency_overrides[get_compute_cell] = lambda: "cell_a"
 
         try:
             resp = client.post(f"/declared/circuit/{circuit_id}/validate")
@@ -148,6 +157,7 @@ class TestValidateCircuitEndpoint:
             assert "force=true" in resp.json()["detail"]
         finally:
             app.dependency_overrides.pop(get_client, None)
+            app.dependency_overrides.pop(get_compute_cell, None)
 
     @patch("app.endpoints.circuit_registration.trigger_validation_task")
     def test_force_triggers_validation(self, mock_trigger, client):
@@ -156,6 +166,9 @@ class TestValidateCircuitEndpoint:
         mock_circuit.lifecycle_status = "active"
 
         from app.application import app  # ruff: ignore[import-outside-top-level]
+        from app.dependencies.compute_cell import (  # ruff: ignore[import-outside-top-level]
+            get_compute_cell,
+        )
         from app.dependencies.entitysdk import get_client  # ruff: ignore[import-outside-top-level]
 
         mock_db = MagicMock()
@@ -163,6 +176,7 @@ class TestValidateCircuitEndpoint:
         mock_db.project_context.project_id = uuid4()
         mock_db.project_context.virtual_lab_id = uuid4()
         app.dependency_overrides[get_client] = lambda: mock_db
+        app.dependency_overrides[get_compute_cell] = lambda: "cell_a"
 
         try:
             resp = client.post(f"/declared/circuit/{circuit_id}/validate?force=true")
@@ -170,8 +184,10 @@ class TestValidateCircuitEndpoint:
             assert resp.json()["status"] == "validation_triggered"
             mock_trigger.assert_called_once()
             assert mock_trigger.call_args.kwargs["force"] is True
+            assert mock_trigger.call_args.kwargs["compute_cell"] == "cell_a"
         finally:
             app.dependency_overrides.pop(get_client, None)
+            app.dependency_overrides.pop(get_compute_cell, None)
 
     @patch("app.endpoints.circuit_registration.trigger_validation_task")
     def test_draft_triggers_without_force(self, mock_trigger, client):
@@ -180,6 +196,9 @@ class TestValidateCircuitEndpoint:
         mock_circuit.lifecycle_status = "draft"
 
         from app.application import app  # ruff: ignore[import-outside-top-level]
+        from app.dependencies.compute_cell import (  # ruff: ignore[import-outside-top-level]
+            get_compute_cell,
+        )
         from app.dependencies.entitysdk import get_client  # ruff: ignore[import-outside-top-level]
 
         mock_db = MagicMock()
@@ -187,14 +206,17 @@ class TestValidateCircuitEndpoint:
         mock_db.project_context.project_id = uuid4()
         mock_db.project_context.virtual_lab_id = uuid4()
         app.dependency_overrides[get_client] = lambda: mock_db
+        app.dependency_overrides[get_compute_cell] = lambda: "cell_b"
 
         try:
             resp = client.post(f"/declared/circuit/{circuit_id}/validate")
             assert resp.status_code == 200
             mock_trigger.assert_called_once()
             assert mock_trigger.call_args.kwargs["force"] is False
+            assert mock_trigger.call_args.kwargs["compute_cell"] == "cell_b"
         finally:
             app.dependency_overrides.pop(get_client, None)
+            app.dependency_overrides.pop(get_compute_cell, None)
 
 
 class TestTriggerAssetGenerationTask:
@@ -217,12 +239,14 @@ class TestTriggerAssetGenerationTask:
             circuit_id=circuit_id,
             project_id=project_id,
             virtual_lab_id=virtual_lab_id,
+            compute_cell="cell_a",
         )
 
         ls_client.post.assert_called_once()
         call_kwargs = ls_client.post.call_args[1]
         job_data = call_kwargs["json"]
         assert "tag:1.2.3" in job_data["code"]["ref"]
+        assert job_data["resources"]["compute_cell"] == "cell_a"
         assert f"--circuit_id {circuit_id}" in job_data["inputs"]
         assert "--force false" in job_data["inputs"]
 
@@ -241,11 +265,13 @@ class TestTriggerAssetGenerationTask:
             circuit_id=uuid4(),
             project_id=uuid4(),
             virtual_lab_id=uuid4(),
+            compute_cell="cell_b",
             force=True,
         )
 
         job_data = ls_client.post.call_args[1]["json"]
         assert "--force true" in job_data["inputs"]
+        assert job_data["resources"]["compute_cell"] == "cell_b"
 
     @patch("app.endpoints.circuit_helpers.settings")
     def test_none_app_version(self, mock_settings):
@@ -262,6 +288,7 @@ class TestTriggerAssetGenerationTask:
             circuit_id=uuid4(),
             project_id=uuid4(),
             virtual_lab_id=uuid4(),
+            compute_cell="cell_a",
         )
 
         call_kwargs = ls_client.post.call_args[1]
@@ -284,6 +311,7 @@ class TestTriggerAssetGenerationTask:
             circuit_id=uuid4(),
             project_id=uuid4(),
             virtual_lab_id=uuid4(),
+            compute_cell="cell_a",
         )
         ls_client.post.assert_called_once()
 
@@ -311,11 +339,15 @@ class TestGenerateAssetsEndpoint:
             mock_get_client.return_value = mock_db
 
             from app.application import app  # ruff: ignore[import-outside-top-level]
+            from app.dependencies.compute_cell import (  # ruff: ignore[import-outside-top-level]
+                get_compute_cell,
+            )
             from app.dependencies.entitysdk import (  # ruff: ignore[import-outside-top-level]
                 get_client,
             )
 
             app.dependency_overrides[get_client] = lambda: mock_db
+            app.dependency_overrides[get_compute_cell] = lambda: "cell_a"
 
             try:
                 resp = client.post(f"/declared/circuit/{circuit_id}/generate-assets")
@@ -323,6 +355,7 @@ class TestGenerateAssetsEndpoint:
                 assert "lifecycle_status" in resp.json()["detail"]
             finally:
                 app.dependency_overrides.pop(get_client, None)
+                app.dependency_overrides.pop(get_compute_cell, None)
 
     def test_returns_already_exists(self, client):
         """If assets already exist and not force, returns message."""
@@ -339,11 +372,15 @@ class TestGenerateAssetsEndpoint:
         mock_circuit.assets = [asset1, asset2]
 
         from app.application import app  # ruff: ignore[import-outside-top-level]
+        from app.dependencies.compute_cell import (  # ruff: ignore[import-outside-top-level]
+            get_compute_cell,
+        )
         from app.dependencies.entitysdk import get_client  # ruff: ignore[import-outside-top-level]
 
         mock_db = MagicMock()
         mock_db.get_entity.return_value = mock_circuit
         app.dependency_overrides[get_client] = lambda: mock_db
+        app.dependency_overrides[get_compute_cell] = lambda: "cell_a"
 
         try:
             resp = client.post(f"/declared/circuit/{circuit_id}/generate-assets")
@@ -351,6 +388,7 @@ class TestGenerateAssetsEndpoint:
             assert "already exist" in resp.json()["message"]
         finally:
             app.dependency_overrides.pop(get_client, None)
+            app.dependency_overrides.pop(get_compute_cell, None)
 
 
 class TestRegisterCircuitEndpoint:
@@ -398,6 +436,7 @@ class TestRegisterCircuitEndpoint:
         result = register_circuit_endpoint(
             ls_client=MagicMock(),
             db_client=mock_db_client,
+            compute_cell="cell_a",
             name="test-circuit",
             description="A test circuit",
             brain_region_id=uuid4(),
@@ -430,6 +469,7 @@ class TestRegisterCircuitEndpoint:
         assert result["status"] == "draft"
         assert result["number_neurons"] == 1000
         mock_trigger_validation.assert_called_once()
+        assert mock_trigger_validation.call_args.kwargs["compute_cell"] == "cell_a"
 
     @patch("app.endpoints.circuit_registration.trigger_validation_task")
     @patch("app.endpoints.circuit_registration.register_circuit")
@@ -452,6 +492,7 @@ class TestRegisterCircuitEndpoint:
         result = register_circuit_endpoint(
             ls_client=MagicMock(),
             db_client=mock_db_client,
+            compute_cell="cell_a",
             name="dry-run-circuit",
             description="A dry run",
             brain_region_id=uuid4(),
@@ -506,6 +547,7 @@ class TestRegisterCircuitEndpoint:
             result = register_circuit_endpoint(
                 ls_client=MagicMock(),
                 db_client=mock_db_client,
+                compute_cell="cell_a",
                 name="test-circuit",
                 description="A test circuit",
                 brain_region_id=uuid4(),
@@ -545,6 +587,7 @@ class TestRegisterCircuitEndpoint:
             register_circuit_endpoint(
                 ls_client=MagicMock(),
                 db_client=MagicMock(),
+                compute_cell="cell_a",
                 name="test-circuit",
                 description="A test circuit",
                 brain_region_id=uuid4(),
@@ -581,6 +624,7 @@ class TestRegisterCircuitEndpoint:
             register_circuit_endpoint(
                 ls_client=MagicMock(),
                 db_client=mock_db_client,
+                compute_cell="cell_a",
                 name="test-circuit",
                 description="A test circuit",
                 brain_region_id=uuid4(),
@@ -601,6 +645,7 @@ class TestRegisterCircuitEndpoint:
             register_circuit_endpoint(
                 ls_client=MagicMock(),
                 db_client=MagicMock(),
+                compute_cell="cell_a",
                 name="test-circuit",
                 description="A test circuit",
                 brain_region_id=uuid4(),
@@ -625,6 +670,7 @@ class TestRegisterCircuitEndpoint:
             register_circuit_endpoint(
                 ls_client=MagicMock(),
                 db_client=mock_db_client,
+                compute_cell="cell_a",
                 name="test-circuit",
                 description="A test circuit",
                 brain_region_id=uuid4(),

--- a/tests/obi_one/db_sdk/registration/circuit/test_launch_jobs.py
+++ b/tests/obi_one/db_sdk/registration/circuit/test_launch_jobs.py
@@ -54,6 +54,7 @@ class TestSubmitCircuitJobs:
                 project_id=project_id,
                 virtual_lab_id=virtual_lab_id,
                 api_url="http://localhost:8100",
+                compute_cell="cell_a",
                 obi_one_repo="https://github.com/org/repo.git",
                 app_version="1.2.3-dev",
                 force=True,
@@ -64,6 +65,7 @@ class TestSubmitCircuitJobs:
         job = ls_client.post.call_args[1]["json"]
         assert job["code"]["ref"] == "tag:1.2.3"
         assert job["resources"]["image_type"] == "python_3_12_openmpi5_neuron9_neurodamus"
+        assert job["resources"]["compute_cell"] == "cell_a"
         assert f"--circuit_id {circuit_id}" in job["inputs"]
         assert "--force true" in job["inputs"]
         assert job["callbacks"][0]["config"]["url"].endswith(
@@ -83,6 +85,7 @@ class TestSubmitCircuitJobs:
                 circuit_id=circuit_id,
                 project_id=project_id,
                 virtual_lab_id=virtual_lab_id,
+                compute_cell="cell_b",
                 obi_one_repo="https://github.com/org/repo.git",
                 app_version="9.9.9",
                 force=False,
@@ -93,6 +96,7 @@ class TestSubmitCircuitJobs:
         job = ls_client.post.call_args[1]["json"]
         assert job["code"]["ref"] == "tag:9.9.9"
         assert "launch_circuit_asset_generation" in job["code"]["path"]
+        assert job["resources"]["compute_cell"] == "cell_b"
         assert f"--circuit_id {circuit_id}" in job["inputs"]
         assert "--force false" in job["inputs"]
         assert job["callbacks"] == []


### PR DESCRIPTION
## Summary
- Circuit validation and asset-generation launch jobs were hardcoding `compute_cell: "local"`, which fails on staging/prod launch-system.
- Wire `ComputeCellDep` through register/validate/generate-assets endpoints into the job payloads (same pattern as mesh registration).

## Test plan
- [ ] `make test-file FILE=tests/app/endpoints/test_circuit_registration.py`
- [ ] `make test-file FILE=tests/obi_one/db_sdk/registration/circuit/test_launch_jobs.py`
- [ ] On staging, register a circuit and confirm the validation job runs with the vlab compute cell (e.g. `cell_a` / `cell_b`), not `local`


Made with [Cursor](https://cursor.com)