### PR TITLE
Add lint to launch_scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ format:  ## Run formatters
 lint:  ## Run linters
 	uv run -m ruff format --check
 	uv run -m ruff check
-	uv run --with ty ty check app obi_one
+	uv run --with ty ty check
 
 format_count: ## Count the number of errors by file
 	uv run -m ruff check --output-format=json | jq '.[].filename' | sort | uniq -c

--- a/launch_scripts/launch_circuit_asset_generation/main.py
+++ b/launch_scripts/launch_circuit_asset_generation/main.py
@@ -35,7 +35,7 @@ def main() -> int:
     deployment = os.getenv("DEPLOYMENT")
     local_store_prefix = os.getenv("LOCAL_STORE_PREFIX")
 
-    try:
+    try:  # ruff: ignore[too-many-statements-in-try-clause]
         parser = argparse.ArgumentParser(description="Generate circuit assets.")
         parser.add_argument("--circuit_id", required=True, help="Circuit entity ID")
         parser.add_argument("--virtual_lab_id", required=True, help="Virtual lab ID")
@@ -53,21 +53,21 @@ def main() -> int:
         token_manager = TokenFromFunction(
             partial(
                 get_token,
-                environment=deployment,
-                auth_mode="persistent_token",
+                environment=deployment,  # ty:ignore[invalid-argument-type]
+                auth_mode="persistent_token",  # ty:ignore[invalid-argument-type]
                 persistent_token_id=persistent_token_id,
             ),
         )
         project_context = ProjectContext(
             project_id=args.project_id,
             virtual_lab_id=args.virtual_lab_id,
-            environment=deployment,
+            environment=deployment,  # ty:ignore[unknown-argument]
         )
         db_client = Client(
             environment=deployment,
             project_context=project_context,
             token_manager=token_manager,
-            local_store=LocalAssetStore(prefix=local_store_prefix),
+            local_store=LocalAssetStore(prefix=local_store_prefix),  # ty:ignore[invalid-argument-type]
         )
 
         circuit = db_client.get_entity(entity_id=circuit_id, entity_type=models.Circuit)
@@ -78,10 +78,14 @@ def main() -> int:
             circuit_config_path = stage_circuit(db_client, model=circuit, output_dir=staged_dir)
 
             # Determine edge population for matrix extraction
-            from obi_one.scientific.library.circuit import Circuit as OBICircuit
+            from obi_one.scientific.library.circuit import (  # ruff: ignore[import-outside-top-level]
+                Circuit as OBICircuit,
+            )
 
-            c = OBICircuit(name=circuit.name, path=str(circuit_config_path))
-            edge_pop = c.default_edge_population_name if c.sonata_circuit.edges.population_names else None
+            c = OBICircuit(name=circuit.name, path=str(circuit_config_path))  # ty:ignore[invalid-argument-type]
+            edge_pop = (
+                c.default_edge_population_name if c.sonata_circuit.edges.population_names else None
+            )
 
             generate_additional_circuit_assets(
                 circuit_path=circuit_config_path,
@@ -94,7 +98,7 @@ def main() -> int:
 
         L.info("Asset generation complete for circuit %s", circuit_id)
 
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:  # ruff: ignore[blind-except]
         L.exception("Asset generation failed: %s", e)
         return 1
 

--- a/launch_scripts/launch_circuit_asset_generation/main.py
+++ b/launch_scripts/launch_circuit_asset_generation/main.py
@@ -68,7 +68,7 @@ def main() -> int:
             token_manager=token_manager,
             local_store=None
             if local_store_prefix is None
-            else LocalAssetStore(prefix=local_store_prefix),
+            else LocalAssetStore(prefix=Path(local_store_prefix)),
         )
 
         circuit = db_client.get_entity(entity_id=UUID(args.circuit_id), entity_type=models.Circuit)

--- a/launch_scripts/launch_circuit_asset_generation/main.py
+++ b/launch_scripts/launch_circuit_asset_generation/main.py
@@ -61,7 +61,6 @@ def main() -> int:
         project_context = ProjectContext(
             project_id=args.project_id,
             virtual_lab_id=args.virtual_lab_id,
-            environment=deployment,  # ty:ignore[unknown-argument]
         )
         db_client = Client(
             environment=deployment,

--- a/launch_scripts/launch_circuit_asset_generation/main.py
+++ b/launch_scripts/launch_circuit_asset_generation/main.py
@@ -54,7 +54,7 @@ def main() -> int:
             partial(
                 get_token,
                 environment=DeploymentEnvironment(deployment),
-                auth_mode=AuthMode("persistent_token"),
+                auth_mode=AuthMode.persistent_token,
                 persistent_token_id=persistent_token_id,
             ),
         )

--- a/launch_scripts/launch_circuit_asset_generation/main.py
+++ b/launch_scripts/launch_circuit_asset_generation/main.py
@@ -27,6 +27,7 @@ from obi_auth import get_token
 from obi_auth.typedef import AuthMode, DeploymentEnvironment
 
 from obi_one.db_sdk.registration.circuit.generate import generate_additional_circuit_assets
+from obi_one.scientific.library.circuit import Circuit as OBICircuit
 
 L = logging.getLogger(__name__)
 
@@ -79,10 +80,6 @@ def main() -> int:
             circuit_config_path = stage_circuit(db_client, model=circuit, output_dir=staged_dir)
 
             # Determine edge population for matrix extraction
-            from obi_one.scientific.library.circuit import (  # ruff: ignore[import-outside-top-level]
-                Circuit as OBICircuit,
-            )
-
             c = OBICircuit(name=str(circuit.name), path=str(circuit_config_path))
             edge_pop = (
                 c.default_edge_population_name if c.sonata_circuit.edges.population_names else None

--- a/launch_scripts/launch_circuit_asset_generation/main.py
+++ b/launch_scripts/launch_circuit_asset_generation/main.py
@@ -24,6 +24,7 @@ from entitysdk import Client, LocalAssetStore, ProjectContext, models
 from entitysdk.staging.circuit import stage_circuit
 from entitysdk.token_manager import TokenFromFunction
 from obi_auth import get_token
+from obi_auth.typedef import AuthMode, DeploymentEnvironment
 
 from obi_one.db_sdk.registration.circuit.generate import generate_additional_circuit_assets
 
@@ -35,26 +36,25 @@ def main() -> int:
     deployment = os.getenv("DEPLOYMENT")
     local_store_prefix = os.getenv("LOCAL_STORE_PREFIX")
 
-    try:  # ruff: ignore[too-many-statements-in-try-clause]
-        parser = argparse.ArgumentParser(description="Generate circuit assets.")
-        parser.add_argument("--circuit_id", required=True, help="Circuit entity ID")
-        parser.add_argument("--virtual_lab_id", required=True, help="Virtual lab ID")
-        parser.add_argument("--project_id", required=True, help="Project ID")
-        parser.add_argument(
-            "--force",
-            type=lambda value: str(value).lower() == "true",
-            default=False,
-            help="Regenerate compressed archive even if it already exists",
-        )
-        args = parser.parse_args()
+    parser = argparse.ArgumentParser(description="Generate circuit assets.")
+    parser.add_argument("--circuit_id", required=True, help="Circuit entity ID")
+    parser.add_argument("--virtual_lab_id", required=True, help="Virtual lab ID")
+    parser.add_argument("--project_id", required=True, help="Project ID")
+    parser.add_argument(
+        "--force",
+        type=lambda value: str(value).lower() == "true",
+        default=False,
+        help="Regenerate compressed archive even if it already exists",
+    )
 
-        circuit_id = UUID(args.circuit_id)
+    try:  # ruff: ignore[too-many-statements-in-try-clause]
+        args = parser.parse_args()
 
         token_manager = TokenFromFunction(
             partial(
                 get_token,
-                environment=deployment,  # ty:ignore[invalid-argument-type]
-                auth_mode="persistent_token",  # ty:ignore[invalid-argument-type]
+                environment=DeploymentEnvironment(deployment),
+                auth_mode=AuthMode("persistent_token"),
                 persistent_token_id=persistent_token_id,
             ),
         )
@@ -66,10 +66,12 @@ def main() -> int:
             environment=deployment,
             project_context=project_context,
             token_manager=token_manager,
-            local_store=LocalAssetStore(prefix=local_store_prefix),  # ty:ignore[invalid-argument-type]
+            local_store=None
+            if local_store_prefix is None
+            else LocalAssetStore(prefix=local_store_prefix),
         )
 
-        circuit = db_client.get_entity(entity_id=circuit_id, entity_type=models.Circuit)
+        circuit = db_client.get_entity(entity_id=UUID(args.circuit_id), entity_type=models.Circuit)
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             staged_dir = Path(tmp_dir) / "circuit"
@@ -81,7 +83,7 @@ def main() -> int:
                 Circuit as OBICircuit,
             )
 
-            c = OBICircuit(name=circuit.name, path=str(circuit_config_path))  # ty:ignore[invalid-argument-type]
+            c = OBICircuit(name=str(circuit.name), path=str(circuit_config_path))
             edge_pop = (
                 c.default_edge_population_name if c.sonata_circuit.edges.population_names else None
             )
@@ -95,7 +97,7 @@ def main() -> int:
                 include_visualization=False,
             )
 
-        L.info("Asset generation complete for circuit %s", circuit_id)
+        L.info("Asset generation complete for circuit %s", UUID(args.circuit_id))
 
     except Exception as e:  # ruff: ignore[blind-except]
         L.exception("Asset generation failed: %s", e)

--- a/launch_scripts/launch_circuit_validation/main.py
+++ b/launch_scripts/launch_circuit_validation/main.py
@@ -63,7 +63,7 @@ def main() -> int:
                 partial(
                     get_token,
                     environment=DeploymentEnvironment(deployment),
-                    auth_mode=AuthMode("persistent_token"),
+                    auth_mode=AuthMode.persistent_token,
                     persistent_token_id=persistent_token_id,
                 ),
             )

--- a/launch_scripts/launch_circuit_validation/main.py
+++ b/launch_scripts/launch_circuit_validation/main.py
@@ -68,7 +68,6 @@ def main() -> int:
         project_context = ProjectContext(
             project_id=args.project_id,
             virtual_lab_id=args.virtual_lab_id,
-            environment=deployment,  # ty:ignore[unknown-argument]
         )
         db_client = Client(
             environment=deployment,

--- a/launch_scripts/launch_circuit_validation/main.py
+++ b/launch_scripts/launch_circuit_validation/main.py
@@ -20,6 +20,7 @@ from uuid import UUID
 from entitysdk import Client, LocalAssetStore, ProjectContext, models
 from entitysdk.token_manager import TokenFromFunction
 from obi_auth import get_token
+from obi_auth.typedef import AuthMode, DeploymentEnvironment
 
 from obi_one.db_sdk.registration.circuit.lifecycle import is_validation_allowed
 from obi_one.scientific.tasks.circuit_validation.task import (
@@ -60,8 +61,8 @@ def main() -> int:
             token_manager = TokenFromFunction(
                 partial(
                     get_token,
-                    environment=deployment,  # ty:ignore[invalid-argument-type]
-                    auth_mode="persistent_token",  # ty:ignore[invalid-argument-type]
+                    environment=DeploymentEnvironment(deployment),
+                    auth_mode=AuthMode("persistent_token"),
                     persistent_token_id=persistent_token_id,
                 ),
             )
@@ -73,7 +74,9 @@ def main() -> int:
             environment=deployment,
             project_context=project_context,
             token_manager=token_manager,
-            local_store=LocalAssetStore(prefix=local_store_prefix),  # ty:ignore[invalid-argument-type]
+            local_store=None
+            if local_store_prefix is None
+            else LocalAssetStore(prefix=local_store_prefix),
         )
 
         circuit = db_client.get_entity(entity_id=circuit_id, entity_type=models.Circuit)

--- a/launch_scripts/launch_circuit_validation/main.py
+++ b/launch_scripts/launch_circuit_validation/main.py
@@ -1,4 +1,3 @@
-# ruff: file-ignore[implicit-namespace-package]
 """Launch script for circuit validation task.
 
 Runs on the launch-system with image ``python_3_12_openmpi5_neuron9_neurodamus``.
@@ -61,21 +60,21 @@ def main() -> int:
             token_manager = TokenFromFunction(
                 partial(
                     get_token,
-                    environment=deployment,
-                    auth_mode="persistent_token",
+                    environment=deployment,  # ty:ignore[invalid-argument-type]
+                    auth_mode="persistent_token",  # ty:ignore[invalid-argument-type]
                     persistent_token_id=persistent_token_id,
                 ),
             )
         project_context = ProjectContext(
             project_id=args.project_id,
             virtual_lab_id=args.virtual_lab_id,
-            environment=deployment,
+            environment=deployment,  # ty:ignore[unknown-argument]
         )
         db_client = Client(
             environment=deployment,
             project_context=project_context,
             token_manager=token_manager,
-            local_store=LocalAssetStore(prefix=local_store_prefix),
+            local_store=LocalAssetStore(prefix=local_store_prefix),  # ty:ignore[invalid-argument-type]
         )
 
         circuit = db_client.get_entity(entity_id=circuit_id, entity_type=models.Circuit)

--- a/launch_scripts/launch_circuit_validation/main.py
+++ b/launch_scripts/launch_circuit_validation/main.py
@@ -15,6 +15,7 @@ import logging
 import os
 import sys
 from functools import partial
+from pathlib import Path
 from uuid import UUID
 
 from entitysdk import Client, LocalAssetStore, ProjectContext, models
@@ -76,7 +77,7 @@ def main() -> int:
             token_manager=token_manager,
             local_store=None
             if local_store_prefix is None
-            else LocalAssetStore(prefix=local_store_prefix),
+            else LocalAssetStore(prefix=Path(local_store_prefix)),
         )
 
         circuit = db_client.get_entity(entity_id=circuit_id, entity_type=models.Circuit)

--- a/launch_scripts/launch_mesh_lod_generation/main.py
+++ b/launch_scripts/launch_mesh_lod_generation/main.py
@@ -58,7 +58,6 @@ def main() -> int:
         project_context = ProjectContext(
             project_id=args.project_id,
             virtual_lab_id=args.virtual_lab_id,
-            environment=deployment,  # ty:ignore[unknown-argument]
         )
         db_client = Client(
             environment=deployment,

--- a/launch_scripts/launch_mesh_lod_generation/main.py
+++ b/launch_scripts/launch_mesh_lod_generation/main.py
@@ -21,6 +21,7 @@ from entitysdk import Client, LocalAssetStore, ProjectContext
 from entitysdk.config import settings as entitysdk_settings
 from entitysdk.token_manager import TokenFromFunction
 from obi_auth import get_token
+from obi_auth.typedef import AuthMode, DeploymentEnvironment
 
 from obi_one.scientific.tasks.mesh_lod_generation.config import MeshLodGenerationSingleConfig
 from obi_one.scientific.tasks.mesh_lod_generation.task import MeshLODGenerationTask
@@ -50,8 +51,8 @@ def main() -> int:
         token_manager = TokenFromFunction(
             partial(
                 get_token,
-                environment=deployment,  # ty:ignore[invalid-argument-type]
-                auth_mode="persistent_token",  # ty:ignore[invalid-argument-type]
+                environment=DeploymentEnvironment(deployment),
+                auth_mode=AuthMode.persistent_token,
                 persistent_token_id=persistent_token_id,
             ),
         )

--- a/launch_scripts/launch_mesh_lod_generation/main.py
+++ b/launch_scripts/launch_mesh_lod_generation/main.py
@@ -38,7 +38,7 @@ def main() -> int:
     deployment = os.getenv("DEPLOYMENT")
     local_store_prefix = os.getenv("LOCAL_STORE_PREFIX")
 
-    try:
+    try:  # ruff: ignore[too-many-statements-in-try-clause]
         parser = argparse.ArgumentParser(description="Generate LOD meshes for an EMCellMesh asset.")
         parser.add_argument("--entity_id", required=True, help="EMCellMesh entity ID")
         parser.add_argument("--mesh_asset_id", required=True, help="Source mesh asset ID")
@@ -50,21 +50,21 @@ def main() -> int:
         token_manager = TokenFromFunction(
             partial(
                 get_token,
-                environment=deployment,
-                auth_mode="persistent_token",
+                environment=deployment,  # ty:ignore[invalid-argument-type]
+                auth_mode="persistent_token",  # ty:ignore[invalid-argument-type]
                 persistent_token_id=persistent_token_id,
             ),
         )
         project_context = ProjectContext(
             project_id=args.project_id,
             virtual_lab_id=args.virtual_lab_id,
-            environment=deployment,
+            environment=deployment,  # ty:ignore[unknown-argument]
         )
         db_client = Client(
             environment=deployment,
             project_context=project_context,
             token_manager=token_manager,
-            local_store=LocalAssetStore(prefix=local_store_prefix),
+            local_store=LocalAssetStore(prefix=local_store_prefix),  # ty:ignore[invalid-argument-type]
         )
 
         config = MeshLodGenerationSingleConfig(
@@ -77,7 +77,7 @@ def main() -> int:
 
         L.info("LOD generation complete for entity %s", args.entity_id)
 
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:  # ruff: ignore[blind-except]
         L.exception("Mesh LOD generation failed: %s", e)
         return 1
 

--- a/launch_scripts/launch_mesh_lod_generation/main.py
+++ b/launch_scripts/launch_mesh_lod_generation/main.py
@@ -15,6 +15,7 @@ import logging
 import os
 import sys
 from functools import partial
+from pathlib import Path
 from uuid import UUID
 
 from entitysdk import Client, LocalAssetStore, ProjectContext
@@ -64,7 +65,9 @@ def main() -> int:
             environment=deployment,
             project_context=project_context,
             token_manager=token_manager,
-            local_store=LocalAssetStore(prefix=local_store_prefix),  # ty:ignore[invalid-argument-type]
+            local_store=None
+            if local_store_prefix is None
+            else LocalAssetStore(prefix=Path(local_store_prefix)),
         )
 
         config = MeshLodGenerationSingleConfig(

--- a/launch_scripts/launch_task_for_single_config_asset/main.py
+++ b/launch_scripts/launch_task_for_single_config_asset/main.py
@@ -5,12 +5,12 @@ import sys
 from functools import partial
 
 from entitysdk import Client, LocalAssetStore, ProjectContext, models
-from entitysdk.types import ActivityStatus
 from entitysdk.token_manager import TokenFromFunction
+from entitysdk.types import ActivityStatus
 from obi_auth import get_token
 
 from obi_one.core.run_tasks import run_task_type
-from obi_one.db_sdk.db_sdk import update_activity_status, finalize_activity
+from obi_one.db_sdk.db_sdk import finalize_activity, update_activity_status
 
 L = logging.getLogger(__name__)
 
@@ -40,12 +40,14 @@ def main() -> int:
     local_store_prefix = os.getenv("LOCAL_STORE_PREFIX")
     db_client = None
 
-    try:
+    try:  # ruff: ignore[too-many-statements-in-try-clause]
         parser = argparse.ArgumentParser(
             description="Script to launch a task for a single configuration asset."
         )
         parser.add_argument("--task-type", required=True, help="Task type")
-        parser.add_argument("--config_entity_type", required=False, help="EntitySDK entity type as string")
+        parser.add_argument(
+            "--config_entity_type", required=False, help="EntitySDK entity type as string"
+        )
         parser.add_argument("--config_entity_id", required=True, help="Entity ID as string")
         parser.add_argument(
             "--execution_activity_type",
@@ -76,7 +78,7 @@ def main() -> int:
         L.error(f"Argument parsing error: {e}")
         return 1
 
-    try:
+    try:  # ruff: ignore[too-many-statements-in-try-clause]
         # TODO: Remove once legacy tasks are moved to generic configs/activities
         if args.config_entity_type:
             config_entity_type = getattr(models, args.config_entity_type)
@@ -89,19 +91,21 @@ def main() -> int:
         token_manager = TokenFromFunction(
             partial(
                 get_token,
-                environment=deployment,
-                auth_mode="persistent_token",
+                environment=deployment,  # ty:ignore[invalid-argument-type]
+                auth_mode="persistent_token",  # ty:ignore[invalid-argument-type]
                 persistent_token_id=persistent_token_id,
             ),
         )
         project_context = ProjectContext(
-            project_id=args.project_id, virtual_lab_id=args.virtual_lab_id, environment=deployment
+            project_id=args.project_id,
+            virtual_lab_id=args.virtual_lab_id,
+            environment=deployment,  # ty:ignore[unknown-argument]
         )
         db_client = Client(
             environment=deployment,
             project_context=project_context,
             token_manager=token_manager,
-            local_store=LocalAssetStore(prefix=local_store_prefix),
+            local_store=LocalAssetStore(prefix=local_store_prefix),  # ty:ignore[invalid-argument-type]
         )
         update_activity_status(
             client=db_client,
@@ -118,11 +122,11 @@ def main() -> int:
             entity_cache=args.entity_cache,
             execution_activity_id=args.execution_activity_id,
         )
-    except Exception as e:  # noqa: BLE001
+    except Exception as e:  # ruff: ignore[blind-except]
         # Catch any error that may occur to make sure that error status is correctly set
         L.exception(f"Error launching task for single configuration asset: {e}")
         finalize_activity(
-            client=db_client,
+            client=db_client,  # ty:ignore[invalid-argument-type]
             activity_id=args.execution_activity_id,
             activity_type=execution_activity_type,
             status=ActivityStatus.error,

--- a/launch_scripts/launch_task_for_single_config_asset/main.py
+++ b/launch_scripts/launch_task_for_single_config_asset/main.py
@@ -8,11 +8,46 @@ from entitysdk import Client, LocalAssetStore, ProjectContext, models
 from entitysdk.token_manager import TokenFromFunction
 from entitysdk.types import ActivityStatus
 from obi_auth import get_token
+from obi_auth.typedef import AuthMode, DeploymentEnvironment
 
 from obi_one.core.run_tasks import run_task_type
 from obi_one.db_sdk.db_sdk import finalize_activity, update_activity_status
 
 L = logging.getLogger(__name__)
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Script to launch a task for a single configuration asset."
+    )
+    parser.add_argument("--task-type", required=True, help="Task type")
+    parser.add_argument(
+        "--config_entity_type", required=False, help="EntitySDK entity type as string"
+    )
+    parser.add_argument("--config_entity_id", required=True, help="Entity ID as string")
+    parser.add_argument(
+        "--execution_activity_type",
+        required=False,
+        help="EntitySDK execution activity type as string",
+    )
+    parser.add_argument(
+        "--execution_activity_id", required=False, help="Execution activity ID as string"
+    )
+    parser.add_argument(
+        "--entity_cache",
+        required=True,
+        help="Boolean flag for campaign entity caching.\
+                Check if enabled for particular EntityFromID types.",
+    )
+    parser.add_argument(
+        "--scan_output_root",
+        required=True,
+        help="scan_output_root as string. The coordinate output root will be relative to this\
+            in a directory named using the idx of the single coordinate config.",
+    )
+    parser.add_argument("--virtual_lab_id", required=True, help="Virtual Lab ID as string")
+    parser.add_argument("--project_id", required=True, help="Project ID as string.")
+    return parser
 
 
 def main() -> int:
@@ -40,40 +75,8 @@ def main() -> int:
     local_store_prefix = os.getenv("LOCAL_STORE_PREFIX")
     db_client = None
 
-    try:  # ruff: ignore[too-many-statements-in-try-clause]
-        parser = argparse.ArgumentParser(
-            description="Script to launch a task for a single configuration asset."
-        )
-        parser.add_argument("--task-type", required=True, help="Task type")
-        parser.add_argument(
-            "--config_entity_type", required=False, help="EntitySDK entity type as string"
-        )
-        parser.add_argument("--config_entity_id", required=True, help="Entity ID as string")
-        parser.add_argument(
-            "--execution_activity_type",
-            required=False,
-            help="EntitySDK execution activity type as string",
-        )
-        parser.add_argument(
-            "--execution_activity_id", required=False, help="Execution activity ID as string"
-        )
-        parser.add_argument(
-            "--entity_cache",
-            required=True,
-            help="Boolean flag for campaign entity caching.\
-                    Check if enabled for particular EntityFromID types.",
-        )
-        parser.add_argument(
-            "--scan_output_root",
-            required=True,
-            help="scan_output_root as string. The coordinate output root will be relative to this\
-                in a directory named using the idx of the single coordinate config.",
-        )
-        parser.add_argument("--virtual_lab_id", required=True, help="Virtual Lab ID as string")
-        parser.add_argument("--project_id", required=True, help="Project ID as string.")
-
-        args = parser.parse_args()
-
+    try:
+        args = get_parser().parse_args()
     except ValueError as e:
         L.error(f"Argument parsing error: {e}")
         return 1
@@ -91,8 +94,8 @@ def main() -> int:
         token_manager = TokenFromFunction(
             partial(
                 get_token,
-                environment=deployment,  # ty:ignore[invalid-argument-type]
-                auth_mode="persistent_token",  # ty:ignore[invalid-argument-type]
+                environment=DeploymentEnvironment(deployment),
+                auth_mode=AuthMode("persistent_token"),
                 persistent_token_id=persistent_token_id,
             ),
         )
@@ -104,7 +107,9 @@ def main() -> int:
             environment=deployment,
             project_context=project_context,
             token_manager=token_manager,
-            local_store=LocalAssetStore(prefix=local_store_prefix),  # ty:ignore[invalid-argument-type]
+            local_store=None
+            if local_store_prefix is None
+            else LocalAssetStore(prefix=local_store_prefix),
         )
         update_activity_status(
             client=db_client,

--- a/launch_scripts/launch_task_for_single_config_asset/main.py
+++ b/launch_scripts/launch_task_for_single_config_asset/main.py
@@ -99,7 +99,6 @@ def main() -> int:
         project_context = ProjectContext(
             project_id=args.project_id,
             virtual_lab_id=args.virtual_lab_id,
-            environment=deployment,  # ty:ignore[unknown-argument]
         )
         db_client = Client(
             environment=deployment,

--- a/launch_scripts/launch_task_for_single_config_asset/main.py
+++ b/launch_scripts/launch_task_for_single_config_asset/main.py
@@ -3,6 +3,7 @@ import logging
 import os
 import sys
 from functools import partial
+from pathlib import Path
 
 from entitysdk import Client, LocalAssetStore, ProjectContext, models
 from entitysdk.token_manager import TokenFromFunction
@@ -109,7 +110,7 @@ def main() -> int:
             token_manager=token_manager,
             local_store=None
             if local_store_prefix is None
-            else LocalAssetStore(prefix=local_store_prefix),
+            else LocalAssetStore(prefix=Path(local_store_prefix)),
         )
         update_activity_status(
             client=db_client,

--- a/launch_scripts/launch_task_for_single_config_asset/main.py
+++ b/launch_scripts/launch_task_for_single_config_asset/main.py
@@ -96,7 +96,7 @@ def main() -> int:
             partial(
                 get_token,
                 environment=DeploymentEnvironment(deployment),
-                auth_mode=AuthMode("persistent_token"),
+                auth_mode=AuthMode.persistent_token,
                 persistent_token_id=persistent_token_id,
             ),
         )

--- a/launch_scripts/launch_task_for_single_config_asset/main.py
+++ b/launch_scripts/launch_task_for_single_config_asset/main.py
@@ -74,7 +74,6 @@ def main() -> int:
     persistent_token_id = os.getenv("PERSISTENT_TOKEN_ID")
     deployment = os.getenv("DEPLOYMENT")
     local_store_prefix = os.getenv("LOCAL_STORE_PREFIX")
-    db_client = None
 
     try:
         args = get_parser().parse_args()
@@ -82,36 +81,37 @@ def main() -> int:
         L.error(f"Argument parsing error: {e}")
         return 1
 
-    try:  # ruff: ignore[too-many-statements-in-try-clause]
-        # TODO: Remove once legacy tasks are moved to generic configs/activities
-        if args.config_entity_type:
-            config_entity_type = getattr(models, args.config_entity_type)
-            execution_activity_type = getattr(models, args.execution_activity_type)
-        else:
-            config_entity_type = models.TaskConfig
-            execution_activity_type = models.TaskActivity
+    if args.config_entity_type:
+        config_entity_type = getattr(models, args.config_entity_type)
+        execution_activity_type = getattr(models, args.execution_activity_type)
+    else:
+        config_entity_type = models.TaskConfig
+        execution_activity_type = models.TaskActivity
 
-        # Get DB client (incl. file mounting)
-        token_manager = TokenFromFunction(
-            partial(
-                get_token,
-                environment=DeploymentEnvironment(deployment),
-                auth_mode=AuthMode.persistent_token,
-                persistent_token_id=persistent_token_id,
-            ),
-        )
-        project_context = ProjectContext(
-            project_id=args.project_id,
-            virtual_lab_id=args.virtual_lab_id,
-        )
-        db_client = Client(
-            environment=deployment,
-            project_context=project_context,
-            token_manager=token_manager,
-            local_store=None
-            if local_store_prefix is None
-            else LocalAssetStore(prefix=Path(local_store_prefix)),
-        )
+    # Get DB client (incl. file mounting)
+    token_manager = TokenFromFunction(
+        partial(
+            get_token,
+            environment=DeploymentEnvironment(deployment),
+            auth_mode=AuthMode.persistent_token,
+            persistent_token_id=persistent_token_id,
+        ),
+    )
+    project_context = ProjectContext(
+        project_id=args.project_id,
+        virtual_lab_id=args.virtual_lab_id,
+    )
+    db_client = Client(
+        environment=deployment,
+        project_context=project_context,
+        token_manager=token_manager,
+        local_store=None
+        if local_store_prefix is None
+        else LocalAssetStore(prefix=Path(local_store_prefix)),
+    )
+
+    try:
+        # TODO: Remove once legacy tasks are moved to generic configs/activities
         update_activity_status(
             client=db_client,
             activity_id=args.execution_activity_id,
@@ -131,7 +131,7 @@ def main() -> int:
         # Catch any error that may occur to make sure that error status is correctly set
         L.exception(f"Error launching task for single configuration asset: {e}")
         finalize_activity(
-            client=db_client,  # ty:ignore[invalid-argument-type]
+            client=db_client,
             activity_id=args.execution_activity_id,
             activity_type=execution_activity_type,
             status=ActivityStatus.error,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -238,6 +238,9 @@ builtins-ignorelist = ["license"]
 "obi_one/scientific/blocks/neuron_sets/deprecated.py" = [
     "unused-method-argument"
 ]
+"launch_scripts/**/*.py" = [
+    "implicit-namespace-package",
+]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,7 +168,13 @@ ultraliser = { index = "obi-codeartifact" }
 [tool.ruff]
 line-length = 100
 target-version = "py312"
-include = ["pyproject.toml", "app/**/*.py", "tests/**/*.py", "obi_one/**/*.py"]
+include = [
+    "pyproject.toml",
+    "app/**/*.py",
+    "tests/**/*.py",
+    "obi_one/**/*.py",
+    "launch_scripts/**/*.py",
+]
 # Legacy modules kept for reference; excluded from formatting and linting.
 extend-exclude = [
     "obi_one/scientific/blocks/neuron_sets/old",
@@ -245,9 +251,12 @@ max-statements = 50
 max-public-methods = 60
 
 [tool.ty.src]
+include = [
+    "app",
+    "obi_one",
+    "launch_scripts",
+]
 # Legacy modules kept for reference; excluded from ty type checking.
-# (ty has no config-level force-exclude; this is honoured when ty walks a parent dir,
-# which is how `make lint` invokes it: `ty check app obi_one`.)
 exclude = [
     "obi_one/scientific/blocks/neuron_sets/old",
     "obi_one/scientific/blocks/synaptic_model_assigners",


### PR DESCRIPTION
launch_scripts wasn't included in lint (ruff and ty).
This PR adds the launch_scripts directory, and ~add ignore to avoid modifying the existing code in the same PR~ fixes some lint errors.

Note: in some scripts ProjectContext was initialized with the parameter `environment`, that has been removed in entitysdk in version 0.14.2, released on 2026-04-20. This is fixed in this PR.
