### PR TITLE
Install obi-one in the brian2 simulation executor

### DIFF
--- a/obi_one/scientific/library/simulation/brian2/requirements.txt
+++ b/obi_one/scientific/library/simulation/brian2/requirements.txt
@@ -1,3 +1,6 @@
+# simulate_brian2.py imports obi_one.db_sdk.registration, and the executor
+# sparse-checks-out only this script, so obi-one has to be installed.
+obi-one
 obi-auth
 entitysdk
 brian2


### PR DESCRIPTION
Every brian2 simulation on staging dies before it starts:

```
File "/workspace/user_repo/obi_one/scientific/library/simulation/brian2/simulate_brian2.py", line 38, in <module>
    from obi_one.db_sdk.registration.simulation_result import register_simulation_results
ModuleNotFoundError: No module named 'obi_one'
```

`circuit_simulation_brian2_machine` is the only obi-one task that runs a bespoke script with a bespoke requirements file (`app/mappings.py`), and that file never listed `obi-one`. It didn't need to: the script was standalone until #935 replaced its inline registration with the shared `register_simulation_results`, adding the first `obi_one` import to it. The requirements file beside it was not updated.

Nothing else can supply the package. The launch-system wrapper sparse-checks-out only `[script_file, deps_file, *staged_directories]` into `/workspace/user_repo` (`staged_directories` is empty here, so the rest of `obi_one/` is not even on disk), installs that requirements file into a fresh venv, and runs `{venv}/bin/python -u <script>` with no `PYTHONPATH` — so `obi_one` can only resolve from an installed package. Every other obi-one task's dependency file lists it (`dependencies/default.txt` is literally `obi-one`).

**Affected releases** — the import landed in 2026.8.2 (2026-08-04). Staging runs 2026.8.10 and has been broken since. Production is on 2026.7.5, which predates the import, so it still works and breaks at its next release without this.

**Cost** — the executor venv goes from 7 packages to obi-one's full dependency tree, since `import obi_one.db_sdk...` executes `obi_one/__init__.py`, which imports the whole package. That is what every other task already pays, and `circuit_extraction` installs `obi-one[connectivity]` on this same default `python3.12-compiler` image, so it is a known-good install rather than a new risk. If the install time turns out to matter for brian2 specifically, the alternative is to make the script standalone again — it uses exactly one thing from obi-one, and `register.py` itself imports only entitysdk — at the cost of re-duplicating what #935 deduplicated.

**Testing** — not covered by the suite: no test installs a task's dependency file, so nothing here catches an import the requirements do not satisfy. Verified instead by reading the deployed tag: at 2026.8.10 (`5dd7aa43`) line 38 of the script is the `obi_one` import and the requirements file has no `obi-one`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VDrMeNvpM3djDA65tDAxQF