### PR TITLE
Install obi-one in the brian2 simulation executor

### DIFF
--- a/obi_one/scientific/library/simulation/brian2/requirements.txt
+++ b/obi_one/scientific/library/simulation/brian2/requirements.txt
@@ -1,3 +1,4 @@
+obi-one
 obi-auth
 entitysdk
 brian2


### PR DESCRIPTION
Every brian2 simulation on staging dies before it starts:

```
File "/workspace/user_repo/obi_one/scientific/library/simulation/brian2/simulate_brian2.py", line 38, in <module>
    from obi_one.db_sdk.registration.simulation_result import register_simulation_results
ModuleNotFoundError: No module named 'obi_one'
```

`circuit_simulation_brian2_machine` is the only obi-one task that runs a bespoke script with a bespoke requirements file (`app/mappings.py`), and that file never listed `obi-one`. It didn't need to: the script was standalone until #935 replaced its inline registration with the shared `register_simulation_results`, adding the first `obi_one` import to it. The requirements file beside it was not updated.